### PR TITLE
fix: Wire up encounter repository in server initialization

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -35,6 +35,7 @@ import (
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	characterdraftrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 	dicesessionrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
+	encountersrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 )
 
 var (
@@ -132,9 +133,13 @@ func runServer(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create dice service: %w", err)
 	}
 
+	// Create encounter repository (in-memory for now)
+	encounterRepo := encountersrepo.NewInMemory()
+
 	// Create encounter service
 	encounterService, err := encounter.NewOrchestrator(&encounter.Config{
 		IDGenerator: idgen.NewPrefixed("enc-"),
+		Repository:  encounterRepo,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create encounter service: %w", err)


### PR DESCRIPTION
## Critical Production Fix

The encounter service was failing in production with:
```
Error: failed to create encounter service: INVALID_ARGUMENT: invalid config: INVALID_ARGUMENT: validation failed: Repository: is required
```

## Root Cause
When we refactored to use the repository pattern, we updated the orchestrator to require a repository but forgot to update server.go to provide one. The repository creation code was never committed.

## Fix
- Add import for encountersrepo package
- Create encounter repository before orchestrator
- Pass repository to orchestrator config

This fix is critical as it's blocking the demo from working in production.