### PR TITLE
fix: restore character ID generation and list functionality

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -137,7 +137,8 @@ func runServer(_ *cobra.Command, _ []string) error {
 		CharacterDraftRepo: draftRepo,
 		ExternalClient:     client,
 		DiceService:        diceService,
-		IDGenerator:        idgen.NewUUID("draft"),
+		IDGenerator:        idgen.NewUUID("char"),
+		DraftIDGenerator:   idgen.NewUUID("draft"),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create character service: %w", err)

--- a/docs/journey/rebase-lessons-learned.md
+++ b/docs/journey/rebase-lessons-learned.md
@@ -1,0 +1,104 @@
+# Rebase Lessons Learned: The Draft ID Regression
+
+## What Happened
+
+During PR #180 (racial traits), we rebased onto main and lost critical fixes:
+1. Separate ID generators for drafts vs characters
+2. ListCharacters implementation
+3. These fixes silently disappeared - no merge conflicts warned us
+
+## Why It Happened
+
+Rebasing rewrites history by replaying commits on top of the target branch. When the branch being rebased is older:
+- It doesn't know about recent fixes in main
+- Git picks the "rebased" version (the older code) when there's no direct conflict
+- Critical fixes can be silently lost
+
+## Better Approach: Merge Instead of Rebase
+
+### When to Use Merge
+**Default to merge for feature branches:**
+```bash
+git checkout feature-branch
+git merge main
+# Resolve conflicts if any
+git push
+```
+
+Benefits:
+- Preserves complete history
+- Conflicts are explicit and must be resolved
+- Can't accidentally lose code
+- Easier to trace what happened
+
+### When Rebase Might Be OK
+Only for very simple, short-lived branches:
+- Single commit fixes
+- No other PRs merged since branch creation
+- You're 100% sure of the changes
+
+### Pre-Rebase Checklist (If You Must)
+
+Before ANY rebase:
+
+1. **Document current state**
+   ```bash
+   git diff main..HEAD > /tmp/my-changes.patch
+   ```
+
+2. **Check what's been merged recently**
+   ```bash
+   git log --oneline main..origin/main
+   gh pr list --state merged --limit 5
+   ```
+
+3. **Identify critical areas**
+   - ID generation
+   - Service implementations  
+   - Handler implementations
+   - Repository methods
+
+4. **After rebase, verify nothing was lost**
+   ```bash
+   # Check critical files explicitly
+   git show HEAD:cmd/server/server.go | grep -A2 "IDGenerator"
+   git show HEAD:internal/handlers/dnd5e/v1alpha1/handler.go | grep -A10 "ListCharacters"
+   ```
+
+## Red Flags That Should Stop a Rebase
+
+- Branch is more than 2 days old
+- Multiple PRs merged since branch creation
+- Touching core infrastructure (server.go, handlers, orchestrators)
+- Any uncertainty about what's in main
+
+## The Simple Rule
+
+**When in doubt, merge instead of rebase.**
+
+The "messy" merge commit history is worth avoiding silent code loss.
+
+## This Specific Case
+
+What we should have done for PR #180:
+```bash
+git checkout feat/racial-traits
+git merge main
+# See explicit conflicts
+# Carefully resolve keeping both features
+git push
+```
+
+Instead of:
+```bash
+git rebase main  # Silently lost the fixes
+```
+
+## Going Forward
+
+1. Default to merge for feature branches
+2. Only rebase if you created the branch TODAY
+3. Always verify critical code after any rebase
+4. Document in PR description if you rebased and what you verified
+
+Remember: A "clean" history isn't worth losing working code.

--- a/internal/handlers/dnd5e/v1alpha1/handler_list_classes_choices_integration_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/handler_list_classes_choices_integration_test.go
@@ -73,8 +73,9 @@ func (s *HandlerListClassesChoicesIntegrationTestSuite) SetupSuite() {
 	// Create mocked dice service (not used by ListClasses)
 	mockDiceService := dicemock.NewMockService(s.ctrl)
 
-	// Create mocked ID generator (not used by ListClasses)
+	// Create mocked ID generators (not used by ListClasses)
 	mockIDGenerator := idgenmock.NewMockGenerator(s.ctrl)
+	mockDraftIDGenerator := idgenmock.NewMockGenerator(s.ctrl)
 
 	// Create character orchestrator with REAL external client and mocked repos
 	characterOrch, err := character.New(&character.Config{
@@ -83,6 +84,7 @@ func (s *HandlerListClassesChoicesIntegrationTestSuite) SetupSuite() {
 		ExternalClient:     s.externalClient, // REAL external client
 		DiceService:        mockDiceService,
 		IDGenerator:        mockIDGenerator,
+		DraftIDGenerator:   mockDraftIDGenerator,
 	})
 	s.Require().NoError(err)
 	s.characterOrch = characterOrch

--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -26,6 +26,7 @@ type Config struct {
 	ExternalClient     external.Client
 	DiceService        dice.Service
 	IDGenerator        idgen.Generator
+	DraftIDGenerator   idgen.Generator
 }
 
 // Validate ensures all required dependencies are present
@@ -45,6 +46,9 @@ func (c *Config) Validate() error {
 	if c.IDGenerator == nil {
 		return errors.InvalidArgument("ID generator is required")
 	}
+	if c.DraftIDGenerator == nil {
+		return errors.InvalidArgument("draft ID generator is required")
+	}
 	return nil
 }
 
@@ -55,6 +59,7 @@ type Orchestrator struct {
 	externalClient external.Client
 	diceService    dice.Service
 	idGen          idgen.Generator
+	draftIDGen     idgen.Generator
 }
 
 // New creates a new character orchestrator
@@ -69,6 +74,7 @@ func New(cfg *Config) (*Orchestrator, error) {
 		externalClient: cfg.ExternalClient,
 		diceService:    cfg.DiceService,
 		idGen:          cfg.IDGenerator,
+		draftIDGen:     cfg.DraftIDGenerator,
 	}, nil
 }
 
@@ -123,7 +129,7 @@ func (o *Orchestrator) CreateDraft(ctx context.Context, input *CreateDraftInput)
 
 	// Create new draft with minimal data
 	draft := &toolkitchar.DraftData{
-		ID:       o.idGen.Generate(),
+		ID:       o.draftIDGen.Generate(),
 		PlayerID: input.PlayerID,
 	}
 
@@ -925,7 +931,17 @@ func (o *Orchestrator) GetCharacter(ctx context.Context, input *GetCharacterInpu
 }
 
 func (o *Orchestrator) ListCharacters(ctx context.Context, input *ListCharactersInput) (*ListCharactersOutput, error) {
-	return nil, errors.Unimplemented("not implemented")
+	// List characters from repository by player ID
+	listOutput, err := o.charRepo.ListByPlayerID(ctx, character.ListByPlayerIDInput{
+		PlayerID: input.PlayerID,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list characters")
+	}
+
+	return &ListCharactersOutput{
+		Characters: listOutput.Characters,
+	}, nil
 }
 
 func (o *Orchestrator) DeleteCharacter(ctx context.Context, input *DeleteCharacterInput) (*DeleteCharacterOutput, error) {

--- a/internal/orchestrators/character/orchestrator_roll_ability_scores_test.go
+++ b/internal/orchestrators/character/orchestrator_roll_ability_scores_test.go
@@ -43,6 +43,7 @@ func (s *OrchestratorRollAbilityScoresTestSuite) SetupTest() {
 	s.mockChar = charactermock.NewMockRepository(s.ctrl)
 	s.mockExternal = externalmock.NewMockClient(s.ctrl)
 	s.mockIDGen = idgenmock.NewMockGenerator(s.ctrl)
+	mockDraftIDGen := idgenmock.NewMockGenerator(s.ctrl)
 
 	orchestrator, err := character.New(&character.Config{
 		CharacterDraftRepo: s.mockDraft,
@@ -50,6 +51,7 @@ func (s *OrchestratorRollAbilityScoresTestSuite) SetupTest() {
 		CharacterRepo:      s.mockChar,
 		ExternalClient:     s.mockExternal,
 		IDGenerator:        s.mockIDGen,
+		DraftIDGenerator:   mockDraftIDGen,
 	})
 	s.Require().NoError(err)
 	s.orchestrator = orchestrator

--- a/internal/orchestrators/character/orchestrator_test.go
+++ b/internal/orchestrators/character/orchestrator_test.go
@@ -31,8 +31,9 @@ type OrchestratorTestSuite struct {
 	mockDraftRepo   *draftrepomock.MockRepository
 	mockExternal    *externalmock.MockClient
 	mockDiceService *dicemock.MockService
-	mockIDGenerator *idgenmock.MockGenerator
-	orchestrator    *character.Orchestrator
+	mockIDGenerator      *idgenmock.MockGenerator
+	mockDraftIDGenerator *idgenmock.MockGenerator
+	orchestrator         *character.Orchestrator
 	ctx             context.Context
 
 	// Test data
@@ -48,6 +49,7 @@ func (s *OrchestratorTestSuite) SetupTest() {
 	s.mockExternal = externalmock.NewMockClient(s.ctrl)
 	s.mockDiceService = dicemock.NewMockService(s.ctrl)
 	s.mockIDGenerator = idgenmock.NewMockGenerator(s.ctrl)
+	s.mockDraftIDGenerator = idgenmock.NewMockGenerator(s.ctrl)
 	s.ctx = context.Background()
 
 	orchestrator, err := character.New(&character.Config{
@@ -56,6 +58,7 @@ func (s *OrchestratorTestSuite) SetupTest() {
 		ExternalClient:     s.mockExternal,
 		DiceService:        s.mockDiceService,
 		IDGenerator:        s.mockIDGenerator,
+		DraftIDGenerator:   s.mockDraftIDGenerator,
 	})
 	s.Require().NoError(err)
 	s.orchestrator = orchestrator


### PR DESCRIPTION
## Summary
- Restores separate ID generators for drafts (`draft_`) vs characters (`char_`)
- Implements ListCharacters functionality that was lost during rebase
- Documents lessons learned about rebase vs merge

## Problem
After merging PR #180 via rebase, we lost critical fixes:
1. Characters were getting `draft_` prefix instead of `char_` prefix
2. ListCharacters was returning empty response
3. Previous characters appeared to "disappear" (they're in Redis but couldn't be listed)

## Solution
- Added `DraftIDGenerator` to orchestrator config for draft IDs
- Use `IDGenerator` for character IDs (with "char" prefix)
- Implemented ListCharacters in handler and orchestrator
- Updated all test files to include both generators

## Lessons Learned
Created `docs/journey/rebase-lessons-learned.md` documenting why we should prefer merge over rebase for feature branches to avoid silent code loss.

## Test Plan
- [ ] Create a new draft
- [ ] Finalize the draft
- [ ] Verify character ID starts with `char_` not `draft_`
- [ ] Call ListCharacters and verify characters appear
- [ ] Verify existing characters in Redis are now visible

Fixes the regression where finalized characters had wrong IDs and couldn't be listed.