### PR TITLE
feat: Implement secure ability score rolling with dice service

### DIFF
--- a/internal/handlers/api/v1alpha1/dice_handler_test.go
+++ b/internal/handlers/api/v1alpha1/dice_handler_test.go
@@ -1,0 +1,298 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	apiv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/errors"
+	"github.com/KirkDiggler/rpg-api/internal/handlers/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
+	dicemock "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice/mock"
+	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
+)
+
+type DiceHandlerTestSuite struct {
+	suite.Suite
+	ctrl        *gomock.Controller
+	mockDice    *dicemock.MockService
+	handler     *v1alpha1.DiceHandler
+}
+
+func TestDiceHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(DiceHandlerTestSuite))
+}
+
+func (s *DiceHandlerTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockDice = dicemock.NewMockService(s.ctrl)
+
+	handler, err := v1alpha1.NewDiceHandler(&v1alpha1.DiceHandlerConfig{
+		DiceService: s.mockDice,
+	})
+	s.Require().NoError(err)
+	s.handler = handler
+}
+
+func (s *DiceHandlerTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func (s *DiceHandlerTestSuite) TestRollDice_Success() {
+	ctx := context.Background()
+	entityID := "player_123"
+	contextStr := "character_draft_456_abilities"
+	notation := "4d6"
+
+	// Mock dice service response
+	mockRoll := &dicesession.DiceRoll{
+		RollID:      "roll_abc",
+		Notation:    notation,
+		Dice:        []int32{6, 5, 4, 2},
+		Total:       15, // 6+5+4 (dropped 2)
+		Dropped:     []int32{2},
+		Description: "Ability Score Roll",
+		DiceTotal:   15,
+		Modifier:    0,
+	}
+
+	mockSession := &dicesession.DiceSession{
+		EntityID:  entityID,
+		Context:   contextStr,
+		Rolls:     []dicesession.DiceRoll{*mockRoll},
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+		CreatedAt: time.Now(),
+	}
+
+	s.mockDice.EXPECT().
+		RollDice(ctx, &dice.RollDiceInput{
+			EntityID:    entityID,
+			Context:     contextStr,
+			Notation:    notation,
+			Description: "",
+		}).
+		Return(&dice.RollDiceOutput{
+			Roll:    mockRoll,
+			Session: mockSession,
+		}, nil)
+
+	// Call handler
+	req := &apiv1alpha1.RollDiceRequest{
+		EntityId: entityID,
+		Context:  contextStr,
+		Notation: notation,
+	}
+	resp, err := s.handler.RollDice(ctx, req)
+
+	// Verify response
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.Rolls, 1)
+
+	roll := resp.Rolls[0]
+	s.Equal("roll_abc", roll.RollId)
+	s.Equal(notation, roll.Notation)
+	s.Equal([]int32{6, 5, 4, 2}, roll.Dice)
+	s.Equal(int32(15), roll.Total)
+	s.Equal([]int32{2}, roll.Dropped)
+}
+
+func (s *DiceHandlerTestSuite) TestRollDice_ValidationErrors() {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name     string
+		req      *apiv1alpha1.RollDiceRequest
+		errMsg   string
+	}{
+		{
+			name: "missing entity_id",
+			req: &apiv1alpha1.RollDiceRequest{
+				Context:  "test",
+				Notation: "4d6",
+			},
+			errMsg: "entity_id is required",
+		},
+		{
+			name: "missing context",
+			req: &apiv1alpha1.RollDiceRequest{
+				EntityId: "player_123",
+				Notation: "4d6",
+			},
+			errMsg: "context is required",
+		},
+		{
+			name: "missing notation",
+			req: &apiv1alpha1.RollDiceRequest{
+				EntityId: "player_123",
+				Context:  "test",
+			},
+			errMsg: "notation is required",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp, err := s.handler.RollDice(ctx, tc.req)
+
+			s.Require().Error(err)
+			s.Nil(resp)
+
+			st, ok := status.FromError(err)
+			s.Require().True(ok)
+			s.Equal(codes.InvalidArgument, st.Code())
+			s.Contains(st.Message(), tc.errMsg)
+		})
+	}
+}
+
+func (s *DiceHandlerTestSuite) TestGetRollSession_Success() {
+	ctx := context.Background()
+	entityID := "player_123"
+	contextStr := "character_draft_456_abilities"
+
+	// Mock session with multiple rolls
+	mockSession := &dicesession.DiceSession{
+		EntityID: entityID,
+		Context:  contextStr,
+		Rolls: []dicesession.DiceRoll{
+			{
+				RollID:    "roll_1",
+				Notation:  "4d6",
+				Dice:      []int32{6, 5, 4, 3},
+				Total:     15,
+				Dropped:   []int32{3},
+				DiceTotal: 15,
+			},
+			{
+				RollID:    "roll_2",
+				Notation:  "4d6",
+				Dice:      []int32{5, 5, 3, 2},
+				Total:     13,
+				Dropped:   []int32{2},
+				DiceTotal: 13,
+			},
+		},
+		ExpiresAt: time.Now().Add(10 * time.Minute),
+		CreatedAt: time.Now().Add(-5 * time.Minute),
+	}
+
+	s.mockDice.EXPECT().
+		GetRollSession(ctx, &dice.GetRollSessionInput{
+			EntityID: entityID,
+			Context:  contextStr,
+		}).
+		Return(&dice.GetRollSessionOutput{
+			Session: mockSession,
+		}, nil)
+
+	// Call handler
+	req := &apiv1alpha1.GetRollSessionRequest{
+		EntityId: entityID,
+		Context:  contextStr,
+	}
+	resp, err := s.handler.GetRollSession(ctx, req)
+
+	// Verify response
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.Rolls, 2)
+	s.Equal("roll_1", resp.Rolls[0].RollId)
+	s.Equal("roll_2", resp.Rolls[1].RollId)
+	s.Greater(resp.ExpiresAt, int64(0))
+	s.Greater(resp.CreatedAt, int64(0))
+}
+
+func (s *DiceHandlerTestSuite) TestGetRollSession_NotFound() {
+	ctx := context.Background()
+	entityID := "player_123"
+	contextStr := "non_existent"
+
+	s.mockDice.EXPECT().
+		GetRollSession(ctx, gomock.Any()).
+		Return(nil, errors.NotFound("session not found"))
+
+	req := &apiv1alpha1.GetRollSessionRequest{
+		EntityId: entityID,
+		Context:  contextStr,
+	}
+	resp, err := s.handler.GetRollSession(ctx, req)
+
+	s.Require().Error(err)
+	s.Nil(resp)
+
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Equal(codes.NotFound, st.Code())
+}
+
+func (s *DiceHandlerTestSuite) TestClearRollSession_Success() {
+	ctx := context.Background()
+	entityID := "player_123"
+	contextStr := "character_draft_456_abilities"
+
+	s.mockDice.EXPECT().
+		ClearRollSession(ctx, &dice.ClearRollSessionInput{
+			EntityID: entityID,
+			Context:  contextStr,
+		}).
+		Return(&dice.ClearRollSessionOutput{
+			RollsDeleted: 6,
+		}, nil)
+
+	req := &apiv1alpha1.ClearRollSessionRequest{
+		EntityId: entityID,
+		Context:  contextStr,
+	}
+	resp, err := s.handler.ClearRollSession(ctx, req)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal("Roll session cleared successfully", resp.Message)
+	s.Equal(int32(6), resp.RollsCleared)
+}
+
+func (s *DiceHandlerTestSuite) TestClearRollSession_ValidationErrors() {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name   string
+		req    *apiv1alpha1.ClearRollSessionRequest
+		errMsg string
+	}{
+		{
+			name: "missing entity_id",
+			req: &apiv1alpha1.ClearRollSessionRequest{
+				Context: "test",
+			},
+			errMsg: "entity_id is required",
+		},
+		{
+			name: "missing context",
+			req: &apiv1alpha1.ClearRollSessionRequest{
+				EntityId: "player_123",
+			},
+			errMsg: "context is required",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp, err := s.handler.ClearRollSession(ctx, tc.req)
+
+			s.Require().Error(err)
+			s.Nil(resp)
+
+			st, ok := status.FromError(err)
+			s.Require().True(ok)
+			s.Equal(codes.InvalidArgument, st.Code())
+			s.Contains(st.Message(), tc.errMsg)
+		})
+	}
+}

--- a/internal/handlers/dnd5e/v1alpha1/handler_update_ability_scores_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/handler_update_ability_scores_test.go
@@ -1,0 +1,250 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/errors"
+	"github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/orchestrators/character/mock"
+	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+type HandlerUpdateAbilityScoresTestSuite struct {
+	suite.Suite
+	ctrl            *gomock.Controller
+	mockCharService *charactermock.MockService
+	handler         *v1alpha1.Handler
+}
+
+func TestHandlerUpdateAbilityScoresTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlerUpdateAbilityScoresTestSuite))
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharService = charactermock.NewMockService(s.ctrl)
+
+	handler, err := v1alpha1.NewHandler(&v1alpha1.HandlerConfig{
+		CharacterService: s.mockCharService,
+	})
+	s.Require().NoError(err)
+	s.handler = handler
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TestUpdateAbilityScores_WithRollAssignments_Success() {
+	ctx := context.Background()
+	draftID := "draft-123"
+
+	// Mock draft with ability scores after assignment
+	mockDraft := &toolkitchar.DraftData{
+		ID:       draftID,
+		PlayerID: "player-456",
+		Name:     "Test Character",
+		AbilityScoreChoice: shared.AbilityScores{
+			constants.STR: 16,
+			constants.DEX: 14,
+			constants.CON: 13,
+			constants.INT: 12,
+			constants.WIS: 15,
+			constants.CHA: 10,
+		},
+	}
+
+	// Mock roll assignments
+	rollAssignments := &character.RollAssignments{
+		StrengthRollID:     "roll-1",
+		DexterityRollID:    "roll-2",
+		ConstitutionRollID: "roll-3",
+		IntelligenceRollID: "roll-4",
+		WisdomRollID:       "roll-5",
+		CharismaRollID:     "roll-6",
+	}
+
+	s.mockCharService.EXPECT().
+		UpdateAbilityScores(ctx, &character.UpdateAbilityScoresInput{
+			DraftID:         draftID,
+			RollAssignments: rollAssignments,
+		}).
+		Return(&character.UpdateAbilityScoresOutput{
+			Draft:    mockDraft,
+			Warnings: []character.ValidationWarning{},
+		}, nil)
+
+	// Call handler
+	req := &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: draftID,
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_RollAssignments{
+			RollAssignments: &dnd5ev1alpha1.RollAssignments{
+				StrengthRollId:     "roll-1",
+				DexterityRollId:    "roll-2",
+				ConstitutionRollId: "roll-3",
+				IntelligenceRollId: "roll-4",
+				WisdomRollId:       "roll-5",
+				CharismaRollId:     "roll-6",
+			},
+		},
+	}
+	resp, err := s.handler.UpdateAbilityScores(ctx, req)
+
+	// Verify response
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Draft)
+	s.Equal(draftID, resp.Draft.Id)
+	s.Require().NotNil(resp.Draft.AbilityScores)
+	s.Equal(int32(16), resp.Draft.AbilityScores.Strength)
+	s.Equal(int32(14), resp.Draft.AbilityScores.Dexterity)
+	s.Equal(int32(13), resp.Draft.AbilityScores.Constitution)
+	s.Equal(int32(12), resp.Draft.AbilityScores.Intelligence)
+	s.Equal(int32(15), resp.Draft.AbilityScores.Wisdom)
+	s.Equal(int32(10), resp.Draft.AbilityScores.Charisma)
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TestUpdateAbilityScores_MissingDraftID() {
+	ctx := context.Background()
+
+	req := &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: "", // Missing draft ID
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_RollAssignments{
+			RollAssignments: &dnd5ev1alpha1.RollAssignments{
+				StrengthRollId:     "roll-1",
+				DexterityRollId:    "roll-2",
+				ConstitutionRollId: "roll-3",
+				IntelligenceRollId: "roll-4",
+				WisdomRollId:       "roll-5",
+				CharismaRollId:     "roll-6",
+			},
+		},
+	}
+
+	resp, err := s.handler.UpdateAbilityScores(ctx, req)
+
+	s.Require().Error(err)
+	s.Nil(resp)
+
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Equal(codes.InvalidArgument, st.Code())
+	s.Contains(st.Message(), "draft_id is required")
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TestUpdateAbilityScores_MissingRollIDs() {
+	ctx := context.Background()
+
+	req := &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: "draft-123",
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_RollAssignments{
+			RollAssignments: &dnd5ev1alpha1.RollAssignments{
+				StrengthRollId:     "roll-1",
+				DexterityRollId:    "", // Missing
+				ConstitutionRollId: "roll-3",
+				IntelligenceRollId: "roll-4",
+				WisdomRollId:       "roll-5",
+				CharismaRollId:     "roll-6",
+			},
+		},
+	}
+
+	resp, err := s.handler.UpdateAbilityScores(ctx, req)
+
+	s.Require().Error(err)
+	s.Nil(resp)
+
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Equal(codes.InvalidArgument, st.Code())
+	s.Contains(st.Message(), "all ability score roll IDs must be provided")
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TestUpdateAbilityScores_DraftNotFound() {
+	ctx := context.Background()
+	draftID := "non-existent"
+
+	s.mockCharService.EXPECT().
+		UpdateAbilityScores(ctx, gomock.Any()).
+		Return(nil, errors.NotFound("draft not found"))
+
+	req := &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: draftID,
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_RollAssignments{
+			RollAssignments: &dnd5ev1alpha1.RollAssignments{
+				StrengthRollId:     "roll-1",
+				DexterityRollId:    "roll-2",
+				ConstitutionRollId: "roll-3",
+				IntelligenceRollId: "roll-4",
+				WisdomRollId:       "roll-5",
+				CharismaRollId:     "roll-6",
+			},
+		},
+	}
+
+	resp, err := s.handler.UpdateAbilityScores(ctx, req)
+
+	s.Require().Error(err)
+	s.Nil(resp)
+
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TestUpdateAbilityScores_NoScoresProvided() {
+	ctx := context.Background()
+
+	req := &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: "draft-123",
+		// No scores_input provided
+	}
+
+	resp, err := s.handler.UpdateAbilityScores(ctx, req)
+
+	s.Require().Error(err)
+	s.Nil(resp)
+
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Equal(codes.InvalidArgument, st.Code())
+	s.Contains(st.Message(), "scores_input must be provided")
+}
+
+func (s *HandlerUpdateAbilityScoresTestSuite) TestUpdateAbilityScores_ManualAssignment_NotImplemented() {
+	ctx := context.Background()
+
+	req := &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: "draft-123",
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_AbilityScores{
+			AbilityScores: &dnd5ev1alpha1.AbilityScores{
+				Strength:     15,
+				Dexterity:    14,
+				Constitution: 13,
+				Intelligence: 12,
+				Wisdom:       10,
+				Charisma:     8,
+			},
+		},
+	}
+
+	resp, err := s.handler.UpdateAbilityScores(ctx, req)
+
+	s.Require().Error(err)
+	s.Nil(resp)
+
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Equal(codes.Unimplemented, st.Code())
+	s.Contains(st.Message(), "manual ability score assignment not yet implemented")
+}

--- a/internal/orchestrators/character/mock/mock_service.go
+++ b/internal/orchestrators/character/mock/mock_service.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/character/types.go
+++ b/internal/orchestrators/character/types.go
@@ -169,10 +169,21 @@ type UpdateBackgroundOutput struct {
 	Warnings []ValidationWarning
 }
 
+// RollAssignments maps ability scores to dice roll IDs
+type RollAssignments struct {
+	StrengthRollID     string
+	DexterityRollID    string
+	ConstitutionRollID string
+	IntelligenceRollID string
+	WisdomRollID       string
+	CharismaRollID     string
+}
+
 // UpdateAbilityScoresInput defines the request for updating a draft's ability scores
 type UpdateAbilityScoresInput struct {
-	DraftID       string
-	AbilityScores shared.AbilityScores
+	DraftID         string
+	AbilityScores   *shared.AbilityScores // Manual assignment
+	RollAssignments *RollAssignments      // Roll-based assignment
 }
 
 // UpdateAbilityScoresOutput defines the response for updating a draft's ability scores


### PR DESCRIPTION
## Overview
This PR implements Phase 1 and Phase 2 of issue #161 - secure ability score rolling using the generic dice service.

## What's Implemented

### Phase 1: Generic Dice Service Handler ✅
- The dice handler was already implemented and wired up
- Added comprehensive tests for all dice service RPCs
- Tested with grpcurl to verify functionality

### Phase 2: Character Service UpdateAbilityScores ✅
- Implemented `UpdateAbilityScores` RPC in the handler
- Added support for roll-based assignment via `RollAssignments`
- Implemented orchestrator logic to:
  - Fetch dice rolls from the dice service
  - Validate all 6 roll IDs exist and belong to the player
  - Convert roll totals to ability scores
  - Clear the dice session after successful assignment
- Added comprehensive tests for all scenarios

## Testing

### Manual Testing with grpcurl
```bash
# 1. Create a draft
DRAFT_ID=$(grpcurl -plaintext -d '{"player_id": "player_123"}' \
  localhost:50051 dnd5e.api.v1alpha1.CharacterService/CreateDraft | jq -r '.draft.id')

# 2. Roll 6 ability scores
CONTEXT="character_draft_${DRAFT_ID}_abilities"
for i in {1..6}; do
  grpcurl -plaintext -d "{
    \"entity_id\": \"player_123\",
    \"context\": \"$CONTEXT\", 
    \"notation\": \"4d6\"
  }" localhost:50051 api.v1alpha1.DiceService/RollDice
done

# 3. Get roll IDs
ROLLS=$(grpcurl -plaintext -d "{
  \"entity_id\": \"player_123\",
  \"context\": \"$CONTEXT\"
}" localhost:50051 api.v1alpha1.DiceService/GetRollSession | jq -r '.rolls[].rollId')

# 4. Assign rolls to abilities
grpcurl -plaintext -d "{
  \"draft_id\": \"$DRAFT_ID\",
  \"roll_assignments\": {
    \"strength_roll_id\": \"<roll-1>\",
    \"dexterity_roll_id\": \"<roll-2>\",
    \"constitution_roll_id\": \"<roll-3>\",
    \"intelligence_roll_id\": \"<roll-4>\",
    \"wisdom_roll_id\": \"<roll-5>\",
    \"charisma_roll_id\": \"<roll-6>\"
  }
}" localhost:50051 dnd5e.api.v1alpha1.CharacterService/UpdateAbilityScores
```

### Automated Tests
- ✅ Dice handler tests (all RPCs)
- ✅ UpdateAbilityScores handler tests (validation, roll assignment, error cases)
- ✅ All existing tests still pass

## Security Features
- Roll ownership validation - only the player who rolled can use the rolls
- Context validation - rolls must be for the specific draft's ability score context
- Session clearing - rolls are deleted after successful assignment to prevent reuse

## Next Steps
Phase 3 will update the web app to use the dice service instead of local rolling.

Closes part of #161