### PR TITLE
add github token to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: actions/github-script@v7
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const coverage = process.env.COVERAGE;
           const color = process.env.COVERAGE_COLOR;


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/test.yml` file. The change adds the `github-token` input to the `actions/github-script` step to enable authentication for GitHub API calls.