### PR TITLE
fix: apply 4d6 drop lowest for ability score rolls

### DIFF
--- a/internal/orchestrators/dice/orchestrator.go
+++ b/internal/orchestrators/dice/orchestrator.go
@@ -176,6 +176,9 @@ func (o *orchestrator) rollDiceWithToolkit(count, size int, dropLowest int) ([]i
 			newTotal += d
 		}
 
+		// Return the kept dice, dropped dice, and new total
+		// Note: We return only the kept dice as the "dice" for display
+		// The dropped dice are tracked separately
 		return kept, dropped, newTotal, nil
 	}
 
@@ -201,8 +204,14 @@ func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*Rol
 		return nil, err
 	}
 
+	// Determine if we should drop lowest (for ability scores)
+	dropLowest := 0
+	if input.Context == ContextAbilityScores && input.Notation == "4d6" {
+		dropLowest = 1 // Drop the lowest die for ability scores
+	}
+
 	// Roll the dice using rpg-toolkit
-	individualDice, dropped, total, err := o.rollDiceWithToolkit(count, size, 0)
+	individualDice, dropped, total, err := o.rollDiceWithToolkit(count, size, dropLowest)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to roll dice")
 	}

--- a/internal/orchestrators/dice/orchestrator_ability_test.go
+++ b/internal/orchestrators/dice/orchestrator_ability_test.go
@@ -1,0 +1,149 @@
+package dice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/KirkDiggler/rpg-api/internal/errors"
+	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
+	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
+	dicemock "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session/mock"
+)
+
+func TestOrchestrator_RollDice_AbilityScores(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRepo := dicemock.NewMockRepository(ctrl)
+	idGen := idgen.NewUUID("roll")
+
+	o, err := NewOrchestrator(&Config{
+		DiceSessionRepo: mockRepo,
+		IDGenerator:     idGen,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Test rolling 4d6 for ability scores - should drop lowest
+	t.Run("4d6 ability scores drops lowest", func(t *testing.T) {
+		input := &RollDiceInput{
+			EntityID: "player-123",
+			Context:  ContextAbilityScores,
+			Notation: "4d6",
+		}
+
+		// Mock the repository to return NotFound (no existing session)
+		mockRepo.EXPECT().
+			Get(ctx, dicesession.GetInput{
+				EntityID: "player-123",
+				Context:  ContextAbilityScores,
+			}).
+			Return(nil, errors.NotFound("session not found"))
+
+		// Mock creating a new session
+		mockRepo.EXPECT().
+			Create(ctx, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, input dicesession.CreateInput) (*dicesession.CreateOutput, error) {
+				// Verify that we're storing the roll with dropped dice
+				require.Equal(t, "player-123", input.EntityID)
+				require.Equal(t, ContextAbilityScores, input.Context)
+				require.Len(t, input.Rolls, 1)
+				
+				roll := input.Rolls[0]
+				// Should have 3 kept dice (4d6 drop lowest)
+				assert.Len(t, roll.Dice, 3, "Should have 3 kept dice")
+				// Should have 1 dropped die
+				assert.Len(t, roll.Dropped, 1, "Should have 1 dropped die")
+				// Total should be sum of kept dice only
+				var keptSum int32
+				for _, d := range roll.Dice {
+					keptSum += d
+				}
+				assert.Equal(t, keptSum, roll.Total, "Total should be sum of kept dice")
+				// Total should be between 3 and 18 (3d6 range)
+				assert.GreaterOrEqual(t, roll.Total, int32(3))
+				assert.LessOrEqual(t, roll.Total, int32(18))
+
+				return &dicesession.CreateOutput{
+					Session: &dicesession.DiceSession{
+						EntityID: input.EntityID,
+						Context:  input.Context,
+						Rolls:    input.Rolls,
+					},
+				}, nil
+			})
+
+		output, err := o.RollDice(ctx, input)
+		require.NoError(t, err)
+		require.NotNil(t, output)
+		require.NotNil(t, output.Roll)
+		
+		// Verify the roll has the expected properties
+		assert.Equal(t, "4d6", output.Roll.Notation)
+		assert.Len(t, output.Roll.Dice, 3, "Should have 3 kept dice")
+		assert.Len(t, output.Roll.Dropped, 1, "Should have 1 dropped die")
+		assert.GreaterOrEqual(t, output.Roll.Total, int32(3))
+		assert.LessOrEqual(t, output.Roll.Total, int32(18))
+	})
+
+	// Test rolling 4d6 for non-ability context - should NOT drop lowest
+	t.Run("4d6 non-ability context keeps all dice", func(t *testing.T) {
+		input := &RollDiceInput{
+			EntityID: "player-123",
+			Context:  "damage_rolls",
+			Notation: "4d6",
+		}
+
+		// Mock the repository to return NotFound (no existing session)
+		mockRepo.EXPECT().
+			Get(ctx, dicesession.GetInput{
+				EntityID: "player-123",
+				Context:  "damage_rolls",
+			}).
+			Return(nil, errors.NotFound("session not found"))
+
+		// Mock creating a new session
+		mockRepo.EXPECT().
+			Create(ctx, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, input dicesession.CreateInput) (*dicesession.CreateOutput, error) {
+				// Verify that we're NOT dropping dice for non-ability context
+				require.Equal(t, "player-123", input.EntityID)
+				require.Equal(t, "damage_rolls", input.Context)
+				require.Len(t, input.Rolls, 1)
+				
+				roll := input.Rolls[0]
+				// Should have 4 dice (no dropping)
+				assert.Len(t, roll.Dice, 4, "Should have all 4 dice")
+				// Should have no dropped dice
+				assert.Len(t, roll.Dropped, 0, "Should have no dropped dice")
+				// Total should be between 4 and 24 (4d6 range)
+				assert.GreaterOrEqual(t, roll.Total, int32(4))
+				assert.LessOrEqual(t, roll.Total, int32(24))
+
+				return &dicesession.CreateOutput{
+					Session: &dicesession.DiceSession{
+						EntityID: input.EntityID,
+						Context:  input.Context,
+						Rolls:    input.Rolls,
+					},
+				}, nil
+			})
+
+		output, err := o.RollDice(ctx, input)
+		require.NoError(t, err)
+		require.NotNil(t, output)
+		require.NotNil(t, output.Roll)
+		
+		// Verify the roll has the expected properties
+		assert.Equal(t, "4d6", output.Roll.Notation)
+		assert.Len(t, output.Roll.Dice, 4, "Should have all 4 dice")
+		assert.Len(t, output.Roll.Dropped, 0, "Should have no dropped dice")
+		assert.GreaterOrEqual(t, output.Roll.Total, int32(4))
+		assert.LessOrEqual(t, output.Roll.Total, int32(24))
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes ability scores being too high (up to 24 instead of max 18)
- Automatically drops lowest die when rolling 4d6 for ability scores

## Problem
When rolling dice for ability scores, the system was summing all 4 dice from a 4d6 roll, resulting in ability scores as high as 24. D&D 5e standard rules require dropping the lowest die, giving a maximum of 18.

## Solution
- Modified `RollDice` to detect when context is "ability_scores"
- When rolling 4d6 for ability scores, automatically drop the lowest die
- Other contexts (damage, combat, etc.) keep all dice as normal
- Added comprehensive tests for both scenarios

## Test Results
```
=== RUN   TestOrchestrator_RollDice_AbilityScores/4d6_ability_scores_drops_lowest
✅ Correctly drops lowest die, total between 3-18

=== RUN   TestOrchestrator_RollDice_AbilityScores/4d6_non-ability_context_keeps_all_dice  
✅ Keeps all dice for non-ability contexts, total between 4-24
```

## Breaking Changes
None - this is a bug fix that brings the behavior in line with D&D 5e rules.

🤖 Generated with [Claude Code](https://claude.ai/code)