### PR TITLE
fix: unpack equipment bundle references during character finalization

### DIFF
--- a/internal/orchestrators/character/unpack_bundle_test.go
+++ b/internal/orchestrators/character/unpack_bundle_test.go
@@ -1,0 +1,63 @@
+package character
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnpackBundleItem(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "bundle reference with greatclub",
+			input:    "bundle_1:0:greatclub",
+			expected: "greatclub",
+		},
+		{
+			name:     "bundle reference with different item",
+			input:    "bundle_2:3:shortsword",
+			expected: "shortsword",
+		},
+		{
+			name:     "bundle reference with complex item ID",
+			input:    "bundle_0:1:thieves-tools",
+			expected: "thieves-tools",
+		},
+		{
+			name:     "regular item ID without bundle prefix",
+			input:    "longsword",
+			expected: "longsword",
+		},
+		{
+			name:     "regular item ID with hyphen",
+			input:    "chain-mail",
+			expected: "chain-mail",
+		},
+		{
+			name:     "malformed bundle reference with too few parts",
+			input:    "bundle_1:greatclub",
+			expected: "bundle_1:greatclub", // Returns as-is when malformed
+		},
+		{
+			name:     "malformed bundle reference with too many parts",
+			input:    "bundle_1:0:2:greatclub",
+			expected: "bundle_1:0:2:greatclub", // Returns as-is when malformed
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := unpackBundleItem(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes equipment bundles appearing as `bundle_1:0:greatclub` instead of `greatclub`
- Extracts actual item IDs from bundle references during character finalization

## Problem
When users select equipment bundles in the Discord bot, the items are stored with a bundle reference format like `bundle_1:0:greatclub`. This was appearing in the finalized character's inventory instead of the actual item.

## Solution
Added `unpackBundleItem` function that:
- Detects bundle references (items starting with `bundle_`)
- Extracts the actual item ID from the format `bundle_X:Y:item_id`
- Returns regular items unchanged

## Test Plan
- [x] Unit tests for unpacking various bundle formats
- [ ] Create a character with equipment bundles
- [ ] Verify finalized character has actual items (e.g., `greatclub`) not bundle references
- [ ] Verify regular equipment items still work correctly

## Example
**Before**: Character inventory shows `bundle_1:0:greatclub`
**After**: Character inventory shows `greatclub`