### PR TITLE
feat: Add level 1 features to class list API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,26 @@ make pre-commit
 
 ### Error Handling
 
+**NEVER return (nil, nil) - Always return a valid object or an error**
+
+```go
+// ❌ BAD - Never do this
+if input == nil {
+    return nil, nil
+}
+
+// ✅ GOOD - Return error for invalid input
+if input == nil {
+    return nil, errors.New("input is required")
+}
+
+// ✅ GOOD - Return empty/default object if that's the valid behavior
+if items == nil {
+    return &ListOutput{Items: []*Item{}, Total: 0}, nil
+}
+```
+
+Define errors at package level:
 ```go
 var (
     ErrSessionNotFound = errors.New("session not found")


### PR DESCRIPTION
## Summary
- Fixed issue where class list API was not returning level 1 features
- Modified ListAvailableClasses to fetch level 1 features concurrently with class data
- Added convertClassWithFeatures method to hydrate class data with features

## Changes Made
- Updated `ListAvailableClasses` to call both `GetClass` and `GetClassLevel` concurrently
- Added `convertClassWithFeatures` method to populate `LevelOneFeatures` field
- Updated error handling patterns in CLAUDE.md to never return (nil, nil)

## Testing
- Manually tested with `go run ./cmd/server client list-classes --include-features`
- All classes now properly return their level 1 features:
  - Barbarian: Rage, Unarmored Defense
  - Fighter: Fighting Style, Second Wind  
  - Wizard: Spellcasting, Arcane Recovery
  - Rogue: Expertise, Sneak Attack, Thieves' Cant
  - And more...

## Test Coverage
- External client still has 0% test coverage (existing state)
- Pre-commit checks pass (linting, formatting, unit tests)

🤖 Generated with [Claude Code](https://claude.ai/code)