### PR TITLE
fix: Race choice types and language enum mapping

### DIFF
--- a/cmd/server/client/get_race.go
+++ b/cmd/server/client/get_race.go
@@ -6,8 +6,13 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/clients/dnd5e/api/v1alpha1"
+)
+
+var (
+	raceJsonOutput bool
 )
 
 var getRaceCmd = &cobra.Command{
@@ -16,6 +21,10 @@ var getRaceCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific D&D 5e race by its ID.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runGetRace,
+}
+
+func init() {
+	getRaceCmd.Flags().BoolVar(&raceJsonOutput, "json", false, "Output as JSON")
 }
 
 func runGetRace(_ *cobra.Command, args []string) error {
@@ -39,6 +48,21 @@ func runGetRace(_ *cobra.Command, args []string) error {
 	resp, err := client.GetRaceDetails(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to get race details: %w", err)
+	}
+
+	if raceJsonOutput {
+		// Import the protojson package at the top of the file
+		// "google.golang.org/protobuf/encoding/protojson"
+		marshaler := protojson.MarshalOptions{
+			Indent:          "  ",
+			EmitUnpopulated: false,
+		}
+		jsonBytes, err := marshaler.Marshal(resp)
+		if err != nil {
+			return fmt.Errorf("failed to marshal response to JSON: %w", err)
+		}
+		fmt.Println(string(jsonBytes))
+		return nil
 	}
 
 	race := resp.Race

--- a/internal/handlers/dnd5e/v1alpha1/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/handler.go
@@ -1601,7 +1601,8 @@ func convertEntityBackgroundToProto(background *dnd5e.BackgroundInfo) *dnd5ev1al
 
 // mapStringToProtoLanguage converts string to proto language enum
 func mapStringToProtoLanguage(lang string) dnd5ev1alpha1.Language {
-	switch lang {
+	// Convert to lowercase for case-insensitive matching
+	switch strings.ToLower(lang) {
 	case "common":
 		return dnd5ev1alpha1.Language_LANGUAGE_COMMON
 	case "dwarvish":


### PR DESCRIPTION
## Summary
- Fixed dwarf tool proficiency choices showing as equipment type instead of tool type
- Fixed race languages showing as 0 (LANGUAGE_UNSPECIFIED) instead of proper enum values
- Implemented missing GetRaceData method in external client

## Changes
1. **Implemented GetRaceData in external client**
   - Was returning "unimplemented" error
   - Now properly fetches and converts race data

2. **Fixed tool proficiency choice type detection**
   - Added logic to detect tool proficiencies by examining choice descriptions
   - Looks for keywords like "tool" or "supplies" to set correct choice type
   - Dwarf tool proficiencies now correctly show as CHOICE_TYPE_TOOL (3) instead of CHOICE_TYPE_EQUIPMENT (1)

3. **Fixed language enum mapping**
   - Made mapStringToProtoLanguage case-insensitive
   - Handles "Common" vs "common", "Dwarvish" vs "dwarvish" from D&D API
   - Languages now map to correct enum values instead of defaulting to 0

4. **Added JSON output to get-race command**
   - Matches get-class command functionality
   - Helpful for debugging and testing

## Test Plan
```bash
# After server restart
go run ./cmd/server client get-race dwarf --json | jq '.race.choices'
# Should show tool proficiency choices with choiceType: 3 (CHOICE_TYPE_TOOL)

go run ./cmd/server client get-race dwarf --json | jq '.race.languages'
# Should show proper language enums (1 for Common, 2 for Dwarvish)
```

## Related Issues
Fixes race data issues discovered while testing PR #94

🤖 Generated with [Claude Code](https://claude.ai/code)