### PR TITLE
Fix TargetAC bug in attack results (#239)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20250918085706-a89bb4ca971d
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.20.2
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.20.4
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.1.1
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.20.2 h1:Jx+9vEiQqPRlVUforyv+vK4xrr48I1uK8hNM2aZxYxQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.20.2/go.mod h1:CvG7oLXInlmeRaUc+hvWW8zPCmsLneOFcrtlSJCQoJk=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.20.4 h1:q2wK8ErTrk4FmXvCQb5Dj/FOHZ4xQZHXFPwiJuEHnqM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.20.4/go.mod h1:CvG7oLXInlmeRaUc+hvWW8zPCmsLneOFcrtlSJCQoJk=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.1.1 h1:CWKr7NurYH0JtREkN5NO+9s4Q0VQv/uXUA8L/2JKJkI=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.1.1/go.mod h1:6DSb4xhITAy0wstKWoS3BeEYywWLt+138bxRCfH0kzY=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/internal/handlers/dnd5e/v1alpha1/encounter/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/converters.go
@@ -17,7 +17,7 @@ func convertAttackResultToProto(result *encounter.AttackResult) *dnd5ev1alpha1.A
 		Hit:         result.Hit,
 		AttackRoll:  int32(result.AttackRoll),
 		AttackTotal: int32(result.TotalAttack),
-		TargetAc:    int32(result.AttackBonus), // TODO: Fix when orchestrator exposes TargetAC
+		TargetAc:    int32(result.TargetAC),
 		Damage:      int32(result.TotalDamage),
 		DamageType:  result.DamageType,
 		Critical:    result.Critical,

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -141,6 +141,7 @@ func (o *Orchestrator) ResolveAttack(ctx context.Context, input *ResolveAttackIn
 			AttackRoll:      result.AttackRoll,
 			AttackBonus:     result.AttackBonus,
 			TotalAttack:     result.TotalAttack,
+			TargetAC:        result.TargetAC,
 			Hit:             result.Hit,
 			Critical:        result.Critical,
 			IsNaturalTwenty: result.IsNaturalTwenty,

--- a/internal/orchestrators/encounter/service.go
+++ b/internal/orchestrators/encounter/service.go
@@ -39,6 +39,7 @@ type AttackResult struct {
 	AttackRoll      int  // The d20 roll
 	AttackBonus     int  // Total bonus applied
 	TotalAttack     int  // Roll + bonus
+	TargetAC        int  // Target's armor class
 	Hit             bool // Did the attack hit?
 	Critical        bool // Was it a critical hit?
 	IsNaturalTwenty bool // Natural 20


### PR DESCRIPTION
## Problem
TargetAC field in AttackResult proto was incorrectly mapped to AttackBonus, showing the wrong value in attack responses.

## Solution
- Added TargetAC field to orchestrator's AttackResult struct
- Updated orchestrator to populate TargetAC from toolkit result
- Fixed converter to map correct field (TargetAC instead of AttackBonus)
- Updated rpg-toolkit dependency to v0.20.4 (includes TargetAC field)

## Testing
- All orchestrator tests pass
- Converter now maps the correct field
- TargetAC will now show defender's AC value instead of attack bonus

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)