### PR TITLE
fix: make background optional in character finalization

### DIFF
--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -642,9 +642,10 @@ func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftIn
 	if draft.ClassChoice.ClassID == "" {
 		return nil, errors.InvalidArgument("draft is incomplete: class is required")
 	}
-	if draft.BackgroundChoice == "" {
-		return nil, errors.InvalidArgument("draft is incomplete: background is required")
-	}
+	// Background is optional for now (UI not ready)
+	// if draft.BackgroundChoice == "" {
+	// 	return nil, errors.InvalidArgument("draft is incomplete: background is required")
+	// }
 	if len(draft.AbilityScoreChoice) == 0 {
 		return nil, errors.InvalidArgument("draft is incomplete: ability scores are required")
 	}
@@ -661,10 +662,13 @@ func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftIn
 		return nil, errors.Wrapf(err, "failed to get class data for %s", draft.ClassChoice.ClassID)
 	}
 
-	// Get background data
-	backgroundDataOutput, err := o.externalClient.GetBackgroundData(ctx, string(draft.BackgroundChoice))
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get background data for %s", draft.BackgroundChoice)
+	// Get background data (optional for now)
+	var backgroundDataOutput *external.BackgroundData
+	if draft.BackgroundChoice != "" {
+		backgroundDataOutput, err = o.externalClient.GetBackgroundData(ctx, string(draft.BackgroundChoice))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get background data for %s", draft.BackgroundChoice)
+		}
 	}
 
 	// Calculate hit points


### PR DESCRIPTION
## Summary
- Background selection is not yet implemented in the UI
- Made background optional during character finalization to unblock web UI development

## Changes
- Commented out background requirement validation in FinalizeDraft
- Updated GetBackgroundData to be conditional - only fetches when background is provided
- Added test case for successful finalization without background
- Commented out the 'Missing background' validation test

## Why
The web UI doesn't have background selection implemented yet, but we want to allow users to create characters. This change makes background optional temporarily until the UI is ready.

## Test Plan
- [x] Added test for finalization without background
- [x] All existing tests pass
- [x] Verified finalization works with and without background