### PR TITLE
Fix feature converter to match toolkit JSON format

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -1185,41 +1185,30 @@ func ConvertCharacterDataToProto(data *toolkitchar.Data) *dnd5ev1alpha1.Characte
 	}
 
 	// Convert features
+	// Note: ref is stored as string "module:type:id", not an object
 	if len(data.Features) > 0 {
 		for _, featureJSON := range data.Features {
-			// Unmarshal to get basic info
 			var featureData struct {
-				Ref struct {
-					Value string `json:"value"`
-				} `json:"ref"`
 				ID   string `json:"id"`
 				Name string `json:"name"`
 			}
 			if err := json.Unmarshal(featureJSON, &featureData); err != nil {
-				continue // Skip invalid features
-			}
-
-			// Use ID or Ref.Value as the feature identifier
-			featureID := featureData.ID
-			if featureID == "" {
-				featureID = featureData.Ref.Value
-			}
-
-			// Skip if we still don't have an ID
-			if featureID == "" {
 				continue
 			}
 
-			// Get display name - prefer the name from JSON, fall back to lookup
+			if featureData.ID == "" {
+				continue
+			}
+
 			displayName := featureData.Name
 			if displayName == "" {
-				displayName = getFeatureDisplayName(featureID)
+				displayName = getFeatureDisplayName(featureData.ID)
 			}
 
 			char.Features = append(char.Features, &dnd5ev1alpha1.CharacterFeature{
-				Id:     featureID,
+				Id:     featureData.ID,
 				Name:   displayName,
-				Source: featureSourceClass, // Most features are class features
+				Source: featureSourceClass,
 			})
 		}
 	}

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -296,28 +296,30 @@ func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_InvalidFeatureJSON
 	assert.Equal(s.T(), "valid-rage", result.Features[0].Id)
 }
 
-func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_FeatureWithMissingID() {
-	// Create test data with feature missing ID
+func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_FeatureWithToolkitFormat() {
+	// Test actual toolkit format: ref is a string, id and name are top-level
 	testData := &toolkitchar.Data{
 		ID:    "test-char",
 		Name:  "Barbarian",
 		Level: 1,
 		Features: []json.RawMessage{
 			json.RawMessage(`{
-				"ref": {"value": "rage"},
+				"ref": "dnd5e:features:rage",
+				"id": "rage",
 				"name": "Rage",
-				"level": 1
+				"level": 1,
+				"uses": 2,
+				"max_uses": 2
 			}`),
 		},
 	}
 
-	// Convert to proto - should use ref.value as ID fallback
 	result := ConvertCharacterDataToProto(testData)
 
-	// Verify feature uses fallback ID
 	require.NotNil(s.T(), result, "Result should not be nil")
 	require.Len(s.T(), result.Features, 1, "Should have 1 feature")
-	assert.Equal(s.T(), "rage", result.Features[0].Id, "Should use ref.value as fallback ID")
+	assert.Equal(s.T(), "rage", result.Features[0].Id)
+	assert.Equal(s.T(), "Rage", result.Features[0].Name)
 }
 
 func (s *ConvertersTestSuite) TestGetFeatureDisplayName() {


### PR DESCRIPTION
## Summary
- Fix feature converter to parse actual toolkit JSON format
- Toolkit stores `ref` as string "dnd5e:features:rage", not object
- Converter now reads `id` and `name` directly from top-level fields

## Problem
GetCharacter was returning empty features array even though features were correctly stored in Redis. The converter expected `ref.value` as an object but toolkit serializes ref as a string.

## Test plan
- [x] Unit tests updated to use actual toolkit format
- [x] Manually verified with Barbarian character - Rage feature now appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)