### PR TITLE
Wire orchestrator to use EventProcessor

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -34,12 +34,14 @@ import (
 	encounterorc "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/clock"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
+	eventprocessor "github.com/KirkDiggler/rpg-api/internal/processors/event"
 	encounterpub "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/redis"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	characterdraftrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 	dicesessionrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 	dungeonsrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
+	encounterlogrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog"
 	encountersrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 )
 
@@ -143,6 +145,9 @@ func runServer(_ *cobra.Command, _ []string) error {
 	dungeonRepo := dungeonsrepo.NewInMemory()
 	dungeonGen := dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{})
 
+	// Create encounter log repository (in-memory for now)
+	encounterLogRepo := encounterlogrepo.NewInMemory(nil)
+
 	// Create encounter event publisher
 	encounterPublisher, err := encounterpub.NewRedis(&encounterpub.RedisConfig{
 		Client: mustRedisClient(),
@@ -151,14 +156,22 @@ func runServer(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create encounter publisher: %w", err)
 	}
 
+	// Create event processor for persisting and publishing events
+	eventProc, err := eventprocessor.New(&eventprocessor.Config{
+		EncounterLogRepo: encounterLogRepo,
+		Publisher:        encounterPublisher,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create event processor: %w", err)
+	}
+
 	// Create encounter orchestrator with dungeon support
 	encounterService, err := encounterorc.New(&encounterorc.Config{
-		CharacterRepo: charRepo,
-		EncounterRepo: encounterRepo,
-		DungeonRepo:   dungeonRepo,
-		DungeonGen:    dungeonGen,
-		Publisher:     encounterPublisher,
-		EventIDGen:    idgen.NewULID(""),
+		CharacterRepo:  charRepo,
+		EncounterRepo:  encounterRepo,
+		DungeonRepo:    dungeonRepo,
+		DungeonGen:     dungeonGen,
+		EventProcessor: eventProc,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create encounter service: %w", err)

--- a/internal/orchestrators/encounter/event_publishing_test.go
+++ b/internal/orchestrators/encounter/event_publishing_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 
 	"github.com/KirkDiggler/rpg-api/internal/entities"
-	encounterpub "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
-	publishermock "github.com/KirkDiggler/rpg-api/internal/publishers/encounter/mock"
+	eventprocessor "github.com/KirkDiggler/rpg-api/internal/processors/event"
+	eventmock "github.com/KirkDiggler/rpg-api/internal/processors/event/mock"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
 	encounterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
@@ -28,25 +28,24 @@ import (
 // when orchestrator methods are called
 type EventPublishingTestSuite struct {
 	suite.Suite
-	ctrl          *gomock.Controller
-	mockCharRepo  *charactermock.MockRepository
-	mockEncRepo   *encountermock.MockRepository
-	mockPublisher *publishermock.MockPublisher
-	orchestrator  *Orchestrator
+	ctrl               *gomock.Controller
+	mockCharRepo       *charactermock.MockRepository
+	mockEncRepo        *encountermock.MockRepository
+	mockEventProcessor *eventmock.MockProcessor
+	orchestrator       *Orchestrator
 }
 
 func (s *EventPublishingTestSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
 	s.mockEncRepo = encountermock.NewMockRepository(s.ctrl)
-	s.mockPublisher = publishermock.NewMockPublisher(s.ctrl)
+	s.mockEventProcessor = eventmock.NewMockProcessor(s.ctrl)
 
 	var err error
 	s.orchestrator, err = New(&Config{
-		CharacterRepo: s.mockCharRepo,
-		EncounterRepo: s.mockEncRepo,
-		Publisher:     s.mockPublisher,
-		EventIDGen:    &mockEventIDGen{prefix: "evt"},
+		CharacterRepo:  s.mockCharRepo,
+		EncounterRepo:  s.mockEncRepo,
+		EventProcessor: s.mockEventProcessor,
 	})
 	s.Require().NoError(err)
 }
@@ -57,17 +56,6 @@ func (s *EventPublishingTestSuite) TearDownTest() {
 
 func TestEventPublishingSuite(t *testing.T) {
 	suite.Run(t, new(EventPublishingTestSuite))
-}
-
-// mockEventIDGen generates predictable event IDs for testing
-type mockEventIDGen struct {
-	prefix string
-	count  int
-}
-
-func (m *mockEventIDGen) Generate() string {
-	m.count++
-	return m.prefix + "-" + string(rune('0'+m.count))
 }
 
 // lastEventIDUpdateMatcher matches Update calls that only set LastEventID
@@ -159,10 +147,10 @@ func (s *EventPublishingTestSuite) TestJoinEncounter_PublishesPlayerJoinedEvent(
 			},
 		}, nil)
 
-	// Expect PlayerJoined event to be published
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	// Expect PlayerJoined event to be processed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypePlayerJoined, input.Event.Type)
 
@@ -174,7 +162,7 @@ func (s *EventPublishingTestSuite) TestJoinEncounter_PublishesPlayerJoinedEvent(
 			s.Require().NotNil(input.Event.PlayerJoined.CharacterData, "CharacterData should be set")
 			s.Assert().Equal("Test Character", input.Event.PlayerJoined.CharacterData.Name)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -223,10 +211,10 @@ func (s *EventPublishingTestSuite) TestSetReady_PublishesPlayerReadyEvent() {
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// Expect PlayerReady event to be published
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	// Expect PlayerReady event to be processed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypePlayerReady, input.Event.Type)
 
@@ -236,7 +224,7 @@ func (s *EventPublishingTestSuite) TestSetReady_PublishesPlayerReadyEvent() {
 			s.Assert().Equal(characterID, input.Event.PlayerReady.CharacterID)
 			s.Assert().True(input.Event.PlayerReady.Ready)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -312,10 +300,10 @@ func (s *EventPublishingTestSuite) TestStartCombat_PublishesCombatStartedEvent()
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil).
 		AnyTimes()
 
-	// Expect CombatStarted event to be published
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	// Expect CombatStarted event to be processed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypeCombatStarted, input.Event.Type)
 
@@ -323,7 +311,7 @@ func (s *EventPublishingTestSuite) TestStartCombat_PublishesCombatStartedEvent()
 			s.Require().NotNil(input.Event.CombatStarted, "CombatStarted should be set")
 			s.Assert().NotNil(input.Event.CombatStarted.CombatState)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Act
@@ -370,10 +358,10 @@ func (s *EventPublishingTestSuite) TestLeaveEncounter_PublishesPlayerLeftEvent()
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// Expect PlayerLeft event to be published
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	// Expect PlayerLeft event to be processed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypePlayerLeft, input.Event.Type)
 
@@ -383,7 +371,7 @@ func (s *EventPublishingTestSuite) TestLeaveEncounter_PublishesPlayerLeftEvent()
 			s.Assert().Equal(characterID, input.Event.PlayerLeft.CharacterID)
 			s.Assert().Equal("voluntary", input.Event.PlayerLeft.Reason)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -449,10 +437,10 @@ func (s *EventPublishingTestSuite) TestMoveCharacter_PublishesMovementCompletedE
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// Expect MovementCompleted event to be published
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	// Expect MovementCompleted event to be processed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypeMovementCompleted, input.Event.Type)
 
@@ -462,7 +450,7 @@ func (s *EventPublishingTestSuite) TestMoveCharacter_PublishesMovementCompletedE
 			s.Assert().Equal("character", input.Event.MovementCompleted.EntityType)
 			s.Assert().Equal("completed", input.Event.MovementCompleted.StopReason)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -517,10 +505,10 @@ func (s *EventPublishingTestSuite) TestEndTurn_PublishesTurnEndedEvent() {
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// Expect TurnEnded event to be published
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	// Expect TurnEnded event to be processed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypeTurnEnded, input.Event.Type)
 
@@ -531,7 +519,7 @@ func (s *EventPublishingTestSuite) TestEndTurn_PublishesTurnEndedEvent() {
 			s.Assert().Equal(1, input.Event.TurnEnded.Round)
 			s.Assert().False(input.Event.TurnEnded.NewRound)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -644,10 +632,10 @@ func (s *EventPublishingTestSuite) TestPublishing_ContinuesOnPublishError() {
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// Publisher returns error - but operation should still succeed
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		Return(nil, errors.New("publish failed")) // Using any error for testing
+	// EventProcessor returns error - but operation should still succeed
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("process failed")) // Using any error for testing
 
 	// Act - should NOT fail even though publish failed
 	output, err := s.orchestrator.SetReady(context.Background(), &SetReadyInput{
@@ -662,12 +650,12 @@ func (s *EventPublishingTestSuite) TestPublishing_ContinuesOnPublishError() {
 	s.Assert().True(output.Success)
 }
 
-func (s *EventPublishingTestSuite) TestNoPublisher_DoesNotPanic() {
-	// Arrange - orchestrator without publisher
-	orchWithoutPublisher, err := New(&Config{
+func (s *EventPublishingTestSuite) TestNoEventProcessor_DoesNotPanic() {
+	// Arrange - orchestrator without event processor
+	orchWithoutEventProcessor, err := New(&Config{
 		CharacterRepo: s.mockCharRepo,
 		EncounterRepo: s.mockEncRepo,
-		// Publisher: nil - intentionally omitted
+		// EventProcessor: nil - intentionally omitted
 	})
 	s.Require().NoError(err)
 
@@ -698,10 +686,10 @@ func (s *EventPublishingTestSuite) TestNoPublisher_DoesNotPanic() {
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// NO publisher expectations - it's nil
+	// NO event processor expectations - it's nil
 
 	// Act - should NOT panic
-	output, err := orchWithoutPublisher.SetReady(context.Background(), &SetReadyInput{
+	output, err := orchWithoutEventProcessor.SetReady(context.Background(), &SetReadyInput{
 		EncounterID: encounterID,
 		PlayerID:    playerID,
 		IsReady:     true,
@@ -737,13 +725,13 @@ func (s *EventPublishingTestSuite) TestLeaveEncounter_LastPlayer_PublishesBefore
 		}, nil)
 
 	// Expect event BEFORE delete
-	publishCalled := false
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
-			publishCalled = true
+	processCalled := false
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
+			processCalled = true
 			s.Assert().Equal(entities.EventTypePlayerLeft, input.Event.Type)
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -751,12 +739,12 @@ func (s *EventPublishingTestSuite) TestLeaveEncounter_LastPlayer_PublishesBefore
 		Update(gomock.Any(), isLastEventIDUpdate(encounterID)).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
-	// Mock Delete (called after publish)
+	// Mock Delete (called after process)
 	s.mockEncRepo.EXPECT().
 		Delete(gomock.Any(), &encounterrepo.DeleteInput{EncounterID: encounterID}).
 		DoAndReturn(func(ctx context.Context, input *encounterrepo.DeleteInput) (*encounterrepo.DeleteOutput, error) {
-			// Verify publish was called before delete
-			s.Assert().True(publishCalled, "publish should be called before delete")
+			// Verify process was called before delete
+			s.Assert().True(processCalled, "process should be called before delete")
 			return &encounterrepo.DeleteOutput{Success: true}, nil
 		})
 
@@ -808,9 +796,9 @@ func (s *EventPublishingTestSuite) TestEndTurn_NewRound_SetsNewRoundFlag() {
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
 	// Expect TurnEnded with NewRound=true
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(entities.EventTypeTurnEnded, input.Event.Type)
 
 			// Verify event data using typed field
@@ -820,7 +808,7 @@ func (s *EventPublishingTestSuite) TestEndTurn_NewRound_SetsNewRoundFlag() {
 			s.Assert().Equal(2, input.Event.TurnEnded.Round)               // Incremented
 			s.Assert().True(input.Event.TurnEnded.NewRound)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -870,12 +858,12 @@ func (s *EventPublishingTestSuite) TestEventTimestamp_IsRecent() {
 	beforeTest := time.Now()
 
 	// Capture timestamp
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			// Verify timestamp is reasonable (within 1 second)
 			s.Assert().WithinDuration(beforeTest, input.Event.Timestamp, time.Second)
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -928,9 +916,9 @@ func (s *EventPublishingTestSuite) TestPlayerDisconnected_PublishesEvent() {
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
 	// Expect PlayerDisconnected event
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypePlayerDisconnected, input.Event.Type)
 
@@ -940,7 +928,7 @@ func (s *EventPublishingTestSuite) TestPlayerDisconnected_PublishesEvent() {
 			s.Assert().Equal(characterID, input.Event.PlayerDisconnected.CharacterID)
 			s.Assert().Equal("timeout", input.Event.PlayerDisconnected.Reason)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -997,22 +985,22 @@ func (s *EventPublishingTestSuite) TestPlayerDisconnected_PausesCombatWhenAllDis
 		})
 
 	// Expect PlayerDisconnected event first
-	firstCall := s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	firstCall := s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(entities.EventTypePlayerDisconnected, input.Event.Type)
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
-	// Expect LastEventID update after first publish
+	// Expect LastEventID update after first process
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), isLastEventIDUpdate(encounterID)).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
 	// Then CombatPaused event
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(entities.EventTypeCombatPaused, input.Event.Type)
 
 			// Verify event data using typed field
@@ -1020,7 +1008,7 @@ func (s *EventPublishingTestSuite) TestPlayerDisconnected_PausesCombatWhenAllDis
 			s.Assert().Equal(playerID, input.Event.CombatPaused.PausedBy)
 			s.Assert().Equal("all players disconnected", input.Event.CombatPaused.Reason)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-2"}, nil
 		}).After(firstCall)
 
 	// Expect LastEventID update after second publish
@@ -1073,9 +1061,9 @@ func (s *EventPublishingTestSuite) TestPlayerReconnected_PublishesEvent() {
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
 	// Expect PlayerReconnected event
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(encounterID, input.EncounterID)
 			s.Assert().Equal(entities.EventTypePlayerReconnected, input.Event.Type)
 
@@ -1084,7 +1072,7 @@ func (s *EventPublishingTestSuite) TestPlayerReconnected_PublishesEvent() {
 			s.Assert().Equal(playerID, input.Event.PlayerReconnected.PlayerID)
 			s.Assert().Equal(characterID, input.Event.PlayerReconnected.CharacterID)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
 	// Expect LastEventID update after publish
@@ -1155,29 +1143,29 @@ func (s *EventPublishingTestSuite) TestPlayerReconnected_ResumesCombat() {
 		})
 
 	// Expect PlayerReconnected event first
-	firstCall := s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	firstCall := s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(entities.EventTypePlayerReconnected, input.Event.Type)
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-1"}, nil
 		})
 
-	// Expect LastEventID update after first publish
+	// Expect LastEventID update after first process
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), isLastEventIDUpdate(encounterID)).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
 
 	// Then CombatResumed event
-	s.mockPublisher.EXPECT().
-		Publish(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *encounterpub.PublishInput) (*encounterpub.PublishOutput, error) {
+	s.mockEventProcessor.EXPECT().
+		Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, input *eventprocessor.ProcessInput) (*eventprocessor.ProcessOutput, error) {
 			s.Assert().Equal(entities.EventTypeCombatResumed, input.Event.Type)
 
 			// Verify event data using typed field
 			s.Require().NotNil(input.Event.CombatResumed, "CombatResumed should be set")
 			s.Assert().Equal(playerID, input.Event.CombatResumed.ResumedBy)
 
-			return &encounterpub.PublishOutput{}, nil
+			return &eventprocessor.ProcessOutput{EventID: "evt-2"}, nil
 		}).After(firstCall)
 
 	// Expect LastEventID update after second publish

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -26,7 +26,7 @@ import (
 	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
-	encounterpub "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
+	eventprocessor "github.com/KirkDiggler/rpg-api/internal/processors/event"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	dungeonrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
 	encounterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
@@ -36,13 +36,12 @@ import (
 type Config struct {
 	CharacterRepo   characterrepo.Repository
 	EncounterRepo   encounterrepo.Repository
-	DungeonRepo     dungeonrepo.Repository // Optional: for dungeon persistence
-	DungeonGen      *dungeon.Generator     // Optional: for procedural dungeon generation
-	Publisher       encounterpub.Publisher // Optional: for publishing encounter events
-	EventIDGen      idgen.Generator        // Optional: for generating event IDs (defaults to ULID)
-	EncounterIDGen  idgen.Generator        // Optional: for generating encounter IDs (defaults to "enc-" prefix)
-	DungeonIDGen    idgen.Generator        // Optional: for generating dungeon IDs (defaults to "dng-" prefix)
-	ConnectionIDGen idgen.Generator        // Optional: for generating connection IDs (defaults to "conn-" prefix)
+	DungeonRepo     dungeonrepo.Repository   // Optional: for dungeon persistence
+	DungeonGen      *dungeon.Generator       // Optional: for procedural dungeon generation
+	EventProcessor  eventprocessor.Processor // Optional: for persisting and publishing events
+	EncounterIDGen  idgen.Generator          // Optional: for generating encounter IDs (defaults to "enc-" prefix)
+	DungeonIDGen    idgen.Generator          // Optional: for generating dungeon IDs (defaults to "dng-" prefix)
+	ConnectionIDGen idgen.Generator          // Optional: for generating connection IDs (defaults to "conn-" prefix)
 }
 
 // Validate ensures all required dependencies are present
@@ -63,11 +62,10 @@ type Orchestrator struct {
 	dungeonRepo     dungeonrepo.Repository // Optional: for dungeon persistence
 	dungeonGen      *dungeon.Generator     // Optional: for procedural dungeon generation
 	roller          dice.Roller
-	publisher       encounterpub.Publisher // Optional: for publishing encounter events
-	eventIDGen      idgen.Generator        // For generating event IDs
-	encounterIDGen  idgen.Generator        // For generating encounter IDs
-	dungeonIDGen    idgen.Generator        // For generating dungeon IDs
-	connectionIDGen idgen.Generator        // For generating connection IDs
+	eventProcessor  eventprocessor.Processor // Optional: for persisting and publishing events
+	encounterIDGen  idgen.Generator          // For generating encounter IDs
+	dungeonIDGen    idgen.Generator          // For generating dungeon IDs
+	connectionIDGen idgen.Generator          // For generating connection IDs
 }
 
 // New creates a new encounter orchestrator
@@ -77,12 +75,6 @@ func New(cfg *Config) (*Orchestrator, error) {
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
-	}
-
-	// Default to ULID generator for event IDs if not provided
-	eventIDGen := cfg.EventIDGen
-	if eventIDGen == nil {
-		eventIDGen = idgen.NewULID("")
 	}
 
 	// Default to prefixed generators for encounter/dungeon/connection IDs if not provided
@@ -105,25 +97,22 @@ func New(cfg *Config) (*Orchestrator, error) {
 		dungeonRepo:     cfg.DungeonRepo,
 		dungeonGen:      cfg.DungeonGen,
 		roller:          dice.NewRoller(),
-		publisher:       cfg.Publisher,
-		eventIDGen:      eventIDGen,
+		eventProcessor:  cfg.EventProcessor,
 		encounterIDGen:  encounterIDGen,
 		dungeonIDGen:    dungeonIDGen,
 		connectionIDGen: connectionIDGen,
 	}, nil
 }
 
-// publishEvent publishes an event if publisher is configured.
+// publishEvent persists and publishes an event if EventProcessor is configured.
 // Also updates the encounter's LastEventID for the load-then-stream pattern.
 // Errors are logged but not returned to avoid breaking combat flow.
 func (o *Orchestrator) publishEvent(ctx context.Context, encounterID string, eventType entities.EventType, data interface{}) {
-	if o.publisher == nil {
+	if o.eventProcessor == nil {
 		return
 	}
 
-	eventID := o.eventIDGen.Generate()
 	event := &entities.EncounterEvent{
-		ID:          eventID,
 		Type:        eventType,
 		EncounterID: encounterID,
 		Timestamp:   time.Now(),
@@ -168,20 +157,21 @@ func (o *Orchestrator) publishEvent(ctx context.Context, encounterID string, eve
 		return
 	}
 
-	_, err := o.publisher.Publish(ctx, &encounterpub.PublishInput{
+	// Process persists to encounter log and publishes to subscribers
+	output, err := o.eventProcessor.Process(ctx, &eventprocessor.ProcessInput{
 		EncounterID: encounterID,
 		Event:       event,
 	})
 	if err != nil {
-		// Log but don't fail - event publishing is non-critical
-		fmt.Printf("failed to publish %s event for encounter %s: %v\n", eventType, encounterID, err)
+		// Log but don't fail - event processing is non-critical to combat flow
+		fmt.Printf("failed to process %s event for encounter %s: %v\n", eventType, encounterID, err)
 		return
 	}
 
 	// Update LastEventID in the encounter record for load-then-stream pattern
 	_, err = o.encRepo.Update(ctx, &encounterrepo.UpdateInput{
 		EncounterID: encounterID,
-		LastEventID: &eventID,
+		LastEventID: &output.EventID,
 	})
 	if err != nil {
 		// Log but don't fail - this is non-critical for the current operation


### PR DESCRIPTION
## Summary
- Replaced direct Publisher calls with EventProcessor in the encounter orchestrator
- EventProcessor now handles event persistence (to encounterlog repository) and publishing
- Removed EventIDGen from orchestrator since repository generates event IDs via ULID
- Wired EventProcessor with in-memory encounterlog repository in server initialization

## Changes
- Updated `Config` struct: replaced `Publisher` with `EventProcessor`, removed `EventIDGen`
- Updated `publishEvent` method to call `EventProcessor.Process()` instead of `Publisher.Publish()`
- Updated server wiring to create encounterlog repository and event processor
- Updated all event publishing tests to mock EventProcessor

## Flow After This Change
```
Orchestrator → EventProcessor → EncounterLogRepository (persist) + Publisher (SSE)
```

## Test plan
- [x] All existing event publishing tests pass with EventProcessor mock
- [x] Pre-commit passes (lint + tests)
- [x] Server compiles and wires dependencies correctly

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)