### PR TITLE
Rename errors

### DIFF
--- a/docs/adr/008-room-generation-phase-3.md
+++ b/docs/adr/008-room-generation-phase-3.md
@@ -778,7 +778,7 @@ func filterDynamicEntities(entities []*entities.Entity) []DynamicEntity {
 **Error Handling Pattern**:
 ```go
 import (
-    "github.com/KirkDiggler/rpg-api/internal/apierrors"
+    "github.com/KirkDiggler/rpg-api/internal/apierr"
     "github.com/KirkDiggler/rpg-api/internal/idgen"
 )
 

--- a/internal/apierr/codes.go
+++ b/internal/apierr/codes.go
@@ -1,5 +1,5 @@
 //nolint:revive // package name intentionally shadows stdlib errors for API consistency
-package apierrors
+package apierr
 
 import "net/http"
 

--- a/internal/apierr/doc.go
+++ b/internal/apierr/doc.go
@@ -115,4 +115,4 @@
 //   - DataLoss: Unrecoverable data loss
 //   - Canceled: Operation canceled
 //   - DeadlineExceeded: Operation timeout
-package apierrors
+package apierr

--- a/internal/apierr/errors.go
+++ b/internal/apierr/errors.go
@@ -1,5 +1,5 @@
 //nolint:revive // package name intentionally shadows stdlib errors for API consistency
-package apierrors
+package apierr
 
 import (
 	"errors"

--- a/internal/apierr/errors_test.go
+++ b/internal/apierr/errors_test.go
@@ -1,4 +1,4 @@
-package apierrors_test
+package apierr_test
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 )
 
 type ErrorsTestSuite struct {
@@ -22,19 +22,19 @@ func TestErrorsSuite(t *testing.T) {
 func (s *ErrorsTestSuite) TestNewError() {
 	testCases := []struct {
 		name     string
-		code     apierrors.Code
+		code     apierr.Code
 		message  string
 		expected string
 	}{
 		{
 			name:     "not found error",
-			code:     apierrors.CodeNotFound,
+			code:     apierr.CodeNotFound,
 			message:  "character not found",
 			expected: "NOT_FOUND: character not found",
 		},
 		{
 			name:     "invalid argument error",
-			code:     apierrors.CodeInvalidArgument,
+			code:     apierr.CodeInvalidArgument,
 			message:  "invalid input",
 			expected: "INVALID_ARGUMENT: invalid input",
 		},
@@ -42,7 +42,7 @@ func (s *ErrorsTestSuite) TestNewError() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			err := apierrors.New(tc.code, tc.message)
+			err := apierr.New(tc.code, tc.message)
 			s.Assert().Equal(tc.expected, err.Error())
 			s.Assert().Equal(tc.code, err.Code)
 			s.Assert().Equal(tc.message, err.Message)
@@ -51,7 +51,7 @@ func (s *ErrorsTestSuite) TestNewError() {
 }
 
 func (s *ErrorsTestSuite) TestErrorWithMeta() {
-	err := apierrors.NotFound("character not found").
+	err := apierr.NotFound("character not found").
 		WithMeta("character_id", "123").
 		WithMeta("user_id", "456")
 
@@ -59,7 +59,7 @@ func (s *ErrorsTestSuite) TestErrorWithMeta() {
 	s.Assert().Equal("456", err.Meta["user_id"])
 
 	// Test WithMetaMap
-	err2 := apierrors.Internal("server error").
+	err2 := apierr.Internal("server error").
 		WithMetaMap(map[string]interface{}{
 			"request_id": "abc",
 			"trace_id":   "xyz",
@@ -71,29 +71,29 @@ func (s *ErrorsTestSuite) TestErrorWithMeta() {
 
 func (s *ErrorsTestSuite) TestWrap() {
 	baseErr := fmt.Errorf("database connection failed")
-	wrapped := apierrors.Wrap(baseErr, "failed to get character")
+	wrapped := apierr.Wrap(baseErr, "failed to get character")
 
-	s.Assert().Equal(apierrors.CodeInternal, wrapped.Code)
+	s.Assert().Equal(apierr.CodeInternal, wrapped.Code)
 	s.Assert().Equal("failed to get character", wrapped.Message)
 	s.Assert().Equal(baseErr, wrapped.Unwrap())
 }
 
 func (s *ErrorsTestSuite) TestWrapPreservesCode() {
-	baseErr := apierrors.NotFound("record not found")
-	wrapped := apierrors.Wrap(baseErr, "character not found")
+	baseErr := apierr.NotFound("record not found")
+	wrapped := apierr.Wrap(baseErr, "character not found")
 
-	s.Assert().Equal(apierrors.CodeNotFound, wrapped.Code)
+	s.Assert().Equal(apierr.CodeNotFound, wrapped.Code)
 	s.Assert().Equal("character not found", wrapped.Message)
 	s.Assert().Equal(baseErr, wrapped.Unwrap())
 }
 
 func (s *ErrorsTestSuite) TestWrapDoesNotShareMetadata() {
 	// Create base error with metadata
-	baseErr := apierrors.NotFound("record not found").
+	baseErr := apierr.NotFound("record not found").
 		WithMeta("original", "value")
 
 	// Wrap the error
-	wrapped := apierrors.Wrap(baseErr, "wrapped error")
+	wrapped := apierr.Wrap(baseErr, "wrapped error")
 
 	// Modify the wrapped error's metadata
 	err1 := wrapped.WithMeta("wrapped", "data")
@@ -112,40 +112,40 @@ func (s *ErrorsTestSuite) TestWrapDoesNotShareMetadata() {
 
 func (s *ErrorsTestSuite) TestWrapWithCode() {
 	baseErr := fmt.Errorf("connection timeout")
-	wrapped := apierrors.WrapWithCode(baseErr, apierrors.CodeUnavailable, "service unavailable")
+	wrapped := apierr.WrapWithCode(baseErr, apierr.CodeUnavailable, "service unavailable")
 
-	s.Assert().Equal(apierrors.CodeUnavailable, wrapped.Code)
+	s.Assert().Equal(apierr.CodeUnavailable, wrapped.Code)
 	s.Assert().Equal("service unavailable", wrapped.Message)
 	s.Assert().Equal(baseErr, wrapped.Unwrap())
 }
 
 func (s *ErrorsTestSuite) TestWrapNil() {
-	s.Assert().Nil(apierrors.Wrap(nil, "should be nil"))
-	s.Assert().Nil(apierrors.WrapWithCode(nil, apierrors.CodeNotFound, "should be nil"))
-	s.Assert().Nil(apierrors.Wrapf(nil, "should be nil: %s", "test"))
-	s.Assert().Nil(apierrors.WrapWithCodef(nil, apierrors.CodeNotFound, "should be nil: %s", "test"))
+	s.Assert().Nil(apierr.Wrap(nil, "should be nil"))
+	s.Assert().Nil(apierr.WrapWithCode(nil, apierr.CodeNotFound, "should be nil"))
+	s.Assert().Nil(apierr.Wrapf(nil, "should be nil: %s", "test"))
+	s.Assert().Nil(apierr.WrapWithCodef(nil, apierr.CodeNotFound, "should be nil: %s", "test"))
 }
 
 func (s *ErrorsTestSuite) TestWrapfFormatting() {
 	baseErr := fmt.Errorf("base error")
-	wrapped := apierrors.Wrapf(baseErr, "failed to process %s with id %d", "character", 123)
+	wrapped := apierr.Wrapf(baseErr, "failed to process %s with id %d", "character", 123)
 
-	s.Assert().Equal(apierrors.CodeInternal, wrapped.Code)
+	s.Assert().Equal(apierr.CodeInternal, wrapped.Code)
 	s.Assert().Equal("failed to process character with id 123", wrapped.Message)
 	s.Assert().Equal(baseErr, wrapped.Unwrap())
 }
 
 func (s *ErrorsTestSuite) TestWrapWithCodefFormatting() {
 	baseErr := fmt.Errorf("timeout")
-	wrapped := apierrors.WrapWithCodef(
+	wrapped := apierr.WrapWithCodef(
 		baseErr,
-		apierrors.CodeDeadlineExceeded,
+		apierr.CodeDeadlineExceeded,
 		"operation %s timed out after %d seconds",
 		"save",
 		30,
 	)
 
-	s.Assert().Equal(apierrors.CodeDeadlineExceeded, wrapped.Code)
+	s.Assert().Equal(apierr.CodeDeadlineExceeded, wrapped.Code)
 	s.Assert().Equal("operation save timed out after 30 seconds", wrapped.Message)
 	s.Assert().Equal(baseErr, wrapped.Unwrap())
 }
@@ -153,16 +153,16 @@ func (s *ErrorsTestSuite) TestWrapWithCodefFormatting() {
 func (s *ErrorsTestSuite) TestConstructorFunctions() {
 	testCases := []struct {
 		name        string
-		constructor func() *apierrors.Error
-		code        apierrors.Code
+		constructor func() *apierr.Error
+		code        apierr.Code
 	}{
-		{"NotFound", func() *apierrors.Error { return apierrors.NotFound("test") }, apierrors.CodeNotFound},
-		{"InvalidArgument", func() *apierrors.Error { return apierrors.InvalidArgument("test") }, apierrors.CodeInvalidArgument},
-		{"AlreadyExists", func() *apierrors.Error { return apierrors.AlreadyExists("test") }, apierrors.CodeAlreadyExists},
-		{"PermissionDenied", func() *apierrors.Error { return apierrors.PermissionDenied("test") }, apierrors.CodePermissionDenied},
-		{"Internal", func() *apierrors.Error { return apierrors.Internal("test") }, apierrors.CodeInternal},
-		{"Unavailable", func() *apierrors.Error { return apierrors.Unavailable("test") }, apierrors.CodeUnavailable},
-		{"Unauthenticated", func() *apierrors.Error { return apierrors.Unauthenticated("test") }, apierrors.CodeUnauthenticated},
+		{"NotFound", func() *apierr.Error { return apierr.NotFound("test") }, apierr.CodeNotFound},
+		{"InvalidArgument", func() *apierr.Error { return apierr.InvalidArgument("test") }, apierr.CodeInvalidArgument},
+		{"AlreadyExists", func() *apierr.Error { return apierr.AlreadyExists("test") }, apierr.CodeAlreadyExists},
+		{"PermissionDenied", func() *apierr.Error { return apierr.PermissionDenied("test") }, apierr.CodePermissionDenied},
+		{"Internal", func() *apierr.Error { return apierr.Internal("test") }, apierr.CodeInternal},
+		{"Unavailable", func() *apierr.Error { return apierr.Unavailable("test") }, apierr.CodeUnavailable},
+		{"Unauthenticated", func() *apierr.Error { return apierr.Unauthenticated("test") }, apierr.CodeUnauthenticated},
 	}
 
 	for _, tc := range testCases {
@@ -175,79 +175,79 @@ func (s *ErrorsTestSuite) TestConstructorFunctions() {
 }
 
 func (s *ErrorsTestSuite) TestFormattedConstructors() {
-	err := apierrors.NotFoundf("character %s not found", "123")
-	s.Assert().Equal(apierrors.CodeNotFound, err.Code)
+	err := apierr.NotFoundf("character %s not found", "123")
+	s.Assert().Equal(apierr.CodeNotFound, err.Code)
 	s.Assert().Equal("character 123 not found", err.Message)
 
-	err2 := apierrors.InvalidArgumentf("invalid level: %d", 25)
-	s.Assert().Equal(apierrors.CodeInvalidArgument, err2.Code)
+	err2 := apierr.InvalidArgumentf("invalid level: %d", 25)
+	s.Assert().Equal(apierr.CodeInvalidArgument, err2.Code)
 	s.Assert().Equal("invalid level: 25", err2.Message)
 }
 
 func (s *ErrorsTestSuite) TestErrorIs() {
-	err1 := apierrors.NotFound("test")
-	err2 := apierrors.NotFound("test")
-	err3 := apierrors.InvalidArgument("test")
+	err1 := apierr.NotFound("test")
+	err2 := apierr.NotFound("test")
+	err3 := apierr.InvalidArgument("test")
 
 	s.Assert().True(err1.Is(err2))
 	s.Assert().False(err1.Is(err3))
 }
 
 func (s *ErrorsTestSuite) TestHelperFunctions() {
-	notFoundErr := apierrors.NotFound("test")
-	invalidErr := apierrors.InvalidArgument("test")
-	wrappedErr := apierrors.Wrap(notFoundErr, "wrapped")
+	notFoundErr := apierr.NotFound("test")
+	invalidErr := apierr.InvalidArgument("test")
+	wrappedErr := apierr.Wrap(notFoundErr, "wrapped")
 
-	s.Assert().True(apierrors.IsNotFound(notFoundErr))
-	s.Assert().True(apierrors.IsNotFound(wrappedErr))
-	s.Assert().False(apierrors.IsNotFound(invalidErr))
+	s.Assert().True(apierr.IsNotFound(notFoundErr))
+	s.Assert().True(apierr.IsNotFound(wrappedErr))
+	s.Assert().False(apierr.IsNotFound(invalidErr))
 
-	s.Assert().True(apierrors.IsInvalidArgument(invalidErr))
-	s.Assert().False(apierrors.IsInvalidArgument(notFoundErr))
+	s.Assert().True(apierr.IsInvalidArgument(invalidErr))
+	s.Assert().False(apierr.IsInvalidArgument(notFoundErr))
 }
 
 func (s *ErrorsTestSuite) TestGetCode() {
-	err := apierrors.NotFound("test")
-	wrapped := apierrors.Wrap(err, "wrapped")
+	err := apierr.NotFound("test")
+	wrapped := apierr.Wrap(err, "wrapped")
 
-	s.Assert().Equal(apierrors.CodeNotFound, apierrors.GetCode(err))
-	s.Assert().Equal(apierrors.CodeNotFound, apierrors.GetCode(wrapped))
-	s.Assert().Equal(apierrors.CodeInternal, apierrors.GetCode(fmt.Errorf("standard error")))
-	s.Assert().Equal(apierrors.CodeOK, apierrors.GetCode(nil))
+	s.Assert().Equal(apierr.CodeNotFound, apierr.GetCode(err))
+	s.Assert().Equal(apierr.CodeNotFound, apierr.GetCode(wrapped))
+	s.Assert().Equal(apierr.CodeInternal, apierr.GetCode(fmt.Errorf("standard error")))
+	s.Assert().Equal(apierr.CodeOK, apierr.GetCode(nil))
 }
 
 func (s *ErrorsTestSuite) TestGetMeta() {
-	err := apierrors.NotFound("test").WithMeta("key", "value")
-	wrapped := apierrors.Wrap(err, "wrapped")
+	err := apierr.NotFound("test").WithMeta("key", "value")
+	wrapped := apierr.Wrap(err, "wrapped")
 
-	s.Assert().Equal("value", apierrors.GetMeta(err)["key"])
-	s.Assert().Equal("value", apierrors.GetMeta(wrapped)["key"])
-	s.Assert().Nil(apierrors.GetMeta(fmt.Errorf("standard error")))
+	s.Assert().Equal("value", apierr.GetMeta(err)["key"])
+	s.Assert().Equal("value", apierr.GetMeta(wrapped)["key"])
+	s.Assert().Nil(apierr.GetMeta(fmt.Errorf("standard error")))
 }
 
 func (s *ErrorsTestSuite) TestGetMessage() {
-	err := apierrors.NotFound("user friendly message")
-	wrapped := apierrors.Wrap(err, "wrapped message")
+	err := apierr.NotFound("user friendly message")
+	wrapped := apierr.Wrap(err, "wrapped message")
 	stdErr := fmt.Errorf("standard error")
 
-	s.Assert().Equal("user friendly message", apierrors.GetMessage(err))
-	s.Assert().Equal("wrapped message", apierrors.GetMessage(wrapped))
-	s.Assert().Equal("standard error", apierrors.GetMessage(stdErr))
+	s.Assert().Equal("user friendly message", apierr.GetMessage(err))
+	s.Assert().Equal("wrapped message", apierr.GetMessage(wrapped))
+	s.Assert().Equal("standard error", apierr.GetMessage(stdErr))
 }
 
 func (s *ErrorsTestSuite) TestHTTPStatus() {
 	testCases := []struct {
-		code     apierrors.Code
+		code     apierr.Code
 		expected int
 	}{
-		{apierrors.CodeOK, 200},
-		{apierrors.CodeNotFound, 404},
-		{apierrors.CodeInvalidArgument, 400},
-		{apierrors.CodeAlreadyExists, 409},
-		{apierrors.CodePermissionDenied, 403},
-		{apierrors.CodeUnauthenticated, 401},
-		{apierrors.CodeInternal, 500},
-		{apierrors.CodeUnavailable, 503},
+		{apierr.CodeOK, 200},
+		{apierr.CodeNotFound, 404},
+		{apierr.CodeInvalidArgument, 400},
+		{apierr.CodeAlreadyExists, 409},
+		{apierr.CodePermissionDenied, 403},
+		{apierr.CodeUnauthenticated, 401},
+		{apierr.CodeInternal, 500},
+		{apierr.CodeUnavailable, 503},
 	}
 
 	for _, tc := range testCases {
@@ -259,10 +259,10 @@ func (s *ErrorsTestSuite) TestHTTPStatus() {
 
 func (s *ErrorsTestSuite) TestGRPCConversion() {
 	// Test ToGRPCError
-	err := apierrors.NotFound("character not found").
+	err := apierr.NotFound("character not found").
 		WithMeta("character_id", "123")
 
-	grpcErr := apierrors.ToGRPCError(err)
+	grpcErr := apierr.ToGRPCError(err)
 	st, ok := status.FromError(grpcErr)
 	s.Require().True(ok)
 	s.Assert().Equal(codes.NotFound, st.Code())
@@ -270,23 +270,23 @@ func (s *ErrorsTestSuite) TestGRPCConversion() {
 
 	// Test FromGRPCError
 	grpcErr2 := status.Error(codes.InvalidArgument, "invalid input")
-	err2 := apierrors.FromGRPCError(grpcErr2)
-	s.Assert().Equal(apierrors.CodeInvalidArgument, apierrors.GetCode(err2))
-	s.Assert().Equal("invalid input", apierrors.GetMessage(err2))
+	err2 := apierr.FromGRPCError(grpcErr2)
+	s.Assert().Equal(apierr.CodeInvalidArgument, apierr.GetCode(err2))
+	s.Assert().Equal("invalid input", apierr.GetMessage(err2))
 }
 
 func (s *ErrorsTestSuite) TestGRPCCodeMapping() {
 	testCases := []struct {
-		code     apierrors.Code
+		code     apierr.Code
 		expected codes.Code
 	}{
-		{apierrors.CodeNotFound, codes.NotFound},
-		{apierrors.CodeInvalidArgument, codes.InvalidArgument},
-		{apierrors.CodeAlreadyExists, codes.AlreadyExists},
-		{apierrors.CodePermissionDenied, codes.PermissionDenied},
-		{apierrors.CodeInternal, codes.Internal},
-		{apierrors.CodeUnavailable, codes.Unavailable},
-		{apierrors.CodeUnauthenticated, codes.Unauthenticated},
+		{apierr.CodeNotFound, codes.NotFound},
+		{apierr.CodeInvalidArgument, codes.InvalidArgument},
+		{apierr.CodeAlreadyExists, codes.AlreadyExists},
+		{apierr.CodePermissionDenied, codes.PermissionDenied},
+		{apierr.CodeInternal, codes.Internal},
+		{apierr.CodeUnavailable, codes.Unavailable},
+		{apierr.CodeUnauthenticated, codes.Unauthenticated},
 	}
 
 	for _, tc := range testCases {

--- a/internal/apierr/grpc.go
+++ b/internal/apierr/grpc.go
@@ -1,5 +1,5 @@
 //nolint:revive // package name intentionally shadows stdlib errors for API consistency
-package apierrors
+package apierr
 
 import (
 	"google.golang.org/grpc/codes"

--- a/internal/apierr/helpers.go
+++ b/internal/apierr/helpers.go
@@ -1,11 +1,11 @@
 //nolint:revive // package name intentionally shadows stdlib errors for API consistency
-package apierrors
+package apierr
 
 import (
 	"errors"
 )
 
-// As is a wrapper around apierrors.As that works with our Error type
+// As is a wrapper around apierr.As that works with our Error type
 func As(err error, target **Error) bool {
 	return errors.As(err, target)
 }

--- a/internal/apierr/validation.go
+++ b/internal/apierr/validation.go
@@ -1,5 +1,5 @@
 //nolint:revive // package name intentionally shadows stdlib errors for API consistency
-package apierrors
+package apierr
 
 import (
 	"fmt"

--- a/internal/apierr/validation_test.go
+++ b/internal/apierr/validation_test.go
@@ -1,11 +1,11 @@
-package apierrors_test
+package apierr_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 )
 
 type ValidationTestSuite struct {
@@ -17,7 +17,7 @@ func TestValidationSuite(t *testing.T) {
 }
 
 func (s *ValidationTestSuite) TestValidationError() {
-	ve := apierrors.NewValidationError()
+	ve := apierr.NewValidationError()
 	ve.AddFieldError("name", "is required")
 	ve.AddFieldError("email", "is invalid")
 	ve.AddFieldErrorf("age", "must be at least %d", 18)
@@ -28,12 +28,12 @@ func (s *ValidationTestSuite) TestValidationError() {
 	s.Assert().Contains(ve.Error(), "age: must be at least 18")
 
 	err := ve.ToError()
-	s.Assert().Equal(apierrors.CodeInvalidArgument, err.Code)
+	s.Assert().Equal(apierr.CodeInvalidArgument, err.Code)
 	s.Assert().NotNil(err.Meta["validation_errors"])
 }
 
 func (s *ValidationTestSuite) TestValidationBuilder() {
-	vb := apierrors.NewValidationBuilder()
+	vb := apierr.NewValidationBuilder()
 	vb.Field("name", "is required").
 		Fieldf("level", "must be between %d and %d", 1, 20).
 		RequiredField("class").
@@ -41,11 +41,11 @@ func (s *ValidationTestSuite) TestValidationBuilder() {
 
 	err := vb.Build()
 	s.Require().NotNil(err)
-	s.Assert().True(apierrors.IsInvalidArgument(err))
+	s.Assert().True(apierr.IsInvalidArgument(err))
 }
 
 func (s *ValidationTestSuite) TestValidationBuilderNoErrors() {
-	vb := apierrors.NewValidationBuilder()
+	vb := apierr.NewValidationBuilder()
 	err := vb.Build()
 	s.Assert().Nil(err)
 }
@@ -64,8 +64,8 @@ func (s *ValidationTestSuite) TestValidateRequired() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			vb := apierrors.NewValidationBuilder()
-			apierrors.ValidateRequired("field", tc.value, vb)
+			vb := apierr.NewValidationBuilder()
+			apierr.ValidateRequired("field", tc.value, vb)
 			err := vb.Build()
 			if tc.shouldErr {
 				s.Assert().NotNil(err)
@@ -77,40 +77,40 @@ func (s *ValidationTestSuite) TestValidateRequired() {
 }
 
 func (s *ValidationTestSuite) TestValidateMinLength() {
-	vb := apierrors.NewValidationBuilder()
-	apierrors.ValidateMinLength("password", "short", 8, vb)
-	apierrors.ValidateMinLength("username", "validuser", 3, vb)
+	vb := apierr.NewValidationBuilder()
+	apierr.ValidateMinLength("password", "short", 8, vb)
+	apierr.ValidateMinLength("username", "validuser", 3, vb)
 
 	err := vb.Build()
 	s.Require().NotNil(err)
-	meta := apierrors.GetMeta(err)
+	meta := apierr.GetMeta(err)
 	validationErrors := meta["validation_errors"].(map[string][]string)
 	s.Assert().Contains(validationErrors["password"][0], "must be at least 8 characters")
 	s.Assert().NotContains(validationErrors, "username")
 }
 
 func (s *ValidationTestSuite) TestValidateMaxLength() {
-	vb := apierrors.NewValidationBuilder()
-	apierrors.ValidateMaxLength("name", "this is a very long character name", 20, vb)
-	apierrors.ValidateMaxLength("code", "ABC", 5, vb)
+	vb := apierr.NewValidationBuilder()
+	apierr.ValidateMaxLength("name", "this is a very long character name", 20, vb)
+	apierr.ValidateMaxLength("code", "ABC", 5, vb)
 
 	err := vb.Build()
 	s.Require().NotNil(err)
-	meta := apierrors.GetMeta(err)
+	meta := apierr.GetMeta(err)
 	validationErrors := meta["validation_errors"].(map[string][]string)
 	s.Assert().Contains(validationErrors["name"][0], "must be no more than 20 characters")
 	s.Assert().NotContains(validationErrors, "code")
 }
 
 func (s *ValidationTestSuite) TestValidateRange() {
-	vb := apierrors.NewValidationBuilder()
-	apierrors.ValidateRange("level", 25, 1, 20, vb)
-	apierrors.ValidateRange("ability", 15, 3, 18, vb)
-	apierrors.ValidateRange("hp", 0, 1, 100, vb)
+	vb := apierr.NewValidationBuilder()
+	apierr.ValidateRange("level", 25, 1, 20, vb)
+	apierr.ValidateRange("ability", 15, 3, 18, vb)
+	apierr.ValidateRange("hp", 0, 1, 100, vb)
 
 	err := vb.Build()
 	s.Require().NotNil(err)
-	meta := apierrors.GetMeta(err)
+	meta := apierr.GetMeta(err)
 	validationErrors := meta["validation_errors"].(map[string][]string)
 	s.Assert().Contains(validationErrors["level"][0], "must be between 1 and 20")
 	s.Assert().Contains(validationErrors["hp"][0], "must be between 1 and 100")
@@ -120,13 +120,13 @@ func (s *ValidationTestSuite) TestValidateRange() {
 func (s *ValidationTestSuite) TestValidateEnum() {
 	allowedClasses := []string{"fighter", "wizard", "rogue", "cleric"}
 
-	vb := apierrors.NewValidationBuilder()
-	apierrors.ValidateEnum("class", "bard", allowedClasses, vb)
-	apierrors.ValidateEnum("primary_class", "fighter", allowedClasses, vb)
+	vb := apierr.NewValidationBuilder()
+	apierr.ValidateEnum("class", "bard", allowedClasses, vb)
+	apierr.ValidateEnum("primary_class", "fighter", allowedClasses, vb)
 
 	err := vb.Build()
 	s.Require().NotNil(err)
-	meta := apierrors.GetMeta(err)
+	meta := apierr.GetMeta(err)
 	validationErrors := meta["validation_errors"].(map[string][]string)
 	s.Assert().Contains(validationErrors["class"][0], "must be one of: fighter, wizard, rogue, cleric")
 	s.Assert().NotContains(validationErrors, "primary_class")
@@ -152,28 +152,28 @@ func (s *ValidationTestSuite) TestComplexValidation() {
 		},
 	}
 
-	vb := apierrors.NewValidationBuilder()
+	vb := apierr.NewValidationBuilder()
 
 	// Validate name
-	apierrors.ValidateRequired("name", input.Name, vb)
+	apierr.ValidateRequired("name", input.Name, vb)
 
 	// Validate class
 	allowedClasses := []string{"fighter", "wizard", "rogue", "cleric"}
-	apierrors.ValidateEnum("class", input.Class, allowedClasses, vb)
+	apierr.ValidateEnum("class", input.Class, allowedClasses, vb)
 
 	// Validate level
-	apierrors.ValidateRange("level", input.Level, 1, 20, vb)
+	apierr.ValidateRange("level", input.Level, 1, 20, vb)
 
 	// Validate abilities
 	for ability, score := range input.Abilities {
-		apierrors.ValidateRange(ability, score, 3, 18, vb)
+		apierr.ValidateRange(ability, score, 3, 18, vb)
 	}
 
 	err := vb.Build()
 	s.Require().NotNil(err)
-	s.Assert().True(apierrors.IsInvalidArgument(err))
+	s.Assert().True(apierr.IsInvalidArgument(err))
 
-	meta := apierrors.GetMeta(err)
+	meta := apierr.GetMeta(err)
 	validationErrors := meta["validation_errors"].(map[string][]string)
 	s.Assert().Contains(validationErrors, "name")
 	s.Assert().Contains(validationErrors, "class")

--- a/internal/handlers/api/v1alpha1/dice_handler.go
+++ b/internal/handlers/api/v1alpha1/dice_handler.go
@@ -4,7 +4,7 @@ package v1alpha1
 import (
 	"context"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 
 	apiv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/api/v1alpha1"
@@ -18,7 +18,7 @@ type DiceHandlerConfig struct {
 // Validate ensures all required dependencies are present
 func (c *DiceHandlerConfig) Validate() error {
 	if c.DiceService == nil {
-		return apierrors.InvalidArgument("dice service is required")
+		return apierr.InvalidArgument("dice service is required")
 	}
 	return nil
 }
@@ -46,13 +46,13 @@ func (h *DiceHandler) RollDice(
 	req *apiv1alpha1.RollDiceRequest,
 ) (*apiv1alpha1.RollDiceResponse, error) {
 	if req.EntityId == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("entity_id is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("entity_id is required"))
 	}
 	if req.Context == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("context is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("context is required"))
 	}
 	if req.Notation == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("notation is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("notation is required"))
 	}
 
 	// Use the dice service to roll dice
@@ -65,7 +65,7 @@ func (h *DiceHandler) RollDice(
 
 	diceOutput, err := h.diceService.RollDice(ctx, diceInput)
 	if err != nil {
-		return nil, apierrors.ToGRPCError(err)
+		return nil, apierr.ToGRPCError(err)
 	}
 
 	// Convert all session rolls to proto format
@@ -103,10 +103,10 @@ func (h *DiceHandler) GetRollSession(
 	req *apiv1alpha1.GetRollSessionRequest,
 ) (*apiv1alpha1.GetRollSessionResponse, error) {
 	if req.EntityId == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("entity_id is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("entity_id is required"))
 	}
 	if req.Context == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("context is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("context is required"))
 	}
 
 	// Use the dice service to get the session
@@ -117,7 +117,7 @@ func (h *DiceHandler) GetRollSession(
 
 	diceOutput, err := h.diceService.GetRollSession(ctx, diceInput)
 	if err != nil {
-		return nil, apierrors.ToGRPCError(err)
+		return nil, apierr.ToGRPCError(err)
 	}
 
 	// Convert session rolls to proto format
@@ -148,10 +148,10 @@ func (h *DiceHandler) ClearRollSession(
 	req *apiv1alpha1.ClearRollSessionRequest,
 ) (*apiv1alpha1.ClearRollSessionResponse, error) {
 	if req.EntityId == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("entity_id is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("entity_id is required"))
 	}
 	if req.Context == "" {
-		return nil, apierrors.ToGRPCError(apierrors.InvalidArgument("context is required"))
+		return nil, apierr.ToGRPCError(apierr.InvalidArgument("context is required"))
 	}
 
 	// Use the dice service to clear the session
@@ -162,7 +162,7 @@ func (h *DiceHandler) ClearRollSession(
 
 	diceOutput, err := h.diceService.ClearRollSession(ctx, diceInput)
 	if err != nil {
-		return nil, apierrors.ToGRPCError(err)
+		return nil, apierr.ToGRPCError(err)
 	}
 
 	return &apiv1alpha1.ClearRollSessionResponse{

--- a/internal/handlers/api/v1alpha1/dice_handler_test.go
+++ b/internal/handlers/api/v1alpha1/dice_handler_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	apiv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/api/v1alpha1"
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/handlers/api/v1alpha1"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 	dicemock "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice/mock"
@@ -216,7 +216,7 @@ func (s *DiceHandlerTestSuite) TestGetRollSession_NotFound() {
 
 	s.mockDice.EXPECT().
 		GetRollSession(ctx, gomock.Any()).
-		Return(nil, apierrors.NotFound("session not found"))
+		Return(nil, apierr.NotFound("session not found"))
 
 	req := &apiv1alpha1.GetRollSessionRequest{
 		EntityId: entityID,

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/ammunition"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
@@ -1296,9 +1296,9 @@ func convertEquipmentSlotToToolkit(slot dnd5ev1alpha1.EquipmentSlot) (toolkitcha
 	case dnd5ev1alpha1.EquipmentSlot_EQUIPMENT_SLOT_BELT:
 		return toolkitchar.SlotBelt, nil
 	case dnd5ev1alpha1.EquipmentSlot_EQUIPMENT_SLOT_GLOVES:
-		return "", apierrors.InvalidArgument("EQUIPMENT_SLOT_GLOVES is deprecated and not supported")
+		return "", apierr.InvalidArgument("EQUIPMENT_SLOT_GLOVES is deprecated and not supported")
 	default:
-		return "", apierrors.InvalidArgument("unsupported equipment slot")
+		return "", apierr.InvalidArgument("unsupported equipment slot")
 	}
 }
 

--- a/internal/handlers/dnd5e/v1alpha1/character/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/handler.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
@@ -26,7 +26,7 @@ type HandlerConfig struct {
 // Validate ensures all required dependencies are present
 func (c *HandlerConfig) Validate() error {
 	if c.CharacterService == nil {
-		return apierrors.InvalidArgument("character service is required")
+		return apierr.InvalidArgument("character service is required")
 	}
 	return nil
 }
@@ -85,10 +85,10 @@ func (h *Handler) GetDraft(
 	req *dnd5ev1alpha1.GetDraftRequest,
 ) (*dnd5ev1alpha1.GetDraftResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 	if req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft_id is required")
+		return nil, apierr.InvalidArgument("draft_id is required")
 	}
 
 	// Call orchestrator
@@ -96,7 +96,7 @@ func (h *Handler) GetDraft(
 		DraftID: req.DraftId,
 	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierr.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, "draft not found")
 		}
 		return nil, status.Error(codes.Internal, err.Error())
@@ -162,7 +162,7 @@ func (h *Handler) DeleteDraft(
 	_ context.Context,
 	_ *dnd5ev1alpha1.DeleteDraftRequest,
 ) (*dnd5ev1alpha1.DeleteDraftResponse, error) {
-	return nil, apierrors.Unimplemented("DeleteDraft not implemented")
+	return nil, apierr.Unimplemented("DeleteDraft not implemented")
 }
 
 // UpdateName updates the name of a character draft
@@ -171,13 +171,13 @@ func (h *Handler) UpdateName(
 	req *dnd5ev1alpha1.UpdateNameRequest,
 ) (*dnd5ev1alpha1.UpdateNameResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 	if req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft_id is required")
+		return nil, apierr.InvalidArgument("draft_id is required")
 	}
 	if req.Name == "" {
-		return nil, apierrors.InvalidArgument("name is required")
+		return nil, apierr.InvalidArgument("name is required")
 	}
 
 	// Call orchestrator
@@ -201,10 +201,10 @@ func (h *Handler) UpdateRace(
 	req *dnd5ev1alpha1.UpdateRaceRequest,
 ) (*dnd5ev1alpha1.UpdateRaceResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 	if req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft_id is required")
+		return nil, apierr.InvalidArgument("draft_id is required")
 	}
 
 	// Convert proto choices to toolkit format
@@ -261,10 +261,10 @@ func (h *Handler) UpdateClass(
 	req *dnd5ev1alpha1.UpdateClassRequest,
 ) (*dnd5ev1alpha1.UpdateClassResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 	if req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft_id is required")
+		return nil, apierr.InvalidArgument("draft_id is required")
 	}
 
 	// Convert proto choices to toolkit format
@@ -355,10 +355,10 @@ func (h *Handler) UpdateBackground(
 	req *dnd5ev1alpha1.UpdateBackgroundRequest,
 ) (*dnd5ev1alpha1.UpdateBackgroundResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 	if req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft_id is required")
+		return nil, apierr.InvalidArgument("draft_id is required")
 	}
 
 	// Convert proto choices to toolkit format
@@ -399,10 +399,10 @@ func (h *Handler) UpdateAbilityScores(
 	req *dnd5ev1alpha1.UpdateAbilityScoresRequest,
 ) (*dnd5ev1alpha1.UpdateAbilityScoresResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 	if req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft_id is required")
+		return nil, apierr.InvalidArgument("draft_id is required")
 	}
 	// Handle the oneof scores_input field
 	var scores shared.AbilityScores
@@ -411,13 +411,13 @@ func (h *Handler) UpdateAbilityScores(
 	switch scoresInput := req.GetScoresInput().(type) {
 	case *dnd5ev1alpha1.UpdateAbilityScoresRequest_AbilityScores:
 		if scoresInput.AbilityScores == nil {
-			return nil, apierrors.InvalidArgument("ability_scores is required")
+			return nil, apierr.InvalidArgument("ability_scores is required")
 		}
 		scores = convertProtoAbilityScoresToToolkit(scoresInput.AbilityScores)
 		method = "manual"
 	case *dnd5ev1alpha1.UpdateAbilityScoresRequest_RollAssignments:
 		if scoresInput.RollAssignments == nil {
-			return nil, apierrors.InvalidArgument("roll_assignments is required")
+			return nil, apierr.InvalidArgument("roll_assignments is required")
 		}
 		// Convert roll assignments to a map for the orchestrator
 		rollAssignments := convertRollAssignmentsToMap(scoresInput.RollAssignments)
@@ -436,7 +436,7 @@ func (h *Handler) UpdateAbilityScores(
 			Draft: convertDraftDataToProto(result.Draft),
 		}, nil
 	default:
-		return nil, apierrors.InvalidArgument("scores_input is required")
+		return nil, apierr.InvalidArgument("scores_input is required")
 	}
 
 	// Call orchestrator
@@ -462,7 +462,7 @@ func (h *Handler) UpdateSkills(
 	_ context.Context,
 	_ *dnd5ev1alpha1.UpdateSkillsRequest,
 ) (*dnd5ev1alpha1.UpdateSkillsResponse, error) {
-	return nil, apierrors.Unimplemented("UpdateSkills not implemented")
+	return nil, apierr.Unimplemented("UpdateSkills not implemented")
 }
 
 // ValidateDraft validates a character draft
@@ -470,7 +470,7 @@ func (h *Handler) ValidateDraft(
 	_ context.Context,
 	_ *dnd5ev1alpha1.ValidateDraftRequest,
 ) (*dnd5ev1alpha1.ValidateDraftResponse, error) {
-	return nil, apierrors.Unimplemented("ValidateDraft not implemented")
+	return nil, apierr.Unimplemented("ValidateDraft not implemented")
 }
 
 // GetDraftPreview gets a preview of what the character would look like if finalized
@@ -478,7 +478,7 @@ func (h *Handler) GetDraftPreview(
 	_ context.Context,
 	_ *dnd5ev1alpha1.GetDraftPreviewRequest,
 ) (*dnd5ev1alpha1.GetDraftPreviewResponse, error) {
-	return nil, apierrors.Unimplemented("GetDraftPreview not implemented")
+	return nil, apierr.Unimplemented("GetDraftPreview not implemented")
 }
 
 // FinalizeDraft finalizes a character draft
@@ -487,7 +487,7 @@ func (h *Handler) FinalizeDraft(
 	req *dnd5ev1alpha1.FinalizeDraftRequest,
 ) (*dnd5ev1alpha1.FinalizeDraftResponse, error) {
 	if req == nil || req.DraftId == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 
 	// Call orchestrator to finalize the draft
@@ -501,7 +501,7 @@ func (h *Handler) FinalizeDraft(
 	// Convert toolkit character to proto
 	protoChar := convertCharacterToProto(output.Character)
 	if protoChar == nil {
-		return nil, apierrors.Internal("failed to convert character to proto")
+		return nil, apierr.Internal("failed to convert character to proto")
 	}
 
 	return &dnd5ev1alpha1.FinalizeDraftResponse{
@@ -516,7 +516,7 @@ func (h *Handler) GetCharacter(
 ) (*dnd5ev1alpha1.GetCharacterResponse, error) {
 	// Validate request
 	if req.CharacterId == "" {
-		return nil, apierrors.InvalidArgument("character_id is required")
+		return nil, apierr.InvalidArgument("character_id is required")
 	}
 
 	// Get character from orchestrator
@@ -593,10 +593,10 @@ func (h *Handler) DeleteCharacter(
 	})
 	if err != nil {
 		// Convert orchestrator errors to gRPC status
-		if apierrors.IsNotFound(err) {
+		if apierr.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, "character not found")
 		}
-		if apierrors.IsInvalidArgument(err) {
+		if apierr.IsInvalidArgument(err) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, status.Error(codes.Internal, "failed to delete character")
@@ -711,7 +711,7 @@ func (h *Handler) RollAbilityScores(
 	_ context.Context,
 	_ *dnd5ev1alpha1.RollAbilityScoresRequest,
 ) (*dnd5ev1alpha1.RollAbilityScoresResponse, error) {
-	return nil, apierrors.Unimplemented("RollAbilityScores not implemented")
+	return nil, apierr.Unimplemented("RollAbilityScores not implemented")
 }
 
 // ListEquipmentByType lists equipment by type
@@ -786,7 +786,7 @@ func (h *Handler) ListSpellsByLevel(
 	req *dnd5ev1alpha1.ListSpellsByLevelRequest,
 ) (*dnd5ev1alpha1.ListSpellsByLevelResponse, error) {
 	if req == nil {
-		return nil, apierrors.InvalidArgument("request is required")
+		return nil, apierr.InvalidArgument("request is required")
 	}
 
 	// Call the orchestrator
@@ -796,7 +796,7 @@ func (h *Handler) ListSpellsByLevel(
 		// TODO: Convert class filter when needed
 	})
 	if err != nil {
-		return nil, apierrors.ToGRPCError(err)
+		return nil, apierr.ToGRPCError(err)
 	}
 
 	// Convert to proto format
@@ -826,7 +826,7 @@ func (h *Handler) GetCharacterInventory(
 ) (*dnd5ev1alpha1.GetCharacterInventoryResponse, error) {
 	// Validate request
 	if req.CharacterId == "" {
-		return nil, apierrors.InvalidArgument("character_id is required")
+		return nil, apierr.InvalidArgument("character_id is required")
 	}
 
 	// Get character data - equipment slots are part of character data
@@ -860,13 +860,13 @@ func (h *Handler) EquipItem(
 ) (*dnd5ev1alpha1.EquipItemResponse, error) {
 	// Validate request
 	if req.CharacterId == "" {
-		return nil, apierrors.InvalidArgument("character_id is required")
+		return nil, apierr.InvalidArgument("character_id is required")
 	}
 	if req.ItemId == "" {
-		return nil, apierrors.InvalidArgument("item_id is required")
+		return nil, apierr.InvalidArgument("item_id is required")
 	}
 	if req.Slot == dnd5ev1alpha1.EquipmentSlot_EQUIPMENT_SLOT_UNSPECIFIED {
-		return nil, apierrors.InvalidArgument("slot is required")
+		return nil, apierr.InvalidArgument("slot is required")
 	}
 
 	// Convert slot enum to toolkit type
@@ -920,10 +920,10 @@ func (h *Handler) UnequipItem(
 ) (*dnd5ev1alpha1.UnequipItemResponse, error) {
 	// Validate request
 	if req.CharacterId == "" {
-		return nil, apierrors.InvalidArgument("character_id is required")
+		return nil, apierr.InvalidArgument("character_id is required")
 	}
 	if req.Slot == dnd5ev1alpha1.EquipmentSlot_EQUIPMENT_SLOT_UNSPECIFIED {
-		return nil, apierrors.InvalidArgument("slot is required")
+		return nil, apierr.InvalidArgument("slot is required")
 	}
 
 	// Convert slot enum to toolkit type

--- a/internal/handlers/dnd5e/v1alpha1/character/handler_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/handler_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/orchestrators/character/mock"
 )
@@ -109,7 +109,7 @@ func (s *HandlerTestSuite) TestDeleteCharacter_NotFound() {
 		DeleteCharacter(s.ctx, &character.DeleteCharacterInput{
 			CharacterID: characterID,
 		}).
-		Return(nil, apierrors.NotFound("character not found"))
+		Return(nil, apierr.NotFound("character not found"))
 
 	// Call the handler
 	resp, err := s.handler.DeleteCharacter(s.ctx, req)
@@ -135,7 +135,7 @@ func (s *HandlerTestSuite) TestDeleteCharacter_InvalidArgument() {
 		DeleteCharacter(s.ctx, &character.DeleteCharacterInput{
 			CharacterID: characterID,
 		}).
-		Return(nil, apierrors.InvalidArgument("invalid character ID format"))
+		Return(nil, apierr.InvalidArgument("invalid character ID format"))
 
 	// Call the handler
 	resp, err := s.handler.DeleteCharacter(s.ctx, req)
@@ -161,7 +161,7 @@ func (s *HandlerTestSuite) TestDeleteCharacter_InternalError() {
 		DeleteCharacter(s.ctx, &character.DeleteCharacterInput{
 			CharacterID: characterID,
 		}).
-		Return(nil, apierrors.Internal("database error"))
+		Return(nil, apierr.Internal("database error"))
 
 	// Call the handler
 	resp, err := s.handler.DeleteCharacter(s.ctx, req)

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
-	apierrors "github.com/KirkDiggler/rpg-api/internal/apierrors"
+	apierrors "github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
 	characterhandler "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v1alpha1/character"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"

--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
@@ -32,19 +32,19 @@ type Config struct {
 // Validate ensures all required dependencies are present
 func (c *Config) Validate() error {
 	if c.DraftRepo == nil {
-		return apierrors.InvalidArgument("draft repository is required")
+		return apierr.InvalidArgument("draft repository is required")
 	}
 	if c.CharacterRepo == nil {
-		return apierrors.InvalidArgument("character repository is required")
+		return apierr.InvalidArgument("character repository is required")
 	}
 	if c.DiceService == nil {
-		return apierrors.InvalidArgument("dice service is required")
+		return apierr.InvalidArgument("dice service is required")
 	}
 	if c.IDGenerator == nil {
-		return apierrors.InvalidArgument("ID generator is required")
+		return apierr.InvalidArgument("ID generator is required")
 	}
 	if c.DraftIDGenerator == nil {
-		return apierrors.InvalidArgument("draft ID generator is required")
+		return apierr.InvalidArgument("draft ID generator is required")
 	}
 	return nil
 }
@@ -61,7 +61,7 @@ type Orchestrator struct {
 // New creates a new character orchestrator
 func New(cfg *Config) (*Orchestrator, error) {
 	if cfg == nil {
-		return nil, apierrors.InvalidArgument("config is required")
+		return nil, apierr.InvalidArgument("config is required")
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -79,10 +79,10 @@ func New(cfg *Config) (*Orchestrator, error) {
 // CreateDraft creates a new character draft
 func (o *Orchestrator) CreateDraft(ctx context.Context, input *CreateDraftInput) (*CreateDraftOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.PlayerID == "" {
-		return nil, apierrors.InvalidArgument("player ID is required")
+		return nil, apierr.InvalidArgument("player ID is required")
 	}
 
 	// Create new draft with generated ID
@@ -111,10 +111,10 @@ func (o *Orchestrator) CreateDraft(ctx context.Context, input *CreateDraftInput)
 // GetDraft retrieves a draft by ID
 func (o *Orchestrator) GetDraft(ctx context.Context, input *GetDraftInput) (*GetDraftOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 
 	getOutput, err := o.draftRepo.Get(ctx, characterdraft.GetInput{
@@ -133,10 +133,10 @@ func (o *Orchestrator) GetDraft(ctx context.Context, input *GetDraftInput) (*Get
 // DeleteDraft deletes a draft
 func (o *Orchestrator) DeleteDraft(ctx context.Context, input *DeleteDraftInput) (*DeleteDraftOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 
 	if _, err := o.draftRepo.Delete(ctx, characterdraft.DeleteInput{
@@ -153,7 +153,7 @@ func (o *Orchestrator) DeleteDraft(ctx context.Context, input *DeleteDraftInput)
 // GetRequirements returns the requirements for character creation choices
 func (o *Orchestrator) GetRequirements(_ context.Context, input *GetRequirementsInput) (*GetRequirementsOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	// Default to level 1 if not specified
@@ -203,13 +203,13 @@ func (o *Orchestrator) GetRequirements(_ context.Context, input *GetRequirements
 // SetName sets the character name
 func (o *Orchestrator) SetName(ctx context.Context, input *SetNameInput) (*SetNameOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 	if input.Name == "" {
-		return nil, apierrors.InvalidArgument("name is required")
+		return nil, apierr.InvalidArgument("name is required")
 	}
 
 	// Get draft
@@ -244,13 +244,13 @@ func (o *Orchestrator) SetName(ctx context.Context, input *SetNameInput) (*SetNa
 // SetRace sets the race with choices
 func (o *Orchestrator) SetRace(ctx context.Context, input *SetRaceInput) (*SetRaceOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 	if input.Input == nil {
-		return nil, apierrors.InvalidArgument("race input is required")
+		return nil, apierr.InvalidArgument("race input is required")
 	}
 
 	// Get draft
@@ -294,13 +294,13 @@ func (o *Orchestrator) SetRace(ctx context.Context, input *SetRaceInput) (*SetRa
 // SetClass sets the class with choices
 func (o *Orchestrator) SetClass(ctx context.Context, input *SetClassInput) (*SetClassOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 	if input.Input == nil {
-		return nil, apierrors.InvalidArgument("class input is required")
+		return nil, apierr.InvalidArgument("class input is required")
 	}
 
 	// Get draft
@@ -344,13 +344,13 @@ func (o *Orchestrator) SetClass(ctx context.Context, input *SetClassInput) (*Set
 // SetBackground sets the background with choices
 func (o *Orchestrator) SetBackground(ctx context.Context, input *SetBackgroundInput) (*SetBackgroundOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 	if input.Input == nil {
-		return nil, apierrors.InvalidArgument("background input is required")
+		return nil, apierr.InvalidArgument("background input is required")
 	}
 
 	// Get draft
@@ -394,10 +394,10 @@ func (o *Orchestrator) SetBackground(ctx context.Context, input *SetBackgroundIn
 // SetAbilityScores sets ability scores
 func (o *Orchestrator) SetAbilityScores(ctx context.Context, input *SetAbilityScoresInput) (*SetAbilityScoresOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 
 	// Get draft
@@ -432,13 +432,13 @@ func (o *Orchestrator) SetAbilityScores(ctx context.Context, input *SetAbilitySc
 // SetAbilityScoresFromRolls sets ability scores from dice roll assignments
 func (o *Orchestrator) SetAbilityScoresFromRolls(ctx context.Context, input *SetAbilityScoresFromRollsInput) (*SetAbilityScoresFromRollsOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 	if len(input.RollAssignments) == 0 {
-		return nil, apierrors.InvalidArgument("roll assignments are required")
+		return nil, apierr.InvalidArgument("roll assignments are required")
 	}
 
 	// Get draft first - we might need it for player ID lookup
@@ -458,16 +458,16 @@ func (o *Orchestrator) SetAbilityScoresFromRolls(ctx context.Context, input *Set
 	if err != nil {
 		// If not found with draft ID, try with player ID
 		// (for backward compatibility with web app that might be using player ID)
-		if apierrors.IsNotFound(err) {
+		if apierr.IsNotFound(err) {
 			sessionOutput, err = o.diceService.GetRollSession(ctx, &dice.GetRollSessionInput{
 				EntityID: getOutput.Draft.PlayerID,
 				Context:  dice.ContextAbilityScores,
 			})
 			if err != nil {
-				return nil, apierrors.Wrap(err, "failed to get dice roll session (tried both draft ID and player ID)")
+				return nil, apierr.Wrap(err, "failed to get dice roll session (tried both draft ID and player ID)")
 			}
 		} else {
-			return nil, apierrors.Wrap(err, "failed to get dice roll session")
+			return nil, apierr.Wrap(err, "failed to get dice roll session")
 		}
 	}
 
@@ -483,7 +483,7 @@ func (o *Orchestrator) SetAbilityScoresFromRolls(ctx context.Context, input *Set
 		if total, ok := rollTotals[rollID]; ok {
 			scores[ability] = total
 		} else {
-			return nil, apierrors.InvalidArgument(fmt.Sprintf("roll ID %s not found in session", rollID))
+			return nil, apierr.InvalidArgument(fmt.Sprintf("roll ID %s not found in session", rollID))
 		}
 	}
 
@@ -515,10 +515,10 @@ func (o *Orchestrator) SetAbilityScoresFromRolls(ctx context.Context, input *Set
 // ValidateDraft validates a draft
 func (o *Orchestrator) ValidateDraft(ctx context.Context, input *ValidateDraftInput) (*ValidateDraftOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 
 	// Get draft
@@ -574,10 +574,10 @@ func (o *Orchestrator) ValidateDraft(ctx context.Context, input *ValidateDraftIn
 // FinalizeDraft converts a draft to a character
 func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftInput) (*FinalizeDraftOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.DraftID == "" {
-		return nil, apierrors.InvalidArgument("draft ID is required")
+		return nil, apierr.InvalidArgument("draft ID is required")
 	}
 
 	// Get draft
@@ -619,7 +619,7 @@ func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftIn
 			}
 		}
 
-		return nil, apierrors.InvalidArgumentf("draft is incomplete - missing: %v (progress: %d%%)",
+		return nil, apierr.InvalidArgumentf("draft is incomplete - missing: %v (progress: %d%%)",
 			missing, progress.PercentComplete())
 	}
 
@@ -758,10 +758,10 @@ func (o *Orchestrator) RollAbilityScores(ctx context.Context, input *RollAbility
 // ListDrafts returns drafts for a player or session
 func (o *Orchestrator) ListDrafts(ctx context.Context, input *ListDraftsInput) (*ListDraftsOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.PlayerID == "" {
-		return nil, apierrors.InvalidArgument("player ID is required")
+		return nil, apierr.InvalidArgument("player ID is required")
 	}
 
 	// The repository uses a single-draft-per-player pattern
@@ -771,7 +771,7 @@ func (o *Orchestrator) ListDrafts(ctx context.Context, input *ListDraftsInput) (
 	})
 	if err != nil {
 		// If not found, return empty list
-		if apierrors.IsNotFound(err) {
+		if apierr.IsNotFound(err) {
 			return &ListDraftsOutput{
 				Drafts:        []*character.DraftData{},
 				NextPageToken: "",
@@ -790,10 +790,10 @@ func (o *Orchestrator) ListDrafts(ctx context.Context, input *ListDraftsInput) (
 // GetCharacter retrieves a character by ID
 func (o *Orchestrator) GetCharacter(ctx context.Context, input *GetCharacterInput) (*GetCharacterOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.CharacterID == "" {
-		return nil, apierrors.InvalidArgument("character ID is required")
+		return nil, apierr.InvalidArgument("character ID is required")
 	}
 
 	// Get character from repository - equipment slots are part of character.Data
@@ -812,16 +812,16 @@ func (o *Orchestrator) GetCharacter(ctx context.Context, input *GetCharacterInpu
 // EquipItem equips an item to a specific slot
 func (o *Orchestrator) EquipItem(ctx context.Context, input *EquipItemInput) (*EquipItemOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.CharacterID == "" {
-		return nil, apierrors.InvalidArgument("character ID is required")
+		return nil, apierr.InvalidArgument("character ID is required")
 	}
 	if input.ItemID == "" {
-		return nil, apierrors.InvalidArgument("item ID is required")
+		return nil, apierr.InvalidArgument("item ID is required")
 	}
 	if input.Slot == "" {
-		return nil, apierrors.InvalidArgument("slot is required")
+		return nil, apierr.InvalidArgument("slot is required")
 	}
 
 	// Get character data
@@ -861,13 +861,13 @@ func (o *Orchestrator) EquipItem(ctx context.Context, input *EquipItemInput) (*E
 // UnequipItem removes an item from a slot
 func (o *Orchestrator) UnequipItem(ctx context.Context, input *UnequipItemInput) (*UnequipItemOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.CharacterID == "" {
-		return nil, apierrors.InvalidArgument("character ID is required")
+		return nil, apierr.InvalidArgument("character ID is required")
 	}
 	if input.Slot == "" {
-		return nil, apierrors.InvalidArgument("slot is required")
+		return nil, apierr.InvalidArgument("slot is required")
 	}
 
 	// Get character data
@@ -902,7 +902,7 @@ func (o *Orchestrator) UnequipItem(ctx context.Context, input *UnequipItemInput)
 // ListCharacters returns characters for a player or session
 func (o *Orchestrator) ListCharacters(ctx context.Context, input *ListCharactersInput) (*ListCharactersOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	// List by player ID (primary use case)
@@ -938,16 +938,16 @@ func (o *Orchestrator) ListCharacters(ctx context.Context, input *ListCharacters
 	}
 
 	// No filter provided - return error
-	return nil, apierrors.InvalidArgument("either player_id or session_id must be provided")
+	return nil, apierr.InvalidArgument("either player_id or session_id must be provided")
 }
 
 // DeleteCharacter deletes a character permanently
 func (o *Orchestrator) DeleteCharacter(ctx context.Context, input *DeleteCharacterInput) (*DeleteCharacterOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 	if input.CharacterID == "" {
-		return nil, apierrors.InvalidArgument("character ID is required")
+		return nil, apierr.InvalidArgument("character ID is required")
 	}
 
 	// Delete from repository
@@ -976,12 +976,12 @@ func (o *Orchestrator) ListEquipmentByType(_ context.Context, input *ListEquipme
 // ListSpellsByLevel returns spells of a specific level with their info
 func (o *Orchestrator) ListSpellsByLevel(_ context.Context, input *ListSpellsByLevelInput) (*ListSpellsByLevelOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	// Validate spell level
 	if input.Level < 0 || input.Level > 9 {
-		return nil, apierrors.InvalidArgument("spell level must be between 0 (cantrips) and 9")
+		return nil, apierr.InvalidArgument("spell level must be between 0 (cantrips) and 9")
 	}
 
 	// Get all spells for the requested level from the toolkit

--- a/internal/orchestrators/character/orchestrator_test.go
+++ b/internal/orchestrators/character/orchestrator_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
-	rpgerrors "github.com/KirkDiggler/rpg-api/internal/apierrors"
+	rpgerrors "github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 	dicemock "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice/mock"
 	idgenmock "github.com/KirkDiggler/rpg-api/internal/pkg/idgen/mock"

--- a/internal/orchestrators/dice/orchestrator.go
+++ b/internal/orchestrators/dice/orchestrator.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
 	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 )
@@ -63,7 +63,7 @@ type Config struct {
 
 // Validate ensures all required dependencies are provided
 func (c *Config) Validate() error {
-	vb := apierrors.NewValidationBuilder()
+	vb := apierr.NewValidationBuilder()
 
 	if c.DiceSessionRepo == nil {
 		vb.RequiredField("DiceSessionRepo")
@@ -84,7 +84,7 @@ type orchestrator struct {
 // NewOrchestrator creates a new dice orchestrator with the provided dependencies
 func NewOrchestrator(cfg *Config) (Service, error) {
 	if err := cfg.Validate(); err != nil {
-		return nil, apierrors.Wrap(err, "invalid config")
+		return nil, apierr.Wrap(err, "invalid config")
 	}
 
 	return &orchestrator{
@@ -98,21 +98,21 @@ func NewOrchestrator(cfg *Config) (Service, error) {
 func (o *orchestrator) parseDiceNotation(notation string) (count, size int, err error) {
 	matches := diceNotationRegex.FindStringSubmatch(strings.ToLower(notation))
 	if len(matches) != 3 {
-		return 0, 0, apierrors.InvalidArgumentf("invalid dice notation: %s (expected format: XdY)", notation)
+		return 0, 0, apierr.InvalidArgumentf("invalid dice notation: %s (expected format: XdY)", notation)
 	}
 
 	count, err = strconv.Atoi(matches[1])
 	if err != nil {
-		return 0, 0, apierrors.InvalidArgumentf("invalid dice count in notation: %s", notation)
+		return 0, 0, apierr.InvalidArgumentf("invalid dice count in notation: %s", notation)
 	}
 
 	size, err = strconv.Atoi(matches[2])
 	if err != nil {
-		return 0, 0, apierrors.InvalidArgumentf("invalid die size in notation: %s", notation)
+		return 0, 0, apierr.InvalidArgumentf("invalid die size in notation: %s", notation)
 	}
 
 	if count <= 0 || size <= 0 {
-		return 0, 0, apierrors.InvalidArgumentf("dice count and size must be positive: %s", notation)
+		return 0, 0, apierr.InvalidArgumentf("dice count and size must be positive: %s", notation)
 	}
 
 	return count, size, nil
@@ -123,7 +123,7 @@ func (o *orchestrator) rollDiceWithToolkit(ctx context.Context, count, size int,
 	// Use the roller to roll dice
 	rolls, err := o.roller.RollN(ctx, count, size)
 	if err != nil {
-		return nil, nil, 0, apierrors.Wrapf(err, "failed to roll dice")
+		return nil, nil, 0, apierr.Wrapf(err, "failed to roll dice")
 	}
 
 	// Copy rolls to individualDice
@@ -177,13 +177,13 @@ func (o *orchestrator) rollDiceWithToolkit(ctx context.Context, count, size int,
 // RollDice rolls dice using the specified notation and stores the result in a session
 func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*RollDiceOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument("entity ID is required")
+		return nil, apierr.InvalidArgument("entity ID is required")
 	}
 	if input.Context == "" {
-		return nil, apierrors.InvalidArgument("context is required")
+		return nil, apierr.InvalidArgument("context is required")
 	}
 	if input.Notation == "" {
-		return nil, apierrors.InvalidArgument("dice notation is required")
+		return nil, apierr.InvalidArgument("dice notation is required")
 	}
 
 	// Parse the dice notation
@@ -201,7 +201,7 @@ func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*Rol
 	// Roll the dice using rpg-toolkit
 	individualDice, dropped, total, err := o.rollDiceWithToolkit(ctx, count, size, dropLowest)
 	if err != nil {
-		return nil, apierrors.Wrap(err, "failed to roll dice")
+		return nil, apierr.Wrap(err, "failed to roll dice")
 	}
 
 	// Create the dice roll
@@ -224,8 +224,8 @@ func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*Rol
 
 	var session *dicesession.DiceSession
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, apierrors.Wrap(err, "failed to check for existing session")
+		if !apierr.IsNotFound(err) {
+			return nil, apierr.Wrap(err, "failed to check for existing session")
 		}
 
 		// No existing session, create a new one
@@ -241,7 +241,7 @@ func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*Rol
 			TTL:      ttl,
 		})
 		if err != nil {
-			return nil, apierrors.Wrap(err, "failed to create dice session")
+			return nil, apierr.Wrap(err, "failed to create dice session")
 		}
 		session = createOutput.Session
 	} else {
@@ -251,7 +251,7 @@ func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*Rol
 
 		// Update the session
 		if err := o.diceSessionRepo.Update(ctx, session); err != nil {
-			return nil, apierrors.Wrap(err, "failed to update dice session")
+			return nil, apierr.Wrap(err, "failed to update dice session")
 		}
 	}
 
@@ -272,10 +272,10 @@ func (o *orchestrator) RollDice(ctx context.Context, input *RollDiceInput) (*Rol
 // GetRollSession retrieves an existing dice roll session
 func (o *orchestrator) GetRollSession(ctx context.Context, input *GetRollSessionInput) (*GetRollSessionOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument("entity ID is required")
+		return nil, apierr.InvalidArgument("entity ID is required")
 	}
 	if input.Context == "" {
-		return nil, apierrors.InvalidArgument("context is required")
+		return nil, apierr.InvalidArgument("context is required")
 	}
 
 	getOutput, err := o.diceSessionRepo.Get(ctx, dicesession.GetInput{
@@ -283,7 +283,7 @@ func (o *orchestrator) GetRollSession(ctx context.Context, input *GetRollSession
 		Context:  input.Context,
 	})
 	if err != nil {
-		return nil, apierrors.Wrap(err, "failed to get dice session")
+		return nil, apierr.Wrap(err, "failed to get dice session")
 	}
 
 	return &GetRollSessionOutput{
@@ -295,10 +295,10 @@ func (o *orchestrator) GetRollSession(ctx context.Context, input *GetRollSession
 func (o *orchestrator) ClearRollSession(ctx context.Context, input *ClearRollSessionInput) (
 	*ClearRollSessionOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument("entity ID is required")
+		return nil, apierr.InvalidArgument("entity ID is required")
 	}
 	if input.Context == "" {
-		return nil, apierrors.InvalidArgument("context is required")
+		return nil, apierr.InvalidArgument("context is required")
 	}
 
 	deleteOutput, err := o.diceSessionRepo.Delete(ctx, dicesession.DeleteInput{
@@ -306,7 +306,7 @@ func (o *orchestrator) ClearRollSession(ctx context.Context, input *ClearRollSes
 		Context:  input.Context,
 	})
 	if err != nil {
-		return nil, apierrors.Wrap(err, "failed to delete dice session")
+		return nil, apierr.Wrap(err, "failed to delete dice session")
 	}
 
 	slog.Info("Dice session cleared",
@@ -324,7 +324,7 @@ func (o *orchestrator) ClearRollSession(ctx context.Context, input *ClearRollSes
 func (o *orchestrator) RollAbilityScores(ctx context.Context, input *RollAbilityScoresInput) (
 	*RollAbilityScoresOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument("entity ID is required")
+		return nil, apierr.InvalidArgument("entity ID is required")
 	}
 	if input.Method == "" {
 		input.Method = MethodStandard // Default to 4d6 drop lowest
@@ -342,13 +342,13 @@ func (o *orchestrator) RollAbilityScores(ctx context.Context, input *RollAbility
 	case MethodHeroic:
 		notation = "4d6r1" // Reroll 1s
 	default:
-		return nil, apierrors.InvalidArgumentf("unsupported rolling method: %s", input.Method)
+		return nil, apierr.InvalidArgumentf("unsupported rolling method: %s", input.Method)
 	}
 
 	// Parse the dice notation for ability scores
 	count, size, err := o.parseDiceNotation(notation)
 	if err != nil {
-		return nil, apierrors.Wrap(err, "failed to parse ability score notation")
+		return nil, apierr.Wrap(err, "failed to parse ability score notation")
 	}
 
 	// Determine drop lowest count
@@ -363,7 +363,7 @@ func (o *orchestrator) RollAbilityScores(ctx context.Context, input *RollAbility
 		// Roll the dice using rpg-toolkit
 		individualDice, droppedDice, total, rollErr := o.rollDiceWithToolkit(ctx, count, size, dropLowestCount)
 		if rollErr != nil {
-			return nil, apierrors.Wrapf(rollErr, "failed to roll ability score %d", i+1)
+			return nil, apierr.Wrapf(rollErr, "failed to roll ability score %d", i+1)
 		}
 
 		roll := &dicesession.DiceRoll{
@@ -394,7 +394,7 @@ func (o *orchestrator) RollAbilityScores(ctx context.Context, input *RollAbility
 		TTL:      DefaultSessionTTL,
 	})
 	if err != nil {
-		return nil, apierrors.Wrap(err, "failed to create ability score session")
+		return nil, apierr.Wrap(err, "failed to create ability score session")
 	}
 
 	slog.Info("Ability scores rolled successfully",

--- a/internal/orchestrators/dice/orchestrator_ability_test.go
+++ b/internal/orchestrators/dice/orchestrator_ability_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
 	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 	dicemock "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session/mock"
@@ -43,7 +43,7 @@ func TestOrchestrator_RollDice_AbilityScores(t *testing.T) {
 				EntityID: "player-123",
 				Context:  ContextAbilityScores,
 			}).
-			Return(nil, apierrors.NotFound("session not found"))
+			Return(nil, apierr.NotFound("session not found"))
 
 		// Mock creating a new session
 		mockRepo.EXPECT().
@@ -105,7 +105,7 @@ func TestOrchestrator_RollDice_AbilityScores(t *testing.T) {
 				EntityID: "player-123",
 				Context:  "damage_rolls",
 			}).
-			Return(nil, apierrors.NotFound("session not found"))
+			Return(nil, apierr.NotFound("session not found"))
 
 		// Mock creating a new session
 		mockRepo.EXPECT().

--- a/internal/orchestrators/encounter/orchestrator_test.go
+++ b/internal/orchestrators/encounter/orchestrator_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
 	encounterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
@@ -215,7 +215,7 @@ func (s *OrchestratorTestSuite) TestResolveAttack_CharacterNotFound() {
 	// Arrange
 	s.mockCharRepo.EXPECT().
 		Get(gomock.Any(), characterrepo.GetInput{ID: "nonexistent"}).
-		Return(nil, apierrors.NotFound("character not found"))
+		Return(nil, apierr.NotFound("character not found"))
 
 	// Act
 	output, err := s.orchestrator.ResolveAttack(context.Background(), &ResolveAttackInput{
@@ -240,7 +240,7 @@ func (s *OrchestratorTestSuite) TestResolveAttack_EncounterNotFound() {
 	// Arrange - Encounter not found
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "nonexistent"}).
-		Return(nil, apierrors.NotFound("encounter not found"))
+		Return(nil, apierr.NotFound("encounter not found"))
 
 	// Act
 	output, err := s.orchestrator.ResolveAttack(context.Background(), &ResolveAttackInput{
@@ -1512,7 +1512,7 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithPlayerID_CharacterLookupFails() 
 	// Mock character lookup to fail
 	s.mockCharRepo.EXPECT().
 		Get(gomock.Any(), characterrepo.GetInput{ID: "char-1"}).
-		Return(nil, apierrors.NotFound("character not found"))
+		Return(nil, apierr.NotFound("character not found"))
 
 	// Act
 	output, err := s.orchestrator.EndTurn(context.Background(), &EndTurnInput{
@@ -1652,7 +1652,7 @@ func (s *OrchestratorTestSuite) TestActivateFeature_CharacterNotFound() {
 	// Character not found
 	s.mockCharRepo.EXPECT().
 		Get(gomock.Any(), characterrepo.GetInput{ID: "char-1"}).
-		Return(nil, apierrors.NotFound("character not found"))
+		Return(nil, apierr.NotFound("character not found"))
 
 	// Act
 	output, err := s.orchestrator.ActivateFeature(context.Background(), &ActivateFeatureInput{

--- a/internal/publishers/encounter/publisher.go
+++ b/internal/publishers/encounter/publisher.go
@@ -13,21 +13,21 @@ import (
 // Purpose: Enable real-time multiplayer synchronization via pub/sub pattern
 type Publisher interface {
 	// Publish publishes an event to all subscribers of the encounter
-	// Returns apierrors.InvalidArgument for nil events or empty encounter IDs
-	// Returns apierrors.Internal for publishing failures
+	// Returns apierr.InvalidArgument for nil events or empty encounter IDs
+	// Returns apierr.Internal for publishing failures
 	Publish(ctx context.Context, input *PublishInput) (*PublishOutput, error)
 
 	// Subscribe subscribes to events for a specific encounter
 	// Returns a channel that will receive events and an error channel
 	// The event channel will be closed when the context is canceled or Unsubscribe is called
-	// Returns apierrors.InvalidArgument for empty encounter IDs
-	// Returns apierrors.Internal for subscription failures
+	// Returns apierr.InvalidArgument for empty encounter IDs
+	// Returns apierr.Internal for subscription failures
 	Subscribe(ctx context.Context, input *SubscribeInput) (*SubscribeOutput, error)
 
 	// Unsubscribe unsubscribes from encounter events
 	// Closes the event channel associated with the subscription ID
-	// Returns apierrors.InvalidArgument for empty subscription IDs
-	// Returns apierrors.NotFound if subscription doesn't exist
+	// Returns apierr.InvalidArgument for empty subscription IDs
+	// Returns apierr.NotFound if subscription doesn't exist
 	Unsubscribe(ctx context.Context, input *UnsubscribeInput) (*UnsubscribeOutput, error)
 }
 

--- a/internal/publishers/encounter/redis.go
+++ b/internal/publishers/encounter/redis.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
 	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
 )
@@ -49,10 +49,10 @@ type RedisConfig struct {
 // Validate validates the RedisConfig
 func (cfg *RedisConfig) Validate() error {
 	if cfg == nil {
-		return apierrors.InvalidArgument("config cannot be nil")
+		return apierr.InvalidArgument("config cannot be nil")
 	}
 	if cfg.Client == nil {
-		return apierrors.InvalidArgument("client cannot be nil")
+		return apierr.InvalidArgument("client cannot be nil")
 	}
 	return nil
 }
@@ -79,25 +79,25 @@ func NewRedis(cfg *RedisConfig) (Publisher, error) {
 // Publish publishes an event to all subscribers of the encounter
 func (p *redisPublisher) Publish(ctx context.Context, input *PublishInput) (*PublishOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input cannot be nil")
+		return nil, apierr.InvalidArgument("input cannot be nil")
 	}
 	if input.Event == nil {
-		return nil, apierrors.InvalidArgument(errEventNil)
+		return nil, apierr.InvalidArgument(errEventNil)
 	}
 	if input.EncounterID == "" {
-		return nil, apierrors.InvalidArgument(errEncounterIDEmpty)
+		return nil, apierr.InvalidArgument(errEncounterIDEmpty)
 	}
 
 	// Serialize event to JSON
 	data, err := json.Marshal(input.Event)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to marshal event")
+		return nil, apierr.Wrapf(err, "failed to marshal event")
 	}
 
 	// Publish to Redis channel
 	channel := fmt.Sprintf(encounterChannelPattern, input.EncounterID)
 	if err := p.client.Publish(ctx, channel, data).Err(); err != nil {
-		return nil, apierrors.Wrapf(err, "failed to publish event to channel %s", channel)
+		return nil, apierr.Wrapf(err, "failed to publish event to channel %s", channel)
 	}
 
 	return &PublishOutput{}, nil
@@ -106,10 +106,10 @@ func (p *redisPublisher) Publish(ctx context.Context, input *PublishInput) (*Pub
 // Subscribe subscribes to events for a specific encounter
 func (p *redisPublisher) Subscribe(ctx context.Context, input *SubscribeInput) (*SubscribeOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input cannot be nil")
+		return nil, apierr.InvalidArgument("input cannot be nil")
 	}
 	if input.EncounterID == "" {
-		return nil, apierrors.InvalidArgument(errEncounterIDEmpty)
+		return nil, apierr.InvalidArgument(errEncounterIDEmpty)
 	}
 
 	// Generate unique subscription ID
@@ -150,17 +150,17 @@ func (p *redisPublisher) Subscribe(ctx context.Context, input *SubscribeInput) (
 // Unsubscribe unsubscribes from encounter events
 func (p *redisPublisher) Unsubscribe(ctx context.Context, input *UnsubscribeInput) (*UnsubscribeOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input cannot be nil")
+		return nil, apierr.InvalidArgument("input cannot be nil")
 	}
 	if input.SubscriptionID == "" {
-		return nil, apierrors.InvalidArgument(errSubscriptionIDEmpty)
+		return nil, apierr.InvalidArgument(errSubscriptionIDEmpty)
 	}
 
 	p.mu.Lock()
 	sub, exists := p.subscriptions[input.SubscriptionID]
 	if !exists {
 		p.mu.Unlock()
-		return nil, apierrors.NotFoundf("subscription %s not found", input.SubscriptionID)
+		return nil, apierr.NotFoundf("subscription %s not found", input.SubscriptionID)
 	}
 	delete(p.subscriptions, input.SubscriptionID)
 	p.mu.Unlock()
@@ -192,7 +192,7 @@ func (p *redisPublisher) listen(ctx context.Context, sub *subscription) {
 	_, err := pubsub.Receive(ctx)
 	if err != nil {
 		select {
-		case sub.errors <- apierrors.Wrapf(err, "failed to confirm subscription to %s", channel):
+		case sub.errors <- apierr.Wrapf(err, "failed to confirm subscription to %s", channel):
 		case <-ctx.Done():
 		}
 		return
@@ -214,7 +214,7 @@ func (p *redisPublisher) listen(ctx context.Context, sub *subscription) {
 			var event entities.EncounterEvent
 			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
 				select {
-				case sub.errors <- apierrors.Wrapf(err, "failed to unmarshal event"):
+				case sub.errors <- apierr.Wrapf(err, "failed to unmarshal event"):
 				case <-ctx.Done():
 					return
 				}

--- a/internal/publishers/encounter/redis_test.go
+++ b/internal/publishers/encounter/redis_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
 )
@@ -318,7 +318,7 @@ func (s *RedisPublisherTestSuite) TestUnsubscribe_NotFound() {
 	// Assert
 	s.Require().Error(err)
 	s.Assert().Nil(output)
-	s.Assert().True(apierrors.IsNotFound(err))
+	s.Assert().True(apierr.IsNotFound(err))
 }
 
 // Integration Tests

--- a/internal/repositories/character/redis.go
+++ b/internal/repositories/character/redis.go
@@ -7,7 +7,7 @@ import (
 
 	redis "github.com/redis/go-redis/v9"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/clock"
 	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
@@ -39,10 +39,10 @@ type RedisConfig struct {
 // Validate validates the RedisConfig.
 func (cfg *RedisConfig) Validate() error {
 	if cfg == nil {
-		return apierrors.InvalidArgument("config cannot be nil")
+		return apierr.InvalidArgument("config cannot be nil")
 	}
 	if cfg.Client == nil {
-		return apierrors.InvalidArgument("client cannot be nil")
+		return apierr.InvalidArgument("client cannot be nil")
 	}
 	return nil
 }
@@ -67,10 +67,10 @@ func NewRedis(cfg *RedisConfig) (Repository, error) {
 
 func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	if input.CharacterData == nil {
-		return nil, apierrors.InvalidArgument(errCharacterNil)
+		return nil, apierr.InvalidArgument(errCharacterNil)
 	}
 	if input.CharacterData.ID == "" {
-		return nil, apierrors.InvalidArgument(errCharacterIDEmpty)
+		return nil, apierr.InvalidArgument(errCharacterIDEmpty)
 	}
 
 	key := characterKeyPrefix + input.CharacterData.ID
@@ -78,17 +78,17 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 	// Check if already exists
 	exists, err := r.client.Exists(ctx, key).Result()
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to check existence")
+		return nil, apierr.Wrapf(err, "failed to check existence")
 	}
 
 	if exists > 0 {
-		return nil, apierrors.AlreadyExistsf("character with ID %s already exists", input.CharacterData.ID)
+		return nil, apierr.AlreadyExistsf("character with ID %s already exists", input.CharacterData.ID)
 	}
 
 	// Marshal character data
 	data, err := json.Marshal(input.CharacterData)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to marshal character data")
+		return nil, apierr.Wrapf(err, "failed to marshal character data")
 	}
 
 	// Start transaction
@@ -108,7 +108,7 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 	// Execute transaction
 	_, err = pipe.Exec(ctx)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to create character")
+		return nil, apierr.Wrapf(err, "failed to create character")
 	}
 
 	return &CreateOutput{CharacterData: input.CharacterData}, nil
@@ -116,21 +116,21 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 
 func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, error) {
 	if input.ID == "" {
-		return nil, apierrors.InvalidArgument(errCharacterIDEmpty)
+		return nil, apierr.InvalidArgument(errCharacterIDEmpty)
 	}
 
 	key := characterKeyPrefix + input.ID
 	result, err := r.client.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
-			return nil, apierrors.NotFoundf("character with ID %s not found", input.ID)
+			return nil, apierr.NotFoundf("character with ID %s not found", input.ID)
 		}
-		return nil, apierrors.Wrapf(err, "failed to get character")
+		return nil, apierr.Wrapf(err, "failed to get character")
 	}
 
 	var charData toolkitchar.Data
 	if unmarshalErr := json.Unmarshal([]byte(result), &charData); unmarshalErr != nil {
-		return nil, apierrors.Wrapf(unmarshalErr, "failed to unmarshal character data")
+		return nil, apierr.Wrapf(unmarshalErr, "failed to unmarshal character data")
 	}
 
 	return &GetOutput{
@@ -140,10 +140,10 @@ func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, 
 
 func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*UpdateOutput, error) {
 	if input.CharacterData == nil {
-		return nil, apierrors.InvalidArgument(errCharacterNil)
+		return nil, apierr.InvalidArgument(errCharacterNil)
 	}
 	if input.CharacterData.ID == "" {
-		return nil, apierrors.InvalidArgument(errCharacterIDEmpty)
+		return nil, apierr.InvalidArgument(errCharacterIDEmpty)
 	}
 
 	key := characterKeyPrefix + input.CharacterData.ID
@@ -158,7 +158,7 @@ func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*Updat
 	// Marshal updated character data
 	data, err := json.Marshal(input.CharacterData)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to marshal character data")
+		return nil, apierr.Wrapf(err, "failed to marshal character data")
 	}
 
 	// Start transaction
@@ -185,7 +185,7 @@ func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*Updat
 	// Execute transaction
 	_, err = pipe.Exec(ctx)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to update character")
+		return nil, apierr.Wrapf(err, "failed to update character")
 	}
 
 	return &UpdateOutput{CharacterData: input.CharacterData}, nil
@@ -193,7 +193,7 @@ func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*Updat
 
 func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*DeleteOutput, error) {
 	if input.ID == "" {
-		return nil, apierrors.InvalidArgument(errCharacterIDEmpty)
+		return nil, apierr.InvalidArgument(errCharacterIDEmpty)
 	}
 
 	// Get character to find indexes
@@ -221,7 +221,7 @@ func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*Delet
 	// Execute transaction
 	_, err = pipe.Exec(ctx)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to delete character")
+		return nil, apierr.Wrapf(err, "failed to delete character")
 	}
 
 	return &DeleteOutput{}, nil
@@ -232,7 +232,7 @@ func (r *redisRepository) ListByPlayerID(
 	input ListByPlayerIDInput,
 ) (*ListByPlayerIDOutput, error) {
 	if input.PlayerID == "" {
-		return nil, apierrors.InvalidArgument(errPlayerIDEmpty)
+		return nil, apierr.InvalidArgument(errPlayerIDEmpty)
 	}
 
 	indexKey := playerIndexPrefix + input.PlayerID
@@ -261,7 +261,7 @@ func (r *redisRepository) ListBySessionID(
 	input ListBySessionIDInput,
 ) (*ListBySessionIDOutput, error) {
 	if input.SessionID == "" {
-		return nil, apierrors.InvalidArgument(errSessionIDEmpty)
+		return nil, apierr.InvalidArgument(errSessionIDEmpty)
 	}
 
 	indexKey := sessionIndexPrefix + input.SessionID
@@ -296,7 +296,7 @@ func (r *redisRepository) listByIndex(ctx context.Context, indexKey string) ([]*
 		slog.ErrorContext(ctx, "failed to get character IDs from Redis",
 			"index_key", indexKey,
 			"error", err.Error())
-		return nil, apierrors.Wrapf(err, "failed to get characters from index %s", indexKey)
+		return nil, apierr.Wrapf(err, "failed to get characters from index %s", indexKey)
 	}
 
 	slog.DebugContext(ctx, "found character IDs in index",
@@ -313,7 +313,7 @@ func (r *redisRepository) listByIndex(ctx context.Context, indexKey string) ([]*
 		getOutput, err := r.Get(ctx, GetInput{ID: id})
 		if err != nil {
 			// If character doesn't exist, clean up the index
-			if apierrors.IsNotFound(err) {
+			if apierr.IsNotFound(err) {
 				slog.WarnContext(ctx, "character not found, cleaning up index",
 					"character_id", id,
 					"index_key", indexKey)
@@ -323,7 +323,7 @@ func (r *redisRepository) listByIndex(ctx context.Context, indexKey string) ([]*
 			slog.ErrorContext(ctx, "failed to get character from Redis",
 				"character_id", id,
 				"error", err.Error())
-			return nil, apierrors.Wrapf(err, "failed to get character %s", id)
+			return nil, apierr.Wrapf(err, "failed to get character %s", id)
 		}
 		characters = append(characters, getOutput.CharacterData)
 	}

--- a/internal/repositories/character/repository.go
+++ b/internal/repositories/character/repository.go
@@ -12,37 +12,37 @@ import (
 // Repository defines the interface for character persistence
 type Repository interface {
 	// Create creates a new character
-	// Returns apierrors.InvalidArgument for validation failures
-	// Returns apierrors.AlreadyExists if character with same ID exists
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for validation failures
+	// Returns apierr.AlreadyExists if character with same ID exists
+	// Returns apierr.Internal for storage failures
 	Create(ctx context.Context, input CreateInput) (*CreateOutput, error)
 
 	// Get retrieves a character by ID
-	// Returns apierrors.InvalidArgument for empty/invalid IDs
-	// Returns apierrors.NotFound if character doesn't exist
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid IDs
+	// Returns apierr.NotFound if character doesn't exist
+	// Returns apierr.Internal for storage failures
 	Get(ctx context.Context, input GetInput) (*GetOutput, error)
 
 	// Update updates an existing character
-	// Returns apierrors.InvalidArgument for validation failures
-	// Returns apierrors.NotFound if character doesn't exist
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for validation failures
+	// Returns apierr.NotFound if character doesn't exist
+	// Returns apierr.Internal for storage failures
 	Update(ctx context.Context, input UpdateInput) (*UpdateOutput, error)
 
 	// Delete deletes a character by ID
-	// Returns apierrors.InvalidArgument for empty/invalid IDs
-	// Returns apierrors.NotFound if character doesn't exist
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid IDs
+	// Returns apierr.NotFound if character doesn't exist
+	// Returns apierr.Internal for storage failures
 	Delete(ctx context.Context, input DeleteInput) (*DeleteOutput, error)
 
 	// ListByPlayerID retrieves all characters for a player
-	// Returns apierrors.InvalidArgument for empty/invalid player IDs
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid player IDs
+	// Returns apierr.Internal for storage failures
 	ListByPlayerID(ctx context.Context, input ListByPlayerIDInput) (*ListByPlayerIDOutput, error)
 
 	// ListBySessionID retrieves all characters in a session
-	// Returns apierrors.InvalidArgument for empty/invalid session IDs
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid session IDs
+	// Returns apierr.Internal for storage failures
 	ListBySessionID(ctx context.Context, input ListBySessionIDInput) (*ListBySessionIDOutput, error)
 }
 

--- a/internal/repositories/character_draft/redis.go
+++ b/internal/repositories/character_draft/redis.go
@@ -7,7 +7,7 @@ import (
 
 	redis "github.com/redis/go-redis/v9"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/clock"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
 	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
@@ -36,13 +36,13 @@ type Config struct {
 // Validate ensures all required dependencies are provided
 func (c *Config) Validate() error {
 	if c.Client == nil {
-		return apierrors.InvalidArgument("redis client is required")
+		return apierr.InvalidArgument("redis client is required")
 	}
 	if c.Clock == nil {
-		return apierrors.InvalidArgument("clock is required")
+		return apierr.InvalidArgument("clock is required")
 	}
 	if c.IDGenerator == nil {
-		return apierrors.InvalidArgument("ID generator is required")
+		return apierr.InvalidArgument("ID generator is required")
 	}
 	return nil
 }
@@ -68,10 +68,10 @@ func NewRedis(cfg *Config) (Repository, error) {
 
 func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	if input.Draft == nil {
-		return nil, apierrors.InvalidArgument(errDraftNil)
+		return nil, apierr.InvalidArgument(errDraftNil)
 	}
 	if input.Draft.PlayerID == "" {
-		return nil, apierrors.InvalidArgument(errPlayerIDEmpty)
+		return nil, apierr.InvalidArgument(errPlayerIDEmpty)
 	}
 
 	// Make a copy to avoid modifying input
@@ -88,7 +88,7 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 	existingDraftID, err := r.client.Get(ctx, playerKey).Result()
 	if err != nil {
 		if err != redis.Nil {
-			return nil, apierrors.Wrapf(err, "failed to check existing draft")
+			return nil, apierr.Wrapf(err, "failed to check existing draft")
 		}
 		// err == redis.Nil means no existing draft, so isNew stays true
 	} else {
@@ -108,7 +108,7 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 	// Marshal new draft
 	data, err := json.Marshal(&draft)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to marshal draft")
+		return nil, apierr.Wrapf(err, "failed to marshal draft")
 	}
 
 	// Set draft data
@@ -121,7 +121,7 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 	// Execute transaction
 	_, err = pipe.Exec(ctx)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to create draft")
+		return nil, apierr.Wrapf(err, "failed to create draft")
 	}
 
 	return &CreateOutput{Draft: &draft}, nil
@@ -129,23 +129,23 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 
 func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, error) {
 	if input.ID == "" {
-		return nil, apierrors.InvalidArgument(errDraftIDEmpty)
+		return nil, apierr.InvalidArgument(errDraftIDEmpty)
 	}
 
 	key := draftKeyPrefix + input.ID
 	result, err := r.client.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
-			return nil, apierrors.NotFoundf("draft with ID %s not found", input.ID)
+			return nil, apierr.NotFoundf("draft with ID %s not found", input.ID)
 		}
-		return nil, apierrors.Wrapf(err, "failed to get draft")
+		return nil, apierr.Wrapf(err, "failed to get draft")
 	}
 
 	data := []byte(result)
 
 	var draft character.DraftData
 	if err := json.Unmarshal(data, &draft); err != nil {
-		return nil, apierrors.Wrapf(err, "failed to unmarshal draft")
+		return nil, apierr.Wrapf(err, "failed to unmarshal draft")
 	}
 
 	return &GetOutput{Draft: &draft}, nil
@@ -153,7 +153,7 @@ func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, 
 
 func (r *redisRepository) GetByPlayerID(ctx context.Context, input GetByPlayerIDInput) (*GetByPlayerIDOutput, error) {
 	if input.PlayerID == "" {
-		return nil, apierrors.InvalidArgument(errPlayerIDEmpty)
+		return nil, apierr.InvalidArgument(errPlayerIDEmpty)
 	}
 
 	// Get draft ID from player mapping
@@ -161,16 +161,16 @@ func (r *redisRepository) GetByPlayerID(ctx context.Context, input GetByPlayerID
 	draftID, err := r.client.Get(ctx, playerKey).Result()
 	if err != nil {
 		if err == redis.Nil {
-			return nil, apierrors.NotFoundf("no draft found for player %s", input.PlayerID)
+			return nil, apierr.NotFoundf("no draft found for player %s", input.PlayerID)
 		}
-		return nil, apierrors.Wrapf(err, "failed to get player draft mapping")
+		return nil, apierr.Wrapf(err, "failed to get player draft mapping")
 	}
 
 	// Get the actual draft
 	getOutput, err := r.Get(ctx, GetInput{ID: draftID})
 	if err != nil {
 		// If draft doesn't exist, clean up the mapping
-		if apierrors.IsNotFound(err) {
+		if apierr.IsNotFound(err) {
 			r.client.Del(ctx, playerKey)
 		}
 		return nil, err
@@ -181,10 +181,10 @@ func (r *redisRepository) GetByPlayerID(ctx context.Context, input GetByPlayerID
 
 func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*UpdateOutput, error) {
 	if input.Draft == nil {
-		return nil, apierrors.InvalidArgument(errDraftNil)
+		return nil, apierr.InvalidArgument(errDraftNil)
 	}
 	if input.Draft.ID == "" {
-		return nil, apierrors.InvalidArgument(errDraftIDEmpty)
+		return nil, apierr.InvalidArgument(errDraftIDEmpty)
 	}
 
 	key := draftKeyPrefix + input.Draft.ID
@@ -192,10 +192,10 @@ func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*Updat
 	// Check if exists
 	exists, err := r.client.Exists(ctx, key).Result()
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to check existence")
+		return nil, apierr.Wrapf(err, "failed to check existence")
 	}
 	if exists == 0 {
-		return nil, apierrors.NotFoundf("draft with ID %s not found", input.Draft.ID)
+		return nil, apierr.NotFoundf("draft with ID %s not found", input.Draft.ID)
 	}
 
 	// Make a copy to avoid modifying input
@@ -204,12 +204,12 @@ func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*Updat
 	// Marshal draft
 	data, err := json.Marshal(&draft)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to marshal draft")
+		return nil, apierr.Wrapf(err, "failed to marshal draft")
 	}
 
 	// Update with TTL
 	if err := r.client.Set(ctx, key, data, defaultTTL).Err(); err != nil {
-		return nil, apierrors.Wrapf(err, "failed to update draft")
+		return nil, apierr.Wrapf(err, "failed to update draft")
 	}
 
 	return &UpdateOutput{Draft: &draft}, nil
@@ -217,7 +217,7 @@ func (r *redisRepository) Update(ctx context.Context, input UpdateInput) (*Updat
 
 func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*DeleteOutput, error) {
 	if input.ID == "" {
-		return nil, apierrors.InvalidArgument(errDraftIDEmpty)
+		return nil, apierr.InvalidArgument(errDraftIDEmpty)
 	}
 
 	// Get draft to find player ID
@@ -241,7 +241,7 @@ func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*Delet
 	// Execute transaction
 	_, err = pipe.Exec(ctx)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to delete draft")
+		return nil, apierr.Wrapf(err, "failed to delete draft")
 	}
 
 	return &DeleteOutput{}, nil

--- a/internal/repositories/character_draft/repository.go
+++ b/internal/repositories/character_draft/repository.go
@@ -13,32 +13,32 @@ import (
 // Implements a single-draft-per-player pattern for simplicity
 type Repository interface {
 	// Create creates or replaces a player's character draft
-	// Returns apierrors.InvalidArgument for validation failures
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for validation failures
+	// Returns apierr.Internal for storage failures
 	Create(ctx context.Context, input CreateInput) (*CreateOutput, error)
 
 	// Get retrieves a character draft by ID
-	// Returns apierrors.InvalidArgument for empty/invalid IDs
-	// Returns apierrors.NotFound if draft doesn't exist
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid IDs
+	// Returns apierr.NotFound if draft doesn't exist
+	// Returns apierr.Internal for storage failures
 	Get(ctx context.Context, input GetInput) (*GetOutput, error)
 
 	// GetByPlayerID retrieves the player's single draft
-	// Returns apierrors.InvalidArgument for empty/invalid player IDs
-	// Returns apierrors.NotFound if player has no draft
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid player IDs
+	// Returns apierr.NotFound if player has no draft
+	// Returns apierr.Internal for storage failures
 	GetByPlayerID(ctx context.Context, input GetByPlayerIDInput) (*GetByPlayerIDOutput, error)
 
 	// Update updates an existing character draft
-	// Returns apierrors.InvalidArgument for validation failures
-	// Returns apierrors.NotFound if draft doesn't exist
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for validation failures
+	// Returns apierr.NotFound if draft doesn't exist
+	// Returns apierr.Internal for storage failures
 	Update(ctx context.Context, input UpdateInput) (*UpdateOutput, error)
 
 	// Delete deletes a character draft by ID
-	// Returns apierrors.InvalidArgument for empty/invalid IDs
-	// Returns apierrors.NotFound if draft doesn't exist
-	// Returns apierrors.Internal for storage failures
+	// Returns apierr.InvalidArgument for empty/invalid IDs
+	// Returns apierr.NotFound if draft doesn't exist
+	// Returns apierr.Internal for storage failures
 	Delete(ctx context.Context, input DeleteInput) (*DeleteOutput, error)
 }
 

--- a/internal/repositories/dice_session/redis.go
+++ b/internal/repositories/dice_session/redis.go
@@ -8,7 +8,7 @@ import (
 
 	redis "github.com/redis/go-redis/v9"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/clock"
 	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
 )
@@ -34,10 +34,10 @@ type Config struct {
 // Validate ensures all required dependencies are provided
 func (c *Config) Validate() error {
 	if c.Client == nil {
-		return apierrors.InvalidArgument("redis client is required")
+		return apierr.InvalidArgument("redis client is required")
 	}
 	if c.Clock == nil {
-		return apierrors.InvalidArgument("clock is required")
+		return apierr.InvalidArgument("clock is required")
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ type redisRepository struct {
 // NewRedisRepository creates a new Redis repository for dice sessions
 func NewRedisRepository(cfg *Config) (Repository, error) {
 	if err := cfg.Validate(); err != nil {
-		return nil, apierrors.Wrap(err, "invalid config")
+		return nil, apierr.Wrap(err, "invalid config")
 	}
 
 	return &redisRepository{
@@ -65,10 +65,10 @@ var _ Repository = (*redisRepository)(nil)
 // Create stores a new dice session with the specified TTL
 func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*CreateOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument(errEntityIDEmpty)
+		return nil, apierr.InvalidArgument(errEntityIDEmpty)
 	}
 	if input.Context == "" {
-		return nil, apierrors.InvalidArgument(errContextEmpty)
+		return nil, apierr.InvalidArgument(errContextEmpty)
 	}
 
 	now := r.clock.Now()
@@ -88,14 +88,14 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 	// Serialize the session
 	sessionJSON, err := json.Marshal(session)
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to marshal session")
+		return nil, apierr.Wrapf(err, "failed to marshal session")
 	}
 
 	// Store in Redis with TTL
 	key := r.buildKey(input.EntityID, input.Context)
 	err = r.client.Set(ctx, key, sessionJSON, ttl).Err()
 	if err != nil {
-		return nil, apierrors.Wrapf(err, "failed to store session in Redis")
+		return nil, apierr.Wrapf(err, "failed to store session in Redis")
 	}
 
 	return &CreateOutput{
@@ -106,10 +106,10 @@ func (r *redisRepository) Create(ctx context.Context, input CreateInput) (*Creat
 // Get retrieves a dice session by entity ID and context
 func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument(errEntityIDEmpty)
+		return nil, apierr.InvalidArgument(errEntityIDEmpty)
 	}
 	if input.Context == "" {
-		return nil, apierrors.InvalidArgument(errContextEmpty)
+		return nil, apierr.InvalidArgument(errContextEmpty)
 	}
 
 	key := r.buildKey(input.EntityID, input.Context)
@@ -118,22 +118,22 @@ func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, 
 	sessionJSON, err := r.client.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
-			return nil, apierrors.NotFound("dice session not found")
+			return nil, apierr.NotFound("dice session not found")
 		}
-		return nil, apierrors.Wrapf(err, "failed to get session from Redis")
+		return nil, apierr.Wrapf(err, "failed to get session from Redis")
 	}
 
 	// Deserialize the session
 	var session DiceSession
 	if err := json.Unmarshal([]byte(sessionJSON), &session); err != nil {
-		return nil, apierrors.Wrapf(err, "failed to unmarshal session")
+		return nil, apierr.Wrapf(err, "failed to unmarshal session")
 	}
 
 	// Check if session has expired
 	if r.clock.Now().After(session.ExpiresAt) {
 		// Session has expired, clean it up
 		_ = r.client.Del(ctx, key)
-		return nil, apierrors.NotFound("dice session has expired")
+		return nil, apierr.NotFound("dice session has expired")
 	}
 
 	return &GetOutput{
@@ -144,10 +144,10 @@ func (r *redisRepository) Get(ctx context.Context, input GetInput) (*GetOutput, 
 // Delete removes a dice session
 func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*DeleteOutput, error) {
 	if input.EntityID == "" {
-		return nil, apierrors.InvalidArgument(errEntityIDEmpty)
+		return nil, apierr.InvalidArgument(errEntityIDEmpty)
 	}
 	if input.Context == "" {
-		return nil, apierrors.InvalidArgument(errContextEmpty)
+		return nil, apierr.InvalidArgument(errContextEmpty)
 	}
 
 	key := r.buildKey(input.EntityID, input.Context)
@@ -165,7 +165,7 @@ func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*Delet
 	// Delete from Redis
 	result := r.client.Del(ctx, key)
 	if result.Err() != nil {
-		return nil, apierrors.Wrapf(result.Err(), "failed to delete session from Redis")
+		return nil, apierr.Wrapf(result.Err(), "failed to delete session from Redis")
 	}
 
 	return &DeleteOutput{
@@ -176,19 +176,19 @@ func (r *redisRepository) Delete(ctx context.Context, input DeleteInput) (*Delet
 // Update replaces an existing dice session (used for adding rolls)
 func (r *redisRepository) Update(ctx context.Context, session *DiceSession) error {
 	if session == nil {
-		return apierrors.InvalidArgument(errSessionNil)
+		return apierr.InvalidArgument(errSessionNil)
 	}
 	if session.EntityID == "" {
-		return apierrors.InvalidArgument(errEntityIDEmpty)
+		return apierr.InvalidArgument(errEntityIDEmpty)
 	}
 	if session.Context == "" {
-		return apierrors.InvalidArgument(errContextEmpty)
+		return apierr.InvalidArgument(errContextEmpty)
 	}
 
 	// Calculate remaining TTL
 	now := r.clock.Now()
 	if now.After(session.ExpiresAt) {
-		return apierrors.InvalidArgument(errSessionExpired)
+		return apierr.InvalidArgument(errSessionExpired)
 	}
 
 	remainingTTL := session.ExpiresAt.Sub(now)
@@ -196,14 +196,14 @@ func (r *redisRepository) Update(ctx context.Context, session *DiceSession) erro
 	// Serialize the session
 	sessionJSON, err := json.Marshal(session)
 	if err != nil {
-		return apierrors.Wrapf(err, "failed to marshal session")
+		return apierr.Wrapf(err, "failed to marshal session")
 	}
 
 	// Update in Redis with remaining TTL
 	key := r.buildKey(session.EntityID, session.Context)
 	err = r.client.Set(ctx, key, sessionJSON, remainingTTL).Err()
 	if err != nil {
-		return apierrors.Wrapf(err, "failed to update session in Redis")
+		return apierr.Wrapf(err, "failed to update session in Redis")
 	}
 
 	return nil

--- a/internal/repositories/encounters/inmemory.go
+++ b/internal/repositories/encounters/inmemory.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/KirkDiggler/rpg-api/internal/apierrors"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
 )
 
 // InMemoryRepository implements Repository using in-memory storage
@@ -24,11 +24,11 @@ func NewInMemory() *InMemoryRepository {
 // Save stores an encounter
 func (r *InMemoryRepository) Save(_ context.Context, input *SaveInput) (*SaveOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	if input.EncounterID == "" {
-		return nil, apierrors.InvalidArgument("encounter ID is required")
+		return nil, apierr.InvalidArgument("encounter ID is required")
 	}
 
 	r.mu.Lock()
@@ -54,11 +54,11 @@ func (r *InMemoryRepository) Save(_ context.Context, input *SaveInput) (*SaveOut
 // Get retrieves an encounter by ID
 func (r *InMemoryRepository) Get(_ context.Context, input *GetInput) (*GetOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	if input.EncounterID == "" {
-		return nil, apierrors.InvalidArgument("encounter ID is required")
+		return nil, apierr.InvalidArgument("encounter ID is required")
 	}
 
 	r.mu.RLock()
@@ -66,7 +66,7 @@ func (r *InMemoryRepository) Get(_ context.Context, input *GetInput) (*GetOutput
 
 	data, exists := r.store[input.EncounterID]
 	if !exists {
-		return nil, apierrors.NotFound("encounter not found")
+		return nil, apierr.NotFound("encounter not found")
 	}
 
 	// Return a copy to prevent external modification
@@ -90,11 +90,11 @@ func (r *InMemoryRepository) Get(_ context.Context, input *GetInput) (*GetOutput
 // GetByJoinCode retrieves an encounter by its join code
 func (r *InMemoryRepository) GetByJoinCode(_ context.Context, input *GetByJoinCodeInput) (*GetOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	if input.JoinCode == "" {
-		return nil, apierrors.InvalidArgument("join code is required")
+		return nil, apierr.InvalidArgument("join code is required")
 	}
 
 	r.mu.RLock()
@@ -122,17 +122,17 @@ func (r *InMemoryRepository) GetByJoinCode(_ context.Context, input *GetByJoinCo
 		}
 	}
 
-	return nil, apierrors.NotFound("encounter not found")
+	return nil, apierr.NotFound("encounter not found")
 }
 
 // Update modifies an existing encounter
 func (r *InMemoryRepository) Update(_ context.Context, input *UpdateInput) (*UpdateOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	if input.EncounterID == "" {
-		return nil, apierrors.InvalidArgument("encounter ID is required")
+		return nil, apierr.InvalidArgument("encounter ID is required")
 	}
 
 	r.mu.Lock()
@@ -140,7 +140,7 @@ func (r *InMemoryRepository) Update(_ context.Context, input *UpdateInput) (*Upd
 
 	data, exists := r.store[input.EncounterID]
 	if !exists {
-		return nil, apierrors.NotFound("encounter not found")
+		return nil, apierr.NotFound("encounter not found")
 	}
 
 	// Update only what's provided
@@ -174,18 +174,18 @@ func (r *InMemoryRepository) Update(_ context.Context, input *UpdateInput) (*Upd
 // Delete removes an encounter
 func (r *InMemoryRepository) Delete(_ context.Context, input *DeleteInput) (*DeleteOutput, error) {
 	if input == nil {
-		return nil, apierrors.InvalidArgument("input is required")
+		return nil, apierr.InvalidArgument("input is required")
 	}
 
 	if input.EncounterID == "" {
-		return nil, apierrors.InvalidArgument("encounter ID is required")
+		return nil, apierr.InvalidArgument("encounter ID is required")
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if _, exists := r.store[input.EncounterID]; !exists {
-		return nil, apierrors.NotFound("encounter not found")
+		return nil, apierr.NotFound("encounter not found")
 	}
 
 	delete(r.store, input.EncounterID)


### PR DESCRIPTION
closes: https://github.com/KirkDiggler/rpg-api/issues/287

This pull request refactors the internal error handling package by renaming it from `errors` to `apierr` throughout the codebase. This change improves clarity and avoids confusion with Go's standard library `errors` package. All related files, imports, types, and references have been updated accordingly, including both implementation and test files.

**Core package rename and refactoring:**

* Renamed the internal error handling package from `errors` to `apierr` across all relevant files, including `codes.go`, `errors.go`, `grpc.go`, `helpers.go`, and `validation.go`. All package declarations and imports have been updated to reflect this change. [[1]](diffhunk://#diff-a575e74512db1c24bf6f71125f520507a72ed5c537fef9c3973a86402e14a5e7L2-R2) [[2]](diffhunk://#diff-0fcc22944409b9659a498d84fde6ec5238ce0684d22029bcda4b7326404c5881L2-R2) [[3]](diffhunk://#diff-34fa5720272129d99f5af0b53e0949ffe7e07a74c28dc76d082f465a97bfa303L2-R2) [[4]](diffhunk://#diff-a503c4be335da3370789e918cf0e4340ca0f4601ba6ab515af8560c0f633a40bL2-R8) [[5]](diffhunk://#diff-185495795cfcc71ac7cd744ae77dd2973e9b47215367d3a0d5de77e260e8020fL2-R2)

**Test and documentation updates:**

* Renamed all test files and updated test package names and imports to use `apierr` instead of `errors`, ensuring consistency and preventing naming conflicts. [[1]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L1-R1) [[2]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L11-R11) [[3]](diffhunk://#diff-aea6d0bd316b351d2d9f10c8d73ad51ff4603e782ca0e037cfc0174bc92b0c45L1-R8)
* Updated all references in test cases and assertions from `errors` to `apierr`, including constructor calls, helper functions, and type usage in tests for both standard errors and validation errors. [[1]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L25-R45) [[2]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L54-R62) [[3]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L74-R96) [[4]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L115-R165) [[5]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L178-R250) [[6]](diffhunk://#diff-a0e7fc9523d9f0cf19a1e0f20a16a5858052bd6565a611d736b6b276b596ed02L262-R289) [[7]](diffhunk://#diff-aea6d0bd316b351d2d9f10c8d73ad51ff4603e782ca0e037cfc0174bc92b0c45L20-R20) [[8]](diffhunk://#diff-aea6d0bd316b351d2d9f10c8d73ad51ff4603e782ca0e037cfc0174bc92b0c45L31-R48) [[9]](diffhunk://#diff-aea6d0bd316b351d2d9f10c8d73ad51ff4603e782ca0e037cfc0174bc92b0c45L67-R68)
* Updated documentation and comments to reference `apierr` instead of `errors`.

**Dependency and usage updates:**

* Updated all code and documentation that previously imported or referenced `internal/errors` to now use `internal/apierr`. [[1]](diffhunk://#diff-b546a18a9d709251407ceda54967970b1d79d179e6647ed2dcf09e3f2a7ef310L781-R781) [[2]](diffhunk://#diff-aea6d0bd316b351d2d9f10c8d73ad51ff4603e782ca0e037cfc0174bc92b0c45L1-R8)

These changes ensure that the internal error handling is clearly distinguished from the Go standard library and maintain consistency throughout the codebase.