### PR TITLE
fix: Change ability score validation to accept manual entry

### DIFF
--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -715,9 +715,11 @@ func (o *Orchestrator) UpdateAbilityScores(
 	draft := getOutput.Draft.ToCharacterDraft()
 
 	// Validate ability scores with engine
+	// TODO(#82): Make ability score method configurable
+	// For now, default to manual to accept any scores 3-18
 	validateInput := &engine.ValidateAbilityScoresInput{
 		AbilityScores: &input.AbilityScores,
-		Method:        "standard_array", // TODO(#82): Make ability score method configurable
+		Method:        engine.AbilityScoreMethodManual,
 	}
 	validateOutput, err := o.engine.ValidateAbilityScores(ctx, validateInput)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Changed ability score validation from `standard_array` to `manual` method
- Now accepts any ability scores between 3-18 instead of requiring standard array values (15,14,13,12,10,8)

## Context
The ability score validation was hardcoded to only accept standard array values, which prevented clients from using rolled ability scores or other valid combinations. This is a temporary fix until we implement configurable ability score generation methods as tracked in TODO #82.

## Test plan
- [x] Unit tests pass
- [x] Pre-commit checks pass
- [ ] Test with client sending various ability score combinations (3-18 range)

🤖 Generated with [Claude Code](https://claude.ai/code)