### PR TITLE
Add Docker build and push workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,9 @@ jobs:
         go test -v -race -coverprofile=coverage.out -covermode=atomic \
           $(go list ./... | grep -v /gen/ | grep -v /mock | grep -v cmd/server)
           
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
     - name: Log in to Container Registry
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
-          type=ref,event=pull_request
+          type=ref,event=pr
           type=sha
           type=raw,value=latest,enable={{is_default_branch}}
           

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,71 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+        
+    - name: Install dependencies
+      run: |
+        go mod download
+        go install go.uber.org/mock/mockgen@latest
+        
+    - name: Generate code
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        make generate
+        
+    - name: Run tests
+      run: |
+        go test -v -race -coverprofile=coverage.out -covermode=atomic \
+          $(go list ./... | grep -v /gen/ | grep -v /mock | grep -v cmd/server)
+          
+    - name: Log in to Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=sha
+          type=raw,value=latest,enable={{is_default_branch}}
+          
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         go mod download
-        go install go.uber.org/mock/mockgen@latest
+        go install go.uber.org/mock/mockgen@v0.5.0
         
     - name: Generate code
       run: |
@@ -56,7 +56,7 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
+          type=ref,event=pull_request
           type=sha
           type=raw,value=latest,enable={{is_default_branch}}
           


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to build and push Docker images to GitHub Container Registry.

## Changes
- New workflow `.github/workflows/docker.yml`
- Builds Docker image on every push to main
- Pushes to `ghcr.io/kirkdiggler/rpg-api`
- Tags with `latest`, branch name, and SHA
- Uses GitHub Actions cache for faster builds
- Runs tests before building

## Purpose
Enable pre-built Docker images for faster deployment. This eliminates the need to build from source during EC2 deployment, reducing deployment time from ~20 minutes to ~2 minutes.

## Test plan
- [ ] Merge PR to trigger workflow
- [ ] Verify image is pushed to GHCR
- [ ] Test pulling the image locally
- [ ] Update rpg-deployment to use pre-built image

## Related
- rpg-deployment issue #13: Implement pre-built Docker images

🤖 Generated with [Claude Code](https://claude.ai/code)