### PR TITLE
feat: Add toolkit validation infrastructure for character drafts

### DIFF
--- a/internal/orchestrators/character/draft_validation.go
+++ b/internal/orchestrators/character/draft_validation.go
@@ -1,0 +1,143 @@
+package character
+
+// TODO: Uncomment and implement once protos are regenerated with ValidationResult types
+// This file provides draft validation using the toolkit's 3-tier validation system
+
+/*
+import (
+	"context"
+	
+	pb "github.com/KirkDiggler/rpg-api/gen/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/entities/dnd5e"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+)
+
+// validateDraft validates a character draft using the toolkit and returns proto validation
+func (o *Orchestrator) validateDraft(ctx context.Context, draft *dnd5e.CharacterDraftData) *pb.ValidationResult {
+	if draft == nil {
+		return &pb.ValidationResult{
+			IsValid: true,
+			Issues:  []*pb.ValidationResult_Issue{},
+		}
+	}
+
+	// Create validation context
+	validationCtx := choices.NewValidationContext()
+	
+	// Set draft vs finalized mode
+	validationCtx.SetDraftMode(true) // Allow incomplete choices for drafts
+	
+	// Create typed submissions from draft choices
+	submissions := choices.NewTypedSubmissions()
+	
+	// Add choices from draft
+	if draft.ClassChoice != nil {
+		// Add class skills if present
+		if draft.ClassChoice.SkillChoices != nil {
+			submissions.AddSkills(choices.SourceClass, draft.ClassChoice.SkillChoices)
+		}
+		// Add equipment choices
+		for _, equip := range draft.ClassChoice.EquipmentChoices {
+			submissions.AddEquipment(choices.SourceClass, equip)
+		}
+		// Add fighting style if present
+		if draft.ClassChoice.FightingStyle != "" {
+			submissions.AddFightingStyle(draft.ClassChoice.FightingStyle)
+		}
+	}
+
+	if draft.RaceChoice != nil {
+		// Add race language choices
+		if draft.RaceChoice.LanguageChoices != nil {
+			submissions.AddLanguages(choices.SourceRace, draft.RaceChoice.LanguageChoices)
+		}
+		// Add race skill choices
+		if draft.RaceChoice.SkillChoices != nil {
+			submissions.AddSkills(choices.SourceRace, draft.RaceChoice.SkillChoices)
+		}
+	}
+
+	if draft.BackgroundChoice != "" {
+		// Background skills are automatic, not choices
+		// But we could add tool/language choices if they exist
+	}
+
+	// Get requirements based on draft selections
+	var requirements *choices.Requirements
+	if draft.ClassChoice != nil && draft.RaceChoice != nil {
+		requirements = choices.GetRequirements(
+			draft.ClassChoice.ClassID,
+			draft.RaceChoice.RaceID,
+			1, // Level 1 for new characters
+		)
+	} else if draft.ClassChoice != nil {
+		requirements = choices.GetClassRequirements(draft.ClassChoice.ClassID, 1)
+	} else if draft.RaceChoice != nil {
+		requirements = choices.GetRaceRequirements(draft.RaceChoice.RaceID)
+	}
+
+	// Validate if we have requirements
+	var result *choices.ValidationResult
+	if requirements != nil {
+		validator := choices.NewValidator(validationCtx)
+		result = validator.Validate(requirements, submissions)
+	} else {
+		// No requirements yet, return valid but incomplete
+		result = choices.NewValidationResult()
+		result.AddIssue(choices.ValidationIssue{
+			Severity: choices.SeverityIncomplete,
+			Source:   choices.SourceClass,
+			Field:    choices.FieldClass,
+			Message:  "Class selection required",
+		})
+		result.AddIssue(choices.ValidationIssue{
+			Severity: choices.SeverityIncomplete,
+			Source:   choices.SourceRace,
+			Field:    choices.FieldRace,
+			Message:  "Race selection required",
+		})
+	}
+
+	// Convert to proto format
+	return convertToolkitValidationToProto(result)
+}
+
+// attachValidationToDraft adds validation to a draft for responses
+func (o *Orchestrator) attachValidationToDraft(ctx context.Context, draft *pb.CharacterDraft) {
+	if draft == nil {
+		return
+	}
+
+	// Convert proto draft to entity for validation
+	draftData := &dnd5e.CharacterDraftData{
+		ID:       draft.Id,
+		PlayerID: draft.PlayerId,
+	}
+
+	// Map proto enums to entity types
+	if draft.RaceId != pb.Race_RACE_UNSPECIFIED {
+		draftData.RaceChoice = &dnd5e.RaceChoice{
+			RaceID: convertProtoRaceToToolkit(draft.RaceId),
+		}
+	}
+
+	if draft.ClassId != pb.Class_CLASS_UNSPECIFIED {
+		draftData.ClassChoice = &dnd5e.ClassChoice{
+			ClassID: convertProtoClassToToolkit(draft.ClassId),
+		}
+	}
+
+	if draft.BackgroundId != pb.Background_BACKGROUND_UNSPECIFIED {
+		draftData.BackgroundChoice = convertProtoBackgroundToString(draft.BackgroundId)
+	}
+
+	// Map choices
+	for _, choice := range draft.Choices {
+		// Convert proto choices to entity choices
+		// This would need more detailed mapping based on choice types
+	}
+
+	// Validate and attach
+	draft.Validation = o.validateDraft(ctx, draftData)
+}
+*/

--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -1129,21 +1129,21 @@ func (o *Orchestrator) DeleteCharacter(ctx context.Context, input *DeleteCharact
 }
 
 func (o *Orchestrator) ListRaces(ctx context.Context, input *ListRacesInput) (*ListRacesOutput, error) {
-	// For now, we'll return all races from a hardcoded list
-	// In a real implementation, this might come from a database or be cached
-
+	// For now, continue using external client for complete race data
+	// TODO: Migrate to pure toolkit approach when toolkit has all display data
 	allRaces := races.All
 
 	// Get race data for each race
-	races := make([]RaceListItem, 0, len(allRaces))
+	raceList := make([]RaceListItem, 0, len(allRaces))
 	for _, raceID := range allRaces {
+		// Use external client for now since it has complete data
 		raceDataOutput, err := o.externalClient.GetRaceData(ctx, string(raceID))
 		if err != nil {
 			// Skip races that fail to load
 			continue
 		}
 
-		races = append(races, RaceListItem{
+		raceList = append(raceList, RaceListItem{
 			RaceData: raceDataOutput.RaceData,
 			UIData:   raceDataOutput.UIData,
 		})
@@ -1152,9 +1152,9 @@ func (o *Orchestrator) ListRaces(ctx context.Context, input *ListRacesInput) (*L
 	// Simple pagination - for now just return all races
 	// TODO: Implement proper pagination when needed
 	return &ListRacesOutput{
-		Races:         races,
+		Races:         raceList,
 		NextPageToken: "",
-		TotalSize:     len(races),
+		TotalSize:     len(raceList),
 	}, nil
 }
 

--- a/internal/orchestrators/character/proto_converters.go
+++ b/internal/orchestrators/character/proto_converters.go
@@ -1,0 +1,110 @@
+package character
+
+// TODO: Uncomment and implement once protos are regenerated with ValidationResult types
+// This file provides conversion between proto enums and toolkit types
+
+/*
+import (
+	pb "github.com/KirkDiggler/rpg-api/gen/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+)
+
+// convertProtoRaceToToolkit converts proto Race enum to toolkit Race type
+func convertProtoRaceToToolkit(race pb.Race) races.Race {
+	switch race {
+	case pb.Race_RACE_HUMAN:
+		return races.Human
+	case pb.Race_RACE_ELF:
+		return races.Elf
+	case pb.Race_RACE_DWARF:
+		return races.Dwarf
+	case pb.Race_RACE_HALFLING:
+		return races.Halfling
+	case pb.Race_RACE_DRAGONBORN:
+		return races.Dragonborn
+	case pb.Race_RACE_GNOME:
+		return races.Gnome
+	case pb.Race_RACE_HALF_ELF:
+		return races.HalfElf
+	case pb.Race_RACE_HALF_ORC:
+		return races.HalfOrc
+	case pb.Race_RACE_TIEFLING:
+		return races.Tiefling
+	default:
+		return races.Race("")
+	}
+}
+
+// convertProtoClassToToolkit converts proto Class enum to toolkit Class type
+func convertProtoClassToToolkit(class pb.Class) classes.Class {
+	switch class {
+	case pb.Class_CLASS_BARBARIAN:
+		return classes.Barbarian
+	case pb.Class_CLASS_BARD:
+		return classes.Bard
+	case pb.Class_CLASS_CLERIC:
+		return classes.Cleric
+	case pb.Class_CLASS_DRUID:
+		return classes.Druid
+	case pb.Class_CLASS_FIGHTER:
+		return classes.Fighter
+	case pb.Class_CLASS_MONK:
+		return classes.Monk
+	case pb.Class_CLASS_PALADIN:
+		return classes.Paladin
+	case pb.Class_CLASS_RANGER:
+		return classes.Ranger
+	case pb.Class_CLASS_ROGUE:
+		return classes.Rogue
+	case pb.Class_CLASS_SORCERER:
+		return classes.Sorcerer
+	case pb.Class_CLASS_WARLOCK:
+		return classes.Warlock
+	case pb.Class_CLASS_WIZARD:
+		return classes.Wizard
+	default:
+		return classes.Class("")
+	}
+}
+
+// convertProtoBackgroundToString converts proto Background enum to string
+func convertProtoBackgroundToString(bg pb.Background) string {
+	switch bg {
+	case pb.Background_BACKGROUND_ACOLYTE:
+		return "acolyte"
+	case pb.Background_BACKGROUND_CHARLATAN:
+		return "charlatan"
+	case pb.Background_BACKGROUND_CRIMINAL:
+		return "criminal"
+	case pb.Background_BACKGROUND_ENTERTAINER:
+		return "entertainer"
+	case pb.Background_BACKGROUND_FOLK_HERO:
+		return "folk-hero"
+	case pb.Background_BACKGROUND_GUILD_ARTISAN:
+		return "guild-artisan"
+	case pb.Background_BACKGROUND_HERMIT:
+		return "hermit"
+	case pb.Background_BACKGROUND_KNIGHT:
+		return "knight"
+	case pb.Background_BACKGROUND_NOBLE:
+		return "noble"
+	case pb.Background_BACKGROUND_OUTLANDER:
+		return "outlander"
+	case pb.Background_BACKGROUND_PIRATE:
+		return "pirate"
+	case pb.Background_BACKGROUND_SAGE:
+		return "sage"
+	case pb.Background_BACKGROUND_SAILOR:
+		return "sailor"
+	case pb.Background_BACKGROUND_SOLDIER:
+		return "soldier"
+	case pb.Background_BACKGROUND_SPY:
+		return "spy"
+	case pb.Background_BACKGROUND_URCHIN:
+		return "urchin"
+	default:
+		return ""
+	}
+}
+*/

--- a/internal/orchestrators/character/validation_converter.go
+++ b/internal/orchestrators/character/validation_converter.go
@@ -1,0 +1,126 @@
+package character
+
+// TODO: Uncomment and implement once protos are regenerated with ValidationResult types
+// This file provides conversion between toolkit validation and proto validation formats
+
+/*
+import (
+	pb "github.com/KirkDiggler/rpg-api/gen/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+)
+
+// convertToolkitValidationToProto converts toolkit validation results to proto format
+func convertToolkitValidationToProto(result *choices.ValidationResult) *pb.ValidationResult {
+	if result == nil {
+		return &pb.ValidationResult{
+			IsValid: true,
+			Issues:  []*pb.ValidationResult_Issue{},
+		}
+	}
+
+	// Convert issues
+	issues := make([]*pb.ValidationResult_Issue, 0, len(result.Errors)+len(result.Warnings)+len(result.Incomplete))
+	
+	// Add errors
+	for _, err := range result.Errors {
+		issues = append(issues, &pb.ValidationResult_Issue{
+			Severity:     pb.ValidationResult_SEVERITY_ERROR,
+			Source:       convertSourceToProto(err.Source),
+			Field:        convertFieldToProto(err.Field),
+			Message:      err.Message,
+			Details:      err.Details,
+			SourceDetail: string(err.Source), // Keep string representation for detail
+		})
+	}
+
+	// Add incomplete issues
+	for _, inc := range result.Incomplete {
+		issues = append(issues, &pb.ValidationResult_Issue{
+			Severity:     pb.ValidationResult_SEVERITY_INCOMPLETE,
+			Source:       convertSourceToProto(inc.Source),
+			Field:        convertFieldToProto(inc.Field),
+			Message:      inc.Message,
+			Details:      inc.Details,
+			SourceDetail: string(inc.Source),
+		})
+	}
+
+	// Add warnings
+	for _, warn := range result.Warnings {
+		issues = append(issues, &pb.ValidationResult_Issue{
+			Severity:     pb.ValidationResult_SEVERITY_WARNING,
+			Source:       convertSourceToProto(warn.Source),
+			Field:        convertFieldToProto(warn.Field),
+			Message:      warn.Message,
+			Details:      warn.Details,
+			SourceDetail: string(warn.Source),
+		})
+	}
+
+	return &pb.ValidationResult{
+		IsValid:         result.IsValid(),
+		Issues:          issues,
+		ErrorCount:      int32(len(result.Errors)),
+		IncompleteCount: int32(len(result.Incomplete)),
+		WarningCount:    int32(len(result.Warnings)),
+	}
+}
+
+// convertSourceToProto converts toolkit source to proto enum
+func convertSourceToProto(source choices.Source) pb.ValidationSource {
+	switch source {
+	case choices.SourceRace:
+		return pb.ValidationSource_VALIDATION_SOURCE_RACE
+	case choices.SourceClass:
+		return pb.ValidationSource_VALIDATION_SOURCE_CLASS
+	case choices.SourceBackground:
+		return pb.ValidationSource_VALIDATION_SOURCE_BACKGROUND
+	case choices.SourceAbilityScores:
+		return pb.ValidationSource_VALIDATION_SOURCE_ABILITY_SCORES
+	case choices.SourceName:
+		return pb.ValidationSource_VALIDATION_SOURCE_NAME
+	case choices.SourceAlignment:
+		return pb.ValidationSource_VALIDATION_SOURCE_ALIGNMENT
+	case choices.SourceLevel:
+		return pb.ValidationSource_VALIDATION_SOURCE_LEVEL
+	default:
+		return pb.ValidationSource_VALIDATION_SOURCE_UNSPECIFIED
+	}
+}
+
+// convertFieldToProto converts toolkit field to proto enum
+func convertFieldToProto(field choices.Field) pb.ValidationField {
+	switch field {
+	case choices.FieldSkills:
+		return pb.ValidationField_VALIDATION_FIELD_SKILLS
+	case choices.FieldLanguages:
+		return pb.ValidationField_VALIDATION_FIELD_LANGUAGES
+	case choices.FieldEquipment:
+		return pb.ValidationField_VALIDATION_FIELD_EQUIPMENT
+	case choices.FieldSpells:
+		return pb.ValidationField_VALIDATION_FIELD_SPELLS
+	case choices.FieldCantrips:
+		return pb.ValidationField_VALIDATION_FIELD_CANTRIPS
+	case choices.FieldTools:
+		return pb.ValidationField_VALIDATION_FIELD_TOOLS
+	case choices.FieldExpertise:
+		return pb.ValidationField_VALIDATION_FIELD_EXPERTISE
+	case choices.FieldFightingStyle:
+		return pb.ValidationField_VALIDATION_FIELD_FIGHTING_STYLE
+	case choices.FieldAbilityScores:
+		return pb.ValidationField_VALIDATION_FIELD_ABILITY_SCORES
+	case choices.FieldName:
+		return pb.ValidationField_VALIDATION_FIELD_NAME
+	case choices.FieldRace:
+		return pb.ValidationField_VALIDATION_FIELD_RACE
+	case choices.FieldClass:
+		return pb.ValidationField_VALIDATION_FIELD_CLASS
+	case choices.FieldBackground:
+		return pb.ValidationField_VALIDATION_FIELD_BACKGROUND
+	case choices.FieldDraconicAncestry:
+		return pb.ValidationField_VALIDATION_FIELD_DRACONIC_ANCESTRY
+	default:
+		return pb.ValidationField_VALIDATION_FIELD_UNSPECIFIED
+	}
+}
+*/


### PR DESCRIPTION
## Summary
Adds infrastructure to pipe rpg-toolkit's 3-tier validation system through to the proto layer.

## Changes
### Validation Infrastructure
- **validation_converter.go**: Converts toolkit ValidationResult to proto format
- **proto_converters.go**: Maps proto enums to toolkit types (Race, Class, Background)
- **draft_validation.go**: Validates drafts using toolkit's validation system
- All files are temporarily commented out pending proto regeneration

### Orchestrator Updates
- Updated ListRaces to prepare for direct toolkit usage
- Infrastructure ready for toolkit validation integration

## Context
This is the first step in integrating the toolkit's sophisticated validation system:
- **Error severity**: Critical issues that prevent character use
- **Incomplete severity**: Missing required choices (OK for drafts)
- **Warning severity**: Non-blocking issues like duplicate proficiencies

## Next Steps
1. Merge rpg-api-protos#56 to add ValidationResult proto types
2. Regenerate protos in rpg-api
3. Uncomment validation code
4. Add validation to GetDraft and Update methods

## Benefits
- Real-time validation feedback during character creation
- Better UX with warnings for duplicate choices
- Support for draft saves with incomplete data
- Single source of truth for D&D 5e rules

## Related Issues
- Partially addresses #230 (toolkit integration)
- Depends on rpg-api-protos#56 (proto changes)
- Uses rpg-toolkit#298 (validation system)

## Testing
Code compiles but is commented out pending proto generation. Will be tested once protos are updated.