### PR TITLE
Add automatic deployment trigger after Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,7 +75,8 @@ jobs:
 
     - name: Trigger deployment
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: benc-uk/workflow-dispatch@v1
+      continue-on-error: true
+      uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
       with:
         workflow: deploy.yml
         repo: KirkDiggler/rpg-deployment

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,3 +72,12 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Trigger deployment
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: deploy.yml
+        repo: KirkDiggler/rpg-deployment
+        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        inputs: '{"source": "rpg-api", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary

- Add workflow dispatch trigger to rpg-deployment after successful Docker build
- Pass source repository and commit SHA for better deployment visibility
- Only triggers on main branch pushes to avoid unnecessary deployments

## Changes

- Added step to trigger rpg-deployment workflow after Docker image is built and pushed
- Configured to only run on main branch pushes
- Passes source repo name and commit SHA for deployment tracking

## Dependencies

- Requires `DEPLOYMENT_TOKEN` secret to be added to this repository
- Token needs `repo` permissions to trigger workflows in rpg-deployment

## Testing

After merging and adding the token:
1. Push to main branch
2. Watch Docker workflow complete
3. Observe automatic deployment trigger
4. Check deployment summary for source visibility

🤖 Generated with [Claude Code](https://claude.ai/code)