### PR TITLE
feat: initialize class resources and spell slots during character finalization

### DIFF
--- a/internal/orchestrators/character/finalize_draft_test.go
+++ b/internal/orchestrators/character/finalize_draft_test.go
@@ -184,6 +184,17 @@ func (s *FinalizeDraftOrchestratorTestSuite) TestFinalizeDraft_Success() {
 			s.Contains(input.CharacterData.Equipment, "Uniform")
 			s.Contains(input.CharacterData.Equipment, "Javelin")
 
+			// Class resources (Fighter should get Second Wind)
+			s.Contains(input.CharacterData.ClassResources, "second_wind")
+			resource := input.CharacterData.ClassResources["second_wind"]
+			s.Equal("Second Wind", resource.Name)
+			s.Equal(1, resource.Max)
+			s.Equal(1, resource.Current)
+			s.Equal("short_rest", resource.Resets)
+
+			// Spell slots (Fighter should not have any)
+			s.Empty(input.CharacterData.SpellSlots)
+
 			return &charrepo.CreateOutput{CharacterData: input.CharacterData}, nil
 		})
 
@@ -437,6 +448,401 @@ func (s *FinalizeDraftOrchestratorTestSuite) TestFinalizeDraft_DraftDeleteFails(
 	s.Require().NotNil(output.Character)
 	s.Equal("char-123", output.Character.ID)
 	s.False(output.DraftDeleted) // Draft deletion failed
+}
+
+func (s *FinalizeDraftOrchestratorTestSuite) TestFinalizeDraft_BarbarianClassResources() {
+	draftID := "draft_123"
+
+	// Mock ID generation
+	s.mockIDGen.EXPECT().Generate().Return("char-123")
+
+	// Mock draft data for Barbarian
+	draft := &toolkitchar.DraftData{
+		ID:       draftID,
+		PlayerID: "player_123",
+		Name:     "Test Barbarian",
+		RaceChoice: toolkitchar.RaceChoice{
+			RaceID: constants.RaceHuman,
+		},
+		ClassChoice: toolkitchar.ClassChoice{
+			ClassID: constants.ClassBarbarian,
+		},
+		BackgroundChoice: constants.BackgroundSoldier,
+		AbilityScoreChoice: shared.AbilityScores{
+			constants.STR: 16,
+			constants.CON: 14,
+			constants.CHA: 10,
+		},
+	}
+
+	// Mock draft retrieval
+	s.mockDraftRepo.EXPECT().
+		Get(gomock.Any(), draftrepo.GetInput{ID: draftID}).
+		Return(&draftrepo.GetOutput{Draft: draft}, nil)
+
+	// Mock race data
+	s.mockExtClient.EXPECT().
+		GetRaceData(gomock.Any(), string(constants.RaceHuman)).
+		Return(&external.RaceDataOutput{
+			RaceData: &race.Data{
+				ID:        constants.RaceHuman,
+				Name:      "Human",
+				Speed:     30,
+				Size:      "Medium",
+				Languages: []constants.Language{constants.LanguageCommon},
+			},
+		}, nil)
+
+	// Mock class data
+	s.mockExtClient.EXPECT().
+		GetClassData(gomock.Any(), string(constants.ClassBarbarian)).
+		Return(&external.ClassDataOutput{
+			ClassData: &class.Data{
+				ID:           constants.ClassBarbarian,
+				Name:         "Barbarian",
+				HitDice:      12,
+				SavingThrows: []constants.Ability{constants.STR, constants.CON},
+			},
+		}, nil)
+
+	// Mock background data
+	s.mockExtClient.EXPECT().
+		GetBackgroundData(gomock.Any(), string(constants.BackgroundSoldier)).
+		Return(&external.BackgroundData{
+			ID:                 "soldier",
+			Name:               "Soldier",
+			SkillProficiencies: []string{"Athletics", "Intimidation"},
+		}, nil)
+
+	// Mock character creation to verify Barbarian gets Rage
+	s.mockCharRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input charrepo.CreateInput) (*charrepo.CreateOutput, error) {
+			// Verify class resources (Barbarian should get Rage)
+			s.Contains(input.CharacterData.ClassResources, "rage")
+			resource := input.CharacterData.ClassResources["rage"]
+			s.Equal("Rage", resource.Name)
+			s.Equal(2, resource.Max) // 2 rages at level 1
+			s.Equal(2, resource.Current)
+			s.Equal("long_rest", resource.Resets)
+
+			// Spell slots (Barbarian should not have any)
+			s.Empty(input.CharacterData.SpellSlots)
+
+			return &charrepo.CreateOutput{CharacterData: input.CharacterData}, nil
+		})
+
+	// Mock draft deletion
+	s.mockDraftRepo.EXPECT().
+		Delete(gomock.Any(), draftrepo.DeleteInput{ID: draftID}).
+		Return(&draftrepo.DeleteOutput{}, nil)
+
+	// Act
+	input := &character.FinalizeDraftInput{
+		DraftID: draftID,
+	}
+	output, err := s.orchestrator.FinalizeDraft(s.ctx, input)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+	s.True(output.DraftDeleted)
+}
+
+func (s *FinalizeDraftOrchestratorTestSuite) TestFinalizeDraft_WizardSpellSlots() {
+	draftID := "draft_123"
+
+	// Mock ID generation
+	s.mockIDGen.EXPECT().Generate().Return("char-123")
+
+	// Mock draft data for Wizard
+	draft := &toolkitchar.DraftData{
+		ID:       draftID,
+		PlayerID: "player_123",
+		Name:     "Test Wizard",
+		RaceChoice: toolkitchar.RaceChoice{
+			RaceID: constants.RaceHuman,
+		},
+		ClassChoice: toolkitchar.ClassChoice{
+			ClassID: constants.ClassWizard,
+		},
+		BackgroundChoice: constants.BackgroundSoldier,
+		AbilityScoreChoice: shared.AbilityScores{
+			constants.STR: 10,
+			constants.CON: 14,
+			constants.INT: 16,
+		},
+	}
+
+	// Mock draft retrieval
+	s.mockDraftRepo.EXPECT().
+		Get(gomock.Any(), draftrepo.GetInput{ID: draftID}).
+		Return(&draftrepo.GetOutput{Draft: draft}, nil)
+
+	// Mock race data
+	s.mockExtClient.EXPECT().
+		GetRaceData(gomock.Any(), string(constants.RaceHuman)).
+		Return(&external.RaceDataOutput{
+			RaceData: &race.Data{
+				ID:        constants.RaceHuman,
+				Name:      "Human",
+				Speed:     30,
+				Size:      "Medium",
+				Languages: []constants.Language{constants.LanguageCommon},
+			},
+		}, nil)
+
+	// Mock class data
+	s.mockExtClient.EXPECT().
+		GetClassData(gomock.Any(), string(constants.ClassWizard)).
+		Return(&external.ClassDataOutput{
+			ClassData: &class.Data{
+				ID:           constants.ClassWizard,
+				Name:         "Wizard",
+				HitDice:      6,
+				SavingThrows: []constants.Ability{constants.INT, constants.WIS},
+			},
+		}, nil)
+
+	// Mock background data
+	s.mockExtClient.EXPECT().
+		GetBackgroundData(gomock.Any(), string(constants.BackgroundSoldier)).
+		Return(&external.BackgroundData{
+			ID:                 "soldier",
+			Name:               "Soldier",
+			SkillProficiencies: []string{"Athletics", "Intimidation"},
+		}, nil)
+
+	// Mock character creation to verify Wizard gets spell slots
+	s.mockCharRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input charrepo.CreateInput) (*charrepo.CreateOutput, error) {
+			// Class resources (Wizard has no class resources at level 1)
+			s.Empty(input.CharacterData.ClassResources)
+
+			// Spell slots (Wizard should get 2 first-level slots)
+			s.Contains(input.CharacterData.SpellSlots, 1)
+			slots := input.CharacterData.SpellSlots[1]
+			s.Equal(2, slots.Max)  // 2 first-level slots at level 1
+			s.Equal(0, slots.Used) // Unused initially
+
+			return &charrepo.CreateOutput{CharacterData: input.CharacterData}, nil
+		})
+
+	// Mock draft deletion
+	s.mockDraftRepo.EXPECT().
+		Delete(gomock.Any(), draftrepo.DeleteInput{ID: draftID}).
+		Return(&draftrepo.DeleteOutput{}, nil)
+
+	// Act
+	input := &character.FinalizeDraftInput{
+		DraftID: draftID,
+	}
+	output, err := s.orchestrator.FinalizeDraft(s.ctx, input)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+	s.True(output.DraftDeleted)
+}
+
+func (s *FinalizeDraftOrchestratorTestSuite) TestFinalizeDraft_BardCharismaBasedResource() {
+	draftID := "draft_123"
+
+	// Mock ID generation
+	s.mockIDGen.EXPECT().Generate().Return("char-123")
+
+	// Mock draft data for Bard with high CHA
+	draft := &toolkitchar.DraftData{
+		ID:       draftID,
+		PlayerID: "player_123",
+		Name:     "Test Bard",
+		RaceChoice: toolkitchar.RaceChoice{
+			RaceID: constants.RaceHuman,
+		},
+		ClassChoice: toolkitchar.ClassChoice{
+			ClassID: constants.ClassBard,
+		},
+		BackgroundChoice: constants.BackgroundSoldier,
+		AbilityScoreChoice: shared.AbilityScores{
+			constants.STR: 10,
+			constants.CON: 14,
+			constants.CHA: 16, // +3 modifier = 3 uses
+		},
+	}
+
+	// Mock draft retrieval
+	s.mockDraftRepo.EXPECT().
+		Get(gomock.Any(), draftrepo.GetInput{ID: draftID}).
+		Return(&draftrepo.GetOutput{Draft: draft}, nil)
+
+	// Mock race data
+	s.mockExtClient.EXPECT().
+		GetRaceData(gomock.Any(), string(constants.RaceHuman)).
+		Return(&external.RaceDataOutput{
+			RaceData: &race.Data{
+				ID:        constants.RaceHuman,
+				Name:      "Human",
+				Speed:     30,
+				Size:      "Medium",
+				Languages: []constants.Language{constants.LanguageCommon},
+			},
+		}, nil)
+
+	// Mock class data
+	s.mockExtClient.EXPECT().
+		GetClassData(gomock.Any(), string(constants.ClassBard)).
+		Return(&external.ClassDataOutput{
+			ClassData: &class.Data{
+				ID:           constants.ClassBard,
+				Name:         "Bard",
+				HitDice:      8,
+				SavingThrows: []constants.Ability{constants.DEX, constants.CHA},
+			},
+		}, nil)
+
+	// Mock background data
+	s.mockExtClient.EXPECT().
+		GetBackgroundData(gomock.Any(), string(constants.BackgroundSoldier)).
+		Return(&external.BackgroundData{
+			ID:                 "soldier",
+			Name:               "Soldier",
+			SkillProficiencies: []string{"Athletics", "Intimidation"},
+		}, nil)
+
+	// Mock character creation to verify Bard gets Bardic Inspiration and spell slots
+	s.mockCharRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input charrepo.CreateInput) (*charrepo.CreateOutput, error) {
+			// Class resources (Bard should get Bardic Inspiration)
+			s.Contains(input.CharacterData.ClassResources, "bardic_inspiration")
+			resource := input.CharacterData.ClassResources["bardic_inspiration"]
+			s.Equal("Bardic Inspiration", resource.Name)
+			s.Equal(3, resource.Max) // CHA modifier (16 = +3)
+			s.Equal(3, resource.Current)
+			s.Equal("long_rest", resource.Resets)
+
+			// Spell slots (Bard should get 2 first-level slots)
+			s.Contains(input.CharacterData.SpellSlots, 1)
+			slots := input.CharacterData.SpellSlots[1]
+			s.Equal(2, slots.Max)
+			s.Equal(0, slots.Used)
+
+			return &charrepo.CreateOutput{CharacterData: input.CharacterData}, nil
+		})
+
+	// Mock draft deletion
+	s.mockDraftRepo.EXPECT().
+		Delete(gomock.Any(), draftrepo.DeleteInput{ID: draftID}).
+		Return(&draftrepo.DeleteOutput{}, nil)
+
+	// Act
+	input := &character.FinalizeDraftInput{
+		DraftID: draftID,
+	}
+	output, err := s.orchestrator.FinalizeDraft(s.ctx, input)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+	s.True(output.DraftDeleted)
+}
+
+func (s *FinalizeDraftOrchestratorTestSuite) TestFinalizeDraft_WarlockPactMagic() {
+	draftID := "draft_123"
+
+	// Mock ID generation
+	s.mockIDGen.EXPECT().Generate().Return("char-123")
+
+	// Mock draft data for Warlock
+	draft := &toolkitchar.DraftData{
+		ID:       draftID,
+		PlayerID: "player_123",
+		Name:     "Test Warlock",
+		RaceChoice: toolkitchar.RaceChoice{
+			RaceID: constants.RaceHuman,
+		},
+		ClassChoice: toolkitchar.ClassChoice{
+			ClassID: constants.ClassWarlock,
+		},
+		BackgroundChoice: constants.BackgroundSoldier,
+		AbilityScoreChoice: shared.AbilityScores{
+			constants.STR: 10,
+			constants.CON: 14,
+			constants.CHA: 16,
+		},
+	}
+
+	// Mock draft retrieval
+	s.mockDraftRepo.EXPECT().
+		Get(gomock.Any(), draftrepo.GetInput{ID: draftID}).
+		Return(&draftrepo.GetOutput{Draft: draft}, nil)
+
+	// Mock race data
+	s.mockExtClient.EXPECT().
+		GetRaceData(gomock.Any(), string(constants.RaceHuman)).
+		Return(&external.RaceDataOutput{
+			RaceData: &race.Data{
+				ID:        constants.RaceHuman,
+				Name:      "Human",
+				Speed:     30,
+				Size:      "Medium",
+				Languages: []constants.Language{constants.LanguageCommon},
+			},
+		}, nil)
+
+	// Mock class data
+	s.mockExtClient.EXPECT().
+		GetClassData(gomock.Any(), string(constants.ClassWarlock)).
+		Return(&external.ClassDataOutput{
+			ClassData: &class.Data{
+				ID:           constants.ClassWarlock,
+				Name:         "Warlock",
+				HitDice:      8,
+				SavingThrows: []constants.Ability{constants.WIS, constants.CHA},
+			},
+		}, nil)
+
+	// Mock background data
+	s.mockExtClient.EXPECT().
+		GetBackgroundData(gomock.Any(), string(constants.BackgroundSoldier)).
+		Return(&external.BackgroundData{
+			ID:                 "soldier",
+			Name:               "Soldier",
+			SkillProficiencies: []string{"Athletics", "Intimidation"},
+		}, nil)
+
+	// Mock character creation to verify Warlock gets different spell slot pattern
+	s.mockCharRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input charrepo.CreateInput) (*charrepo.CreateOutput, error) {
+			// Class resources (Warlock has no class resources at level 1)
+			s.Empty(input.CharacterData.ClassResources)
+
+			// Spell slots (Warlock should get 1 first-level slot due to Pact Magic)
+			s.Contains(input.CharacterData.SpellSlots, 1)
+			slots := input.CharacterData.SpellSlots[1]
+			s.Equal(1, slots.Max) // 1 slot for Pact Magic
+			s.Equal(0, slots.Used)
+
+			return &charrepo.CreateOutput{CharacterData: input.CharacterData}, nil
+		})
+
+	// Mock draft deletion
+	s.mockDraftRepo.EXPECT().
+		Delete(gomock.Any(), draftrepo.DeleteInput{ID: draftID}).
+		Return(&draftrepo.DeleteOutput{}, nil)
+
+	// Act
+	input := &character.FinalizeDraftInput{
+		DraftID: draftID,
+	}
+	output, err := s.orchestrator.FinalizeDraft(s.ctx, input)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+	s.True(output.DraftDeleted)
 }
 
 func TestFinalizeDraftOrchestratorTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

- Initialize class-specific resources for level 1 characters during draft finalization
- Add spell slot initialization for spellcasting classes  
- Add comprehensive tests for different class resource patterns

## Changes

### Class Resources Added
- **Fighter**: Second Wind (1 use, short rest)
- **Barbarian**: Rage (2 uses, long rest)
- **Paladin**: Lay on Hands (5 HP pool, long rest)
- **Bard**: Bardic Inspiration (CHA modifier uses, long rest)

### Spell Slots Added
- **Full casters** (Wizard, Sorcerer, Cleric, Druid, Bard): 2 first-level slots
- **Warlock**: 1 first-level slot (Pact Magic)
- **Non-casters**: No spell slots

### Implementation Details
- Resources are initialized in the `FinalizeDraft` method after equipment processing
- Bard Bardic Inspiration uses are calculated dynamically based on CHA modifier (minimum 1)
- Rangers and Paladins correctly don't get spell slots until level 2
- Monks correctly don't get Ki until level 2

### Tests Added
- `TestFinalizeDraft_BarbarianClassResources`: Verifies Rage initialization
- `TestFinalizeDraft_WizardSpellSlots`: Verifies spell slot initialization  
- `TestFinalizeDraft_BardCharismaBasedResource`: Verifies CHA-based resource calculation
- `TestFinalizeDraft_WarlockPactMagic`: Verifies Warlock's unique spell slot pattern
- Updated existing test to verify Fighter's Second Wind

## Test Plan

- [x] Run all FinalizeDraft tests - all pass
- [x] Verify Fighter gets Second Wind resource
- [x] Verify Barbarian gets 2 Rage uses  
- [x] Verify Wizard gets 2 first-level spell slots
- [x] Verify Warlock gets 1 first-level spell slot (Pact Magic)
- [x] Verify Bard gets CHA-modifier Bardic Inspiration uses and spell slots
- [x] Verify non-casters don't get spell slots

🤖 Generated with [Claude Code](https://claude.ai/code)