### PR TITLE
feat: Use dungeon generator for combat, fix spawn coordinate conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-api
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251220052702-f6a1894a76ec
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251220072911-0e78e0cfc17e
 	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251219125259-b1f685b8ebc3 h1:/LFNzIMg4dL0frrVf1MMK7YVKRdaPWc09w/6nT3rcms=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251219125259-b1f685b8ebc3/go.mod h1:nnvwwB7Z3PL+U/3XW25DYEojtMilVgkw39MG8y4F9ag=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251220052702-f6a1894a76ec h1:K/a4jh+Hu56tDU4S9+wlez8D5L8RIgYk2GkFM+PVLLk=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251220052702-f6a1894a76ec/go.mod h1:nnvwwB7Z3PL+U/3XW25DYEojtMilVgkw39MG8y4F9ag=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251220072911-0e78e0cfc17e h1:dGxK84wFOVOImXTW1A1Vf6COWGXlmDKoBSx9GIxrmJc=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251220072911-0e78e0cfc17e/go.mod h1:nnvwwB7Z3PL+U/3XW25DYEojtMilVgkw39MG8y4F9ag=
 github.com/KirkDiggler/rpg-toolkit/core v0.9.6 h1:Mqd7jxxiXOfD0vQYzoOrtoa+fqKbVGIY5/Oo7pqbGBk=
 github.com/KirkDiggler/rpg-toolkit/core v0.9.6/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
@@ -14,10 +12,6 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.32.1 h1:pYxNUkFjWk/TRJE7L1eR/4yuKUWLBBsmFT1jnWL26pY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.32.1/go.mod h1:EHwAU/BFTH9MyGXz1gfJDC5EPZHYOcHAX3oQeW58yvA=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.33.0 h1:qK3//O4BoqZMxbabEU3Rz2sCzZKPL5ur6AwFAD9+Lnk=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.33.0/go.mod h1:EHwAU/BFTH9MyGXz1gfJDC5EPZHYOcHAX3oQeW58yvA=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.34.0 h1:uwbuj+uhT/RejcsH3IxM/CZpYSqbEE/DN/UfSZtr55A=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.34.0/go.mod h1:EHwAU/BFTH9MyGXz1gfJDC5EPZHYOcHAX3oQeW58yvA=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2 h1:warO6dvk/Ymyc3lnVU7x1xIM0T6dw7h6DQ8Clz4z/PI=

--- a/internal/components/dungeon/encounter/budget.go
+++ b/internal/components/dungeon/encounter/budget.go
@@ -22,7 +22,12 @@ type BudgetOutput struct {
 	RoomBudgets []float64
 }
 
-// AllocateBudget distributes CR across dungeon rooms with boss room priority
+// MinimumRoomCR is the minimum CR budget per room to ensure at least one monster can spawn.
+// Based on the cheapest monsters in theme pools (Skeleton at CR 0.25).
+const MinimumRoomCR = 0.25
+
+// AllocateBudget distributes CR across dungeon rooms with boss room priority.
+// Ensures each room has at least MinimumRoomCR to spawn at least one monster.
 func AllocateBudget(input *BudgetInput) (*BudgetOutput, error) {
 	if input == nil {
 		return nil, fmt.Errorf("input is required")
@@ -46,12 +51,6 @@ func AllocateBudget(input *BudgetInput) (*BudgetOutput, error) {
 		totalCR = float64(input.PartySize) * input.TargetCR
 	}
 
-	// Allocate 40% to boss room
-	bossRoomBudget := totalCR * 0.4
-
-	// Remaining 60% distributed across regular rooms
-	remainingBudget := totalCR * 0.6
-
 	// Calculate number of regular rooms (total - 1 boss room)
 	regularRoomCount := input.RoomCount - 1
 	if regularRoomCount <= 0 {
@@ -61,6 +60,22 @@ func AllocateBudget(input *BudgetInput) (*BudgetOutput, error) {
 			RoomBudgets:    []float64{},
 		}, nil
 	}
+
+	// Ensure minimum total CR so every room can have at least one monster
+	// Minimum = (regularRoomCount * MinimumRoomCR) + MinimumRoomCR for boss
+	minimumTotalCR := float64(regularRoomCount+1) * MinimumRoomCR
+	if totalCR < minimumTotalCR {
+		totalCR = minimumTotalCR
+	}
+
+	// Allocate 40% to boss room (but at least MinimumRoomCR)
+	bossRoomBudget := totalCR * 0.4
+	if bossRoomBudget < MinimumRoomCR {
+		bossRoomBudget = MinimumRoomCR
+	}
+
+	// Remaining budget distributed across regular rooms
+	remainingBudget := totalCR - bossRoomBudget
 
 	// Progressive scaling: later rooms are harder
 	// Use weighted distribution where room weight = 1 + (index / roomCount)
@@ -75,9 +90,13 @@ func AllocateBudget(input *BudgetInput) (*BudgetOutput, error) {
 		totalWeight += weight
 	}
 
-	// Allocate budget proportional to weight
+	// Allocate budget proportional to weight, ensuring minimum per room
 	for i := 0; i < regularRoomCount; i++ {
-		roomBudgets[i] = remainingBudget * (weights[i] / totalWeight)
+		budget := remainingBudget * (weights[i] / totalWeight)
+		if budget < MinimumRoomCR {
+			budget = MinimumRoomCR
+		}
+		roomBudgets[i] = budget
 	}
 
 	return &BudgetOutput{

--- a/internal/components/dungeon/encounter/selector.go
+++ b/internal/components/dungeon/encounter/selector.go
@@ -119,6 +119,18 @@ func (s *selector) selectRegularEncounter(input *SelectInput, rng *rand.Rand) *S
 	totalCR := 0.0
 	remainingBudget := input.Budget
 
+	// For low budgets, skip role distribution and just fill with any affordable monster
+	// This ensures at least one monster spawns when budget is tight
+	cheapestMonsterCR := s.getCheapestMonsterCR(input.Pool)
+	if remainingBudget < cheapestMonsterCR*2 {
+		// Not enough budget for role-based distribution, just fill with any affordable
+		monsters, totalCR = s.fillRoleSlot(monsters, totalCR, input.Pool, remainingBudget, rng)
+		return &SelectOutput{
+			Monsters: monsters,
+			TotalCR:  totalCR,
+		}
+	}
+
 	// Determine role distribution based on CR budget
 	roleDistribution := s.getRoleDistribution(input.Budget)
 
@@ -141,10 +153,29 @@ func (s *selector) selectRegularEncounter(input *SelectInput, rng *rand.Rand) *S
 	// Select support monsters
 	monsters, totalCR = s.fillRoleSlot(monsters, totalCR, supportMonsters, supportBudget, rng)
 
+	// If no monsters were selected (role budgets too small), fall back to any affordable
+	if len(monsters) == 0 {
+		monsters, totalCR = s.fillRoleSlot(monsters, totalCR, input.Pool, remainingBudget, rng)
+	}
+
 	return &SelectOutput{
 		Monsters: monsters,
 		TotalCR:  totalCR,
 	}
+}
+
+// getCheapestMonsterCR returns the lowest CR monster in the pool
+func (s *selector) getCheapestMonsterCR(pool []dungeon.MonsterRef) float64 {
+	if len(pool) == 0 {
+		return 0
+	}
+	cheapest := pool[0].CR
+	for _, m := range pool {
+		if m.CR < cheapest {
+			cheapest = m.CR
+		}
+	}
+	return cheapest
 }
 
 // roleDistribution defines percentage allocation for each role

--- a/internal/components/dungeon/toolkit/feature.go
+++ b/internal/components/dungeon/toolkit/feature.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
 	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
 )
 
@@ -167,70 +169,79 @@ func getTerrainMovementCost(terrainType dungeon.TerrainType) float64 {
 	}
 }
 
+// gridToCube converts a grid position (col, row) to cube coordinates using toolkit's converter.
+// This ensures we always use the same conversion logic as the toolkit.
+func gridToCube(col, row int) dungeon.Position {
+	// Use toolkit's standard offset-to-cube conversion
+	cube := spatial.OffsetCoordinateToCube(spatial.Position{X: float64(col), Y: float64(row)})
+	return dungeon.Position{X: cube.X, Y: cube.Y, Z: cube.Z}
+}
+
 // generateSpawnZones creates spawn zones based on room type
+// All positions use cube coordinates via toolkit's converter
 func (g *ToolkitFeatureGenerator) generateSpawnZones(shape *dungeon.Shape, roomType string) []dungeon.Zone {
 	var zones []dungeon.Zone
 
 	switch roomType {
 	case "entrance":
-		// Entrance rooms have a player spawn zone near the entrance
+		// Entrance rooms have a player spawn zone near the entrance (bottom-left area)
+		// Generate individual spawn positions for up to 4 players
 		zones = append(zones, dungeon.Zone{
 			ID:   uuid.New().String(),
 			Type: dungeon.ZoneTypePlayerSpawn,
 			Bounds: []dungeon.Position{
-				{X: 0, Y: 0, Z: 0},
-				{X: 3, Y: 0, Z: 0},
-				{X: 3, Y: 3, Z: 0},
-				{X: 0, Y: 3, Z: 0},
+				gridToCube(1, 1),
+				gridToCube(2, 1),
+				gridToCube(1, 2),
+				gridToCube(2, 2),
 			},
 			Capacity: 4, // Standard party size
 		})
 
 	case "boss":
 		// Boss rooms have a boss zone in the center and monster spawn zones around it
-		centerX := shape.Width / 2
-		centerY := shape.Height / 2
+		centerCol := shape.Width / 2
+		centerRow := shape.Height / 2
 
-		// Boss zone in center and monster spawn zones in corners
+		// Boss zone - single position in center
 		zones = append(zones,
 			dungeon.Zone{
 				ID:   uuid.New().String(),
 				Type: dungeon.ZoneTypeBoss,
 				Bounds: []dungeon.Position{
-					{X: centerX - 2, Y: centerY - 2, Z: 0},
-					{X: centerX + 2, Y: centerY - 2, Z: 0},
-					{X: centerX + 2, Y: centerY + 2, Z: 0},
-					{X: centerX - 2, Y: centerY + 2, Z: 0},
+					gridToCube(centerCol, centerRow),
 				},
 				Capacity: 1,
 			},
+			// Monster spawn zone - positions in upper area
 			dungeon.Zone{
 				ID:   uuid.New().String(),
 				Type: dungeon.ZoneTypeMonsterSpawn,
 				Bounds: []dungeon.Position{
-					{X: 0, Y: 0, Z: 0},
-					{X: 4, Y: 0, Z: 0},
-					{X: 4, Y: 4, Z: 0},
-					{X: 0, Y: 4, Z: 0},
+					gridToCube(centerCol-2, centerRow-2),
+					gridToCube(centerCol, centerRow-2),
+					gridToCube(centerCol+2, centerRow-2),
 				},
 				Capacity: 3,
 			},
 		)
 
 	default:
-		// Regular rooms have monster spawn zones
-		// Place spawn zone in the center
-		centerX := shape.Width / 2
-		centerY := shape.Height / 2
+		// Regular rooms have monster spawn zones in the center area
+		centerCol := shape.Width / 2
+		centerRow := shape.Height / 2
 
+		// Generate individual spawn positions for monsters
 		zones = append(zones, dungeon.Zone{
 			ID:   uuid.New().String(),
 			Type: dungeon.ZoneTypeMonsterSpawn,
 			Bounds: []dungeon.Position{
-				{X: centerX - 3, Y: centerY - 3, Z: 0},
-				{X: centerX + 3, Y: centerY - 3, Z: 0},
-				{X: centerX + 3, Y: centerY + 3, Z: 0},
-				{X: centerX - 3, Y: centerY + 3, Z: 0},
+				gridToCube(centerCol-1, centerRow-1),
+				gridToCube(centerCol, centerRow-1),
+				gridToCube(centerCol+1, centerRow-1),
+				gridToCube(centerCol-1, centerRow),
+				gridToCube(centerCol+1, centerRow),
+				gridToCube(centerCol, centerRow+1),
 			},
 			Capacity: 6,
 		})

--- a/internal/entities/encounter_events.go
+++ b/internal/entities/encounter_events.go
@@ -100,11 +100,21 @@ type PlayerReconnectedEvent struct {
 	CharacterID string `json:"character_id"`
 }
 
+// MonsterState represents a monster's combat state for events
+type MonsterState struct {
+	MonsterID        string `json:"monster_id"`         // Unique ID of this monster instance
+	MonsterName      string `json:"monster_name"`       // Display name (e.g., "Skeleton")
+	CurrentHitPoints int    `json:"current_hit_points"` // Current HP
+	MaxHitPoints     int    `json:"max_hit_points"`     // Maximum HP
+	MonsterType      string `json:"monster_type"`       // Type for UI texture (e.g., "skeleton", "goblin")
+}
+
 // CombatStartedEvent is emitted when combat begins
 type CombatStartedEvent struct {
 	CombatState *CombatState      `json:"combat_state"` // Full combat state including initiative order
 	Room        *spatial.RoomData `json:"room"`         // Room with entity positions
 	Party       []*Player         `json:"party"`        // Party members at combat start
+	Monsters    []*MonsterState   `json:"monsters"`     // Monster state with types for UI textures
 }
 
 // CombatEndedEvent is emitted when combat ends

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -14,6 +14,7 @@ import (
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
 	apierrors "github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
+	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	characterhandler "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v1alpha1/character"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
@@ -723,6 +724,21 @@ func (h *Handler) convertToProtoEvent(event *entities.EncounterEvent) (*dnd5ev1a
 				}
 			}
 		}
+		// Convert monsters for event
+		var protoMonsters []*dnd5ev1alpha1.MonsterCombatState
+		if event.CombatStarted.Monsters != nil {
+			protoMonsters = make([]*dnd5ev1alpha1.MonsterCombatState, len(event.CombatStarted.Monsters))
+			for i, m := range event.CombatStarted.Monsters {
+				protoMonsters[i] = &dnd5ev1alpha1.MonsterCombatState{
+					MonsterId:        m.MonsterID,
+					MonsterName:      m.MonsterName,
+					CurrentHitPoints: int32(m.CurrentHitPoints),
+					MaxHitPoints:     int32(m.MaxHitPoints),
+					MonsterType:      dungeon.MonsterTypeFromID(m.MonsterType),
+				}
+			}
+		}
+
 		// Use default grid settings for event conversion
 		gridType := spatial.GridTypeHex
 		hexOrientation := spatial.HexOrientationPointyTop
@@ -731,6 +747,7 @@ func (h *Handler) convertToProtoEvent(event *entities.EncounterEvent) (*dnd5ev1a
 				CombatState: convertCombatStateToProto(event.CombatStarted.CombatState, gridType, hexOrientation),
 				Room:        convertRoomDataToProto(event.CombatStarted.Room),
 				Party:       protoParty,
+				Monsters:    protoMonsters,
 			},
 		}
 

--- a/internal/orchestrators/encounter/event_publishing_test.go
+++ b/internal/orchestrators/encounter/event_publishing_test.go
@@ -16,11 +16,14 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 
+	dungeontoolkit "github.com/KirkDiggler/rpg-api/internal/components/dungeon/toolkit"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	eventprocessor "github.com/KirkDiggler/rpg-api/internal/processors/event"
 	eventmock "github.com/KirkDiggler/rpg-api/internal/processors/event/mock"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	dungeonrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
+	dungeonmock "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons/mock"
 	encounterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 	encountermock "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/mock"
 )
@@ -32,6 +35,7 @@ type EventPublishingTestSuite struct {
 	ctrl               *gomock.Controller
 	mockCharRepo       *charactermock.MockRepository
 	mockEncRepo        *encountermock.MockRepository
+	mockDungeonRepo    *dungeonmock.MockRepository
 	mockEventProcessor *eventmock.MockProcessor
 	mockRoller         *mock_dice.MockRoller
 	orchestrator       *Orchestrator
@@ -41,16 +45,21 @@ func (s *EventPublishingTestSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
 	s.mockEncRepo = encountermock.NewMockRepository(s.ctrl)
+	s.mockDungeonRepo = dungeonmock.NewMockRepository(s.ctrl)
 	s.mockEventProcessor = eventmock.NewMockProcessor(s.ctrl)
 	s.mockRoller = mock_dice.NewMockRoller(s.ctrl)
 
 	// Default: high rolls ensure players go first in initiative (deterministic tests)
 	s.mockRoller.EXPECT().Roll(gomock.Any(), gomock.Any()).Return(20, nil).AnyTimes()
+	// RollN is used by dungeon generator for monster HP (hit dice)
+	s.mockRoller.EXPECT().RollN(gomock.Any(), gomock.Any(), gomock.Any()).Return([]int{4}, nil).AnyTimes()
 
 	var err error
 	s.orchestrator, err = New(&Config{
 		CharacterRepo:  s.mockCharRepo,
 		EncounterRepo:  s.mockEncRepo,
+		DungeonRepo:    s.mockDungeonRepo,
+		DungeonGen:     dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{}),
 		EventProcessor: s.mockEventProcessor,
 		Roller:         s.mockRoller,
 	})
@@ -300,6 +309,11 @@ func (s *EventPublishingTestSuite) TestStartCombat_PublishesCombatStartedEvent()
 				},
 			},
 		}, nil).AnyTimes()
+
+	// Mock dungeon repo save (dungeon is generated when combat starts)
+	s.mockDungeonRepo.EXPECT().
+		Save(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.SaveOutput{Success: true}, nil)
 
 	// Mock Update (may be called multiple times if monster goes first)
 	s.mockEncRepo.EXPECT().
@@ -662,6 +676,8 @@ func (s *EventPublishingTestSuite) TestNoEventProcessor_DoesNotPanic() {
 	orchWithoutEventProcessor, err := New(&Config{
 		CharacterRepo: s.mockCharRepo,
 		EncounterRepo: s.mockEncRepo,
+		DungeonRepo:   s.mockDungeonRepo,
+		DungeonGen:    dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{}),
 		// EventProcessor: nil - intentionally omitted
 	})
 	s.Require().NoError(err)

--- a/internal/orchestrators/encounter/open_door_test.go
+++ b/internal/orchestrators/encounter/open_door_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
+	dungeontoolkit "github.com/KirkDiggler/rpg-api/internal/components/dungeon/toolkit"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
@@ -47,6 +48,7 @@ func (s *OpenDoorTestSuite) SetupTest() {
 		CharacterRepo: s.mockCharRepo,
 		EncounterRepo: s.mockEncRepo,
 		DungeonRepo:   s.mockDungeonRepo,
+		DungeonGen:    dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{}),
 	})
 	s.Require().NoError(err)
 	s.orchestrator = orc

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -37,8 +37,8 @@ import (
 type Config struct {
 	CharacterRepo    characterrepo.Repository
 	EncounterRepo    encounterrepo.Repository
-	DungeonRepo      dungeonrepo.Repository      // Optional: for dungeon persistence
-	DungeonGen       *dungeon.Generator          // Optional: for procedural dungeon generation
+	DungeonRepo      dungeonrepo.Repository      // Required: for dungeon persistence
+	DungeonGen       *dungeon.Generator          // Required: for procedural dungeon generation
 	EventProcessor   eventprocessor.Processor    // Optional: for persisting and publishing events
 	EncounterLogRepo encounterlogrepo.Repository // Optional: for reading event history
 	Roller           dice.Roller                 // Optional: for dice rolls (defaults to random roller)
@@ -55,6 +55,12 @@ func (c *Config) Validate() error {
 	if c.EncounterRepo == nil {
 		return fmt.Errorf("EncounterRepo is required")
 	}
+	if c.DungeonRepo == nil {
+		return fmt.Errorf("DungeonRepo is required")
+	}
+	if c.DungeonGen == nil {
+		return fmt.Errorf("DungeonGen is required")
+	}
 	return nil
 }
 
@@ -62,8 +68,8 @@ func (c *Config) Validate() error {
 type Orchestrator struct {
 	charRepo         characterrepo.Repository
 	encRepo          encounterrepo.Repository
-	dungeonRepo      dungeonrepo.Repository // Optional: for dungeon persistence
-	dungeonGen       *dungeon.Generator     // Optional: for procedural dungeon generation
+	dungeonRepo      dungeonrepo.Repository // Required: for dungeon persistence
+	dungeonGen       *dungeon.Generator     // Required: for procedural dungeon generation
 	roller           dice.Roller
 	eventProcessor   eventprocessor.Processor    // Optional: for persisting and publishing events
 	encounterLogRepo encounterlogrepo.Repository // Optional: for reading event history
@@ -412,230 +418,7 @@ func (o *Orchestrator) CreateDungeon(ctx context.Context, input *CreateDungeonIn
 	// Generate unique encounter ID
 	encounterID := o.encounterIDGen.Generate()
 
-	// If dungeon generator is available, use it for procedural generation
-	if o.dungeonGen != nil {
-		return o.createDungeonWithGenerator(ctx, encounterID, input)
-	}
-
-	// Fallback: Create hardcoded room for backwards compatibility
-	// Create initial room data (20x20 hex grid)
-	roomData := &spatial.RoomData{
-		ID:       encounterID + "-room",
-		Type:     "dungeon",
-		Width:    20,
-		Height:   20,
-		GridType: spatial.GridTypeHex,
-		Entities: make(map[string]spatial.EntityPlacement),
-	}
-
-	// Add goblin target dummy at fixed position (center of room)
-	goblinID := "goblin-dummy"
-	roomData.Entities[goblinID] = spatial.EntityPlacement{
-		EntityID:       goblinID,
-		EntityType:     "monster",
-		Position:       spatial.Position{X: 10, Y: 10}, // Center of room
-		Size:           1,
-		BlocksMovement: true,
-	}
-
-	// Define 4 spawn points close to the goblin (within 30ft/6 squares movement)
-	// Players can move and attack on turn 1
-	spawnPoints := []spatial.Position{
-		{X: 5, Y: 8},  // 5 squares from goblin - reachable in one move
-		{X: 5, Y: 10}, // 5 squares from goblin
-		{X: 5, Y: 12}, // 5 squares from goblin
-		{X: 4, Y: 10}, // 6 squares from goblin - just reachable
-	}
-
-	// Place characters at spawn points (up to 4 characters)
-	for i, characterID := range input.CharacterIDs {
-		if i >= len(spawnPoints) {
-			break // Only place up to 4 characters
-		}
-
-		roomData.Entities[characterID] = spatial.EntityPlacement{
-			EntityID:       characterID,
-			EntityType:     "character",
-			Position:       spawnPoints[i],
-			Size:           1,
-			BlocksMovement: true,
-		}
-	}
-
-	// Add some static walls/obstacles for navigation
-	// Create a simple layout with pillars around the edges
-	obstacles := []spatial.Position{
-		{X: 3, Y: 3},   // Top-left pillar
-		{X: 3, Y: 17},  // Bottom-left pillar
-		{X: 17, Y: 3},  // Top-right pillar
-		{X: 17, Y: 17}, // Bottom-right pillar
-	}
-
-	for i, pos := range obstacles {
-		obstacleID := fmt.Sprintf("pillar-%d", i)
-		roomData.Entities[obstacleID] = spatial.EntityPlacement{
-			EntityID:       obstacleID,
-			EntityType:     "obstacle",
-			Position:       pos,
-			Size:           1,
-			BlocksMovement: true,
-		}
-	}
-
-	// Roll initiative for all combatants
-	combatants := make(map[core.Entity]int)
-
-	// Initialize CharacterHP map for TPK tracking
-	characterHP := make(map[string]int)
-
-	// Add characters with their DEX modifiers
-	for _, characterID := range input.CharacterIDs {
-		// Load character to get DEX modifier
-		charOutput, err := o.charRepo.Get(ctx, characterrepo.GetInput{ID: characterID})
-		if err != nil {
-			return nil, fmt.Errorf("failed to load character %s: %w", characterID, err)
-		}
-
-		// Calculate DEX modifier from ability scores
-		dexModifier := charOutput.CharacterData.AbilityScores.Modifier(abilities.DEX)
-
-		// Track character's current HP for TPK detection
-		characterHP[characterID] = charOutput.CharacterData.HitPoints
-
-		// Create participant entity
-		char := initiative.NewParticipant(characterID, "character")
-		combatants[char] = dexModifier
-	}
-
-	// Add goblin with hardcoded DEX modifier
-	goblin := initiative.NewParticipant(goblinID, "monster")
-	combatants[goblin] = 2 // Goblin DEX +2
-
-	// Roll initiative using rpg-toolkit
-	rolls := initiative.RollForOrder(combatants, o.roller)
-
-	// Create tracker and extract data
-	initiativeOrder := make([]core.Entity, len(rolls))
-	for i, roll := range rolls {
-		initiativeOrder[i] = roll.Entity
-	}
-	tracker := initiative.New(initiativeOrder)
-	trackerData := tracker.ToData()
-
-	// Convert rolls to service layer InitiativeEntry with positions from room
-	turnOrder := make([]InitiativeEntry, len(rolls))
-	for i, roll := range rolls {
-		entityID := roll.Entity.GetID()
-
-		// Get position from room data
-		var position *Position
-		if placement, exists := roomData.Entities[entityID]; exists {
-			position = &Position{
-				X: placement.Position.X,
-				Y: placement.Position.Y,
-			}
-		}
-
-		turnOrder[i] = InitiativeEntry{
-			EntityID:           entityID,
-			EntityType:         string(roll.Entity.GetType()),
-			InitiativeRoll:     roll.Roll,
-			InitiativeModifier: roll.Modifier,
-			InitiativeTotal:    roll.Total,
-			Position:           position,
-		}
-	}
-
-	// Create combat state with fresh action economy
-	combatState := &CombatState{
-		EncounterID:       encounterID,
-		Round:             1,
-		TurnOrder:         turnOrder,
-		ActiveIndex:       0,
-		MovementRemaining: 30,                               // Default movement speed for D&D 5e
-		ActionEconomy:     entities.NewActionEconomyState(), // Fresh action economy for first turn
-		CombatStarted:     true,
-		CombatEnded:       false,
-	}
-
-	// Create monster data for the goblin with scimitar action
-	goblinMonster := monster.NewGoblin(goblinID)
-	goblinMonster.AddAction(monster.NewScimitarAction(monster.ScimitarConfig{
-		AttackBonus: 4,       // +2 DEX + 2 proficiency
-		DamageDice:  "1d6+2", // Scimitar 1d6 + DEX
-		DamageBonus: 2,       // DEX modifier
-	}))
-	goblinData := goblinMonster.ToData()
-
-	// Save encounter data with room, initiative, monsters, and action economy
-	_, err := o.encRepo.Save(ctx, &encounterrepo.SaveInput{
-		EncounterID:       encounterID,
-		RoomData:          roomData,
-		InitiativeData:    &trackerData,
-		InitiativeRolls:   rolls,
-		MovementRemaining: combatState.MovementRemaining,
-		ActionEconomy:     combatState.ActionEconomy,
-		Monsters:          []*monster.Data{goblinData},
-		CharacterHP:       characterHP,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to save encounter: %w", err)
-	}
-
-	// Check if a monster goes first in initiative
-	var monsterTurns []*MonsterTurnResult
-	if trackerData.Order[0].Type == entityTypeMonster {
-		// Monster(s) go first - execute all monster turns until a player's turn
-		// Create EncounterData for monster turn execution
-		encData := &encounterrepo.EncounterData{
-			ID:                encounterID,
-			RoomData:          roomData,
-			InitiativeData:    &trackerData,
-			InitiativeRolls:   rolls,
-			MovementRemaining: combatState.MovementRemaining,
-			Monsters:          []*monster.Data{goblinData},
-			CharacterHP:       characterHP,
-		}
-
-		// Execute monster turns
-		monsterTurns, err = o.executeMonsterTurns(ctx, encData, input.CharacterIDs)
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute monster turns: %w", err)
-		}
-
-		// Update combat state to reflect the new active index after monster turns
-		combatState.ActiveIndex = encData.InitiativeData.Current
-		combatState.Round = encData.InitiativeData.Round
-
-		// Persist updated initiative, monster state, room positions, and character HP
-		_, err = o.encRepo.Update(ctx, &encounterrepo.UpdateInput{
-			EncounterID:    encounterID,
-			InitiativeData: encData.InitiativeData,
-			Monsters:       encData.Monsters,    // Persist monster HP/state changes
-			RoomData:       encData.RoomData,    // Persist monster position changes
-			CharacterHP:    encData.CharacterHP, // Persist character HP changes from monster attacks
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to save initiative after monster turns: %w", err)
-		}
-
-		// Check for TPK after monster turns
-		o.checkAndHandleFailure(ctx, encounterID, encData)
-	} else {
-		// Player goes first - no monster turns to execute
-		// Active index is already set to the first entity (index 0)
-		combatState.ActiveIndex = 0
-	}
-
-	// Return encounter ID, room data, combat state, and any monster turns
-	return &CreateDungeonOutput{
-		EncounterID:  encounterID,
-		DungeonID:    "", // Empty for fallback path (no generator)
-		Room:         roomData,
-		Doors:        nil, // No doors for fallback path
-		CombatState:  combatState,
-		MonsterTurns: monsterTurns,
-	}, nil
+	return o.createDungeonWithGenerator(ctx, encounterID, input)
 }
 
 // createDungeonWithGenerator uses the procedural generator to create a dungeon
@@ -2534,6 +2317,7 @@ func (o *Orchestrator) SetReady(
 }
 
 // StartCombat begins combat (host only, all players must be ready)
+// Generates a dungeon using the dungeon generator and starts combat in the first room.
 func (o *Orchestrator) StartCombat(
 	ctx context.Context,
 	input *StartCombatInput,
@@ -2574,93 +2358,103 @@ func (o *Orchestrator) StartCombat(
 		}
 	}
 
-	// 6. Collect character IDs and place them in the room
-	roomData, ok := encOutput.Data.RoomData.(*spatial.RoomData)
-	if !ok {
-		return nil, fmt.Errorf("invalid room data type")
-	}
+	// 6. Collect character IDs from players
 	characterIDs := make([]string, 0, len(encOutput.Data.Players))
-
-	// Define spawn points for players using cube coordinates (x + y + z = 0)
-	spawnPoints := []spatial.CubeCoordinate{
-		{X: 5, Y: -13, Z: 8},
-		{X: 5, Y: -15, Z: 10},
-		{X: 5, Y: -17, Z: 12},
-		{X: 4, Y: -14, Z: 10},
-	}
-
-	i := 0
 	for _, player := range encOutput.Data.Players {
 		characterIDs = append(characterIDs, player.CharacterID)
+	}
 
-		// Place character in room using cube coordinates
-		if i < len(spawnPoints) {
-			roomData.CubeEntities[player.CharacterID] = spatial.EntityCubePlacement{
-				EntityID:       player.CharacterID,
-				EntityType:     entityTypeCharacter,
-				CubePosition:   spawnPoints[i],
-				Size:           1,
-				BlocksMovement: true,
-			}
+	// 7. Generate dungeon using the dungeon generator
+	partyLevel := input.PartyLevel
+	if partyLevel == 0 {
+		partyLevel = 1 // Default to level 1
+	}
+
+	genInput := MapToGeneratorInput(&MapToGeneratorInputParams{
+		PartySize:  len(characterIDs),
+		PartyLevel: partyLevel,
+		ThemeID:    input.ThemeID,    // Defaults to crypt if empty
+		Difficulty: input.Difficulty, // Defaults to easy if empty
+		Length:     input.Length,     // Defaults to short if empty
+		Seed:       input.Seed,
+	})
+
+	genOutput, err := o.dungeonGen.Generate(ctx, genInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate dungeon: %w", err)
+	}
+
+	generatedDungeon := genOutput.Dungeon
+	if generatedDungeon == nil {
+		return nil, fmt.Errorf("dungeon generator returned nil dungeon")
+	}
+	if len(generatedDungeon.Rooms) == 0 {
+		return nil, fmt.Errorf("dungeon generator returned empty dungeon with no rooms")
+	}
+	if generatedDungeon.StartRoom == "" {
+		return nil, fmt.Errorf("dungeon generator did not specify a start room")
+	}
+
+	// 8. Create entities.Dungeon for storage and save it
+	dungeonEntity := o.convertToDungeonEntity(input.EncounterID, generatedDungeon, genOutput.Seed)
+	_, err = o.dungeonRepo.Save(ctx, &dungeonrepo.SaveInput{
+		Dungeon: dungeonEntity,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to save dungeon: %w", err)
+	}
+
+	// 9. Get the start room and convert to room data
+	startRoom := o.findRoom(generatedDungeon, generatedDungeon.StartRoom)
+	if startRoom == nil {
+		return nil, fmt.Errorf("start room not found: %s", generatedDungeon.StartRoom)
+	}
+
+	roomData := o.convertToRoomData(input.EncounterID, startRoom)
+
+	// 10. Place characters at spawn zones
+	spawnPositions := o.getPlayerSpawnPositions(startRoom)
+	for i, characterID := range characterIDs {
+		if i >= len(spawnPositions) {
+			break
 		}
-		i++
-	}
-
-	// 7. Spawn monsters equal to number of players, spread across the room
-	// Monster spawn points on the right side of the room (away from players) using cube coordinates
-	monsterSpawnPoints := []spatial.CubeCoordinate{
-		{X: 14, Y: -22, Z: 8},  // Right side
-		{X: 14, Y: -26, Z: 12}, // Right side lower
-		{X: 12, Y: -22, Z: 10}, // Center-right
-		{X: 13, Y: -19, Z: 6},  // Right upper
-	}
-
-	numPlayers := len(encOutput.Data.Players)
-	monsters := make([]*monster.Data, 0, numPlayers)
-
-	for i := 0; i < numPlayers; i++ {
-		goblinID := fmt.Sprintf("goblin-%d", i+1)
-		spawnPos := monsterSpawnPoints[i%len(monsterSpawnPoints)]
-
-		roomData.CubeEntities[goblinID] = spatial.EntityCubePlacement{
-			EntityID:       goblinID,
-			EntityType:     entityTypeMonster,
-			CubePosition:   spawnPos,
+		roomData.CubeEntities[characterID] = spatial.EntityCubePlacement{
+			EntityID:       characterID,
+			EntityType:     entityTypeCharacter,
+			CubePosition:   spawnPositions[i],
 			Size:           1,
 			BlocksMovement: true,
 		}
-
-		// Create monster data for each goblin
-		monsters = append(monsters, o.createGoblinData(goblinID))
 	}
 
-	// 9. Roll initiative
-	participants := make(map[core.Entity]int)
+	// 11. Place monsters from the dungeon's encounter
+	monsters := o.placeMonsters(roomData, startRoom)
 
-	// Initialize CharacterHP map for TPK tracking
+	// 12. Roll initiative
+	combatants := make(map[core.Entity]int)
 	characterHP := make(map[string]int)
 
-	// Add characters
-	for _, charID := range characterIDs {
-		var charOutput *characterrepo.GetOutput
-		charOutput, err = o.charRepo.Get(ctx, characterrepo.GetInput{ID: charID})
-		if err != nil {
-			return nil, fmt.Errorf("failed to load character %s: %w", charID, err)
+	// Add characters with their DEX modifiers
+	for _, characterID := range characterIDs {
+		charOutput, charErr := o.charRepo.Get(ctx, characterrepo.GetInput{ID: characterID})
+		if charErr != nil {
+			return nil, fmt.Errorf("failed to load character %s: %w", characterID, charErr)
 		}
-		dexMod := charOutput.CharacterData.AbilityScores.Modifier(abilities.DEX)
-		participants[initiative.NewParticipant(charID, entityTypeCharacter)] = dexMod
-
-		// Track character's current HP for TPK detection
-		characterHP[charID] = charOutput.CharacterData.HitPoints
+		dexModifier := charOutput.CharacterData.AbilityScores.Modifier(abilities.DEX)
+		characterHP[characterID] = charOutput.CharacterData.HitPoints
+		char := initiative.NewParticipant(characterID, entityTypeCharacter)
+		combatants[char] = dexModifier
 	}
 
-	// Add all goblins to initiative
+	// Add monsters to initiative with their actual DEX modifiers
 	for _, m := range monsters {
-		participants[initiative.NewParticipant(m.ID, entityTypeMonster)] = 2 // Goblin DEX +2
+		monsterEntity := initiative.NewParticipant(m.ID, entityTypeMonster)
+		dexModifier := m.AbilityScores.Modifier(abilities.DEX)
+		combatants[monsterEntity] = dexModifier
 	}
 
 	// Roll initiative
-	rolls := initiative.RollForOrder(participants, o.roller)
+	rolls := initiative.RollForOrder(combatants, o.roller)
 
 	// Create tracker
 	initiativeOrder := make([]core.Entity, len(rolls))
@@ -2688,7 +2482,7 @@ func (o *Orchestrator) StartCombat(
 		}
 	}
 
-	// 10. Update encounter state to active with fresh action economy
+	// 13. Update encounter state to active with fresh action economy
 	activeState := encounterrepo.StateActive
 	initialActionEconomy := entities.NewActionEconomyState()
 	_, err = o.encRepo.Update(ctx, &encounterrepo.UpdateInput{
@@ -2698,50 +2492,46 @@ func (o *Orchestrator) StartCombat(
 		InitiativeData:    &trackerData,
 		MovementRemaining: ptrInt32(defaultMovementSpeed),
 		ActionEconomy:     initialActionEconomy,
-		Monsters:          monsters,    // Save all monsters
-		CharacterHP:       characterHP, // Track character HP for TPK detection
+		Monsters:          monsters,
+		CharacterHP:       characterHP,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update encounter: %w", err)
 	}
 
-	// 11. Build combat state
+	// 14. Build combat state
 	combatState := &CombatState{
 		EncounterID:       input.EncounterID,
 		Round:             1,
 		TurnOrder:         turnOrder,
 		ActiveIndex:       0,
 		MovementRemaining: defaultMovementSpeed,
-		ActionEconomy:     initialActionEconomy, // Fresh action economy for first turn
+		ActionEconomy:     initialActionEconomy,
 		CombatStarted:     true,
 		CombatEnded:       false,
 	}
 
-	// 12. Execute monster turns if they go first
+	// 15. Execute monster turns if they go first
 	var monsterTurns []*MonsterTurnResult
-	if trackerData.Order[0].Type == entityTypeMonster {
-		// Monster(s) go first - execute all monster turns until a player's turn
+	if len(trackerData.Order) > 0 && trackerData.Order[0].Type == entityTypeMonster {
 		encData := &encounterrepo.EncounterData{
 			ID:                input.EncounterID,
 			RoomData:          roomData,
 			InitiativeData:    &trackerData,
 			InitiativeRolls:   rolls,
 			MovementRemaining: combatState.MovementRemaining,
-			Monsters:          monsters,    // All monsters
-			CharacterHP:       characterHP, // Track character HP for TPK
+			Monsters:          monsters,
+			CharacterHP:       characterHP,
 		}
 
-		// Execute monster turns
 		monsterTurns, err = o.executeMonsterTurns(ctx, encData, characterIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute monster turns: %w", err)
 		}
 
-		// Update combat state to reflect the new active index after monster turns
 		combatState.ActiveIndex = encData.InitiativeData.Current
 		combatState.Round = encData.InitiativeData.Round
 
-		// Persist updated initiative, monster state, room positions, and character HP
 		_, err = o.encRepo.Update(ctx, &encounterrepo.UpdateInput{
 			EncounterID:    input.EncounterID,
 			InitiativeData: encData.InitiativeData,
@@ -2753,14 +2543,12 @@ func (o *Orchestrator) StartCombat(
 			return nil, fmt.Errorf("failed to save initiative after monster turns: %w", err)
 		}
 
-		// Check for TPK after monster turns
 		o.checkAndHandleFailure(ctx, input.EncounterID, encData)
 	}
 
-	// 13. Build party list for event (with character data)
+	// 16. Build party list for event
 	party := make([]*entities.Player, 0, len(encOutput.Data.Players))
 	for _, player := range encOutput.Data.Players {
-		// Load character data for the event
 		charOutput, charErr := o.charRepo.Get(ctx, characterrepo.GetInput{ID: player.CharacterID})
 		var charData *character.Data
 		if charErr == nil && charOutput != nil {
@@ -2777,14 +2565,31 @@ func (o *Orchestrator) StartCombat(
 		})
 	}
 
-	// 13. Publish CombatStarted event
+	// 17. Build monster state list for event
+	monsterStates := make([]*entities.MonsterState, 0, len(monsters))
+	for _, m := range monsters {
+		monsterType := ""
+		if m.Ref != nil {
+			monsterType = m.Ref.ID // Use ref ID as monster type (e.g., "skeleton", "goblin")
+		}
+		monsterStates = append(monsterStates, &entities.MonsterState{
+			MonsterID:        m.ID,
+			MonsterName:      m.Name,
+			CurrentHitPoints: m.HitPoints,
+			MaxHitPoints:     m.MaxHitPoints,
+			MonsterType:      monsterType,
+		})
+	}
+
+	// 18. Publish CombatStarted event
 	o.publishEvent(ctx, input.EncounterID, entities.EventTypeCombatStarted, &entities.CombatStartedEvent{
 		CombatState: combatState,
 		Room:        roomData,
 		Party:       party,
+		Monsters:    monsterStates,
 	})
 
-	// 14. Publish MonsterTurnCompleted events if monsters went first
+	// 19. Publish MonsterTurnCompleted events if monsters went first
 	for _, mt := range monsterTurns {
 		o.publishEvent(ctx, input.EncounterID, entities.EventTypeMonsterTurnCompleted, &entities.MonsterTurnCompletedEvent{
 			MonsterID:   mt.MonsterID,
@@ -3112,18 +2917,6 @@ func (o *Orchestrator) buildPartyFromPlayers(
 	}
 
 	return party
-}
-
-// createGoblinData creates a goblin monster for encounters
-func (o *Orchestrator) createGoblinData(goblinID string) *monster.Data {
-	goblinMonster := monster.NewGoblin(goblinID)
-	goblinMonster.AddAction(monster.NewScimitarAction(monster.ScimitarConfig{
-		AttackBonus: 4,       // +2 DEX + 2 proficiency
-		DamageDice:  "1d6+2", // Scimitar 1d6 + DEX
-		DamageBonus: 2,       // DEX modifier
-	}))
-	data := goblinMonster.ToData()
-	return data
 }
 
 // GetEncounterState returns a full snapshot of the encounter state.

--- a/internal/orchestrators/encounter/orchestrator_test.go
+++ b/internal/orchestrators/encounter/orchestrator_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 
 	"github.com/KirkDiggler/rpg-api/internal/apierr"
+	dungeontoolkit "github.com/KirkDiggler/rpg-api/internal/components/dungeon/toolkit"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	dungeonrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
 	dungeonmock "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons/mock"
 	encounterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 	encountermock "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/mock"
@@ -34,23 +36,27 @@ import (
 
 type OrchestratorTestSuite struct {
 	suite.Suite
-	ctrl         *gomock.Controller
-	mockCharRepo *charactermock.MockRepository
-	mockEncRepo  *encountermock.MockRepository
-	mockRoller   *dicemock.MockRoller
-	orchestrator *Orchestrator
+	ctrl            *gomock.Controller
+	mockCharRepo    *charactermock.MockRepository
+	mockEncRepo     *encountermock.MockRepository
+	mockDungeonRepo *dungeonmock.MockRepository
+	mockRoller      *dicemock.MockRoller
+	orchestrator    *Orchestrator
 }
 
 func (s *OrchestratorTestSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
 	s.mockEncRepo = encountermock.NewMockRepository(s.ctrl)
+	s.mockDungeonRepo = dungeonmock.NewMockRepository(s.ctrl)
 	s.mockRoller = dicemock.NewMockRoller(s.ctrl)
 
 	var err error
 	s.orchestrator, err = New(&Config{
 		CharacterRepo: s.mockCharRepo,
 		EncounterRepo: s.mockEncRepo,
+		DungeonRepo:   s.mockDungeonRepo,
+		DungeonGen:    dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{}),
 	})
 	s.Require().NoError(err)
 
@@ -71,20 +77,8 @@ func (s *OrchestratorTestSuite) TestNew_Success() {
 	orch, err := New(&Config{
 		CharacterRepo: s.mockCharRepo,
 		EncounterRepo: s.mockEncRepo,
-	})
-	s.Require().NoError(err)
-	s.Assert().NotNil(orch)
-}
-
-func (s *OrchestratorTestSuite) TestNew_WithDungeonDependencies() {
-	// Create a mock dungeon repo
-	mockDungeonRepo := dungeonmock.NewMockRepository(s.ctrl)
-
-	orch, err := New(&Config{
-		CharacterRepo: s.mockCharRepo,
-		EncounterRepo: s.mockEncRepo,
-		DungeonRepo:   mockDungeonRepo,
-		// DungeonGen is nil - optional for unit tests
+		DungeonRepo:   s.mockDungeonRepo,
+		DungeonGen:    dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{}),
 	})
 	s.Require().NoError(err)
 	s.Assert().NotNil(orch)
@@ -387,6 +381,11 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_Success() {
 		}, nil).
 		AnyTimes() // Initiative lookup + potential monster attack target
 
+	// Arrange - Mock dungeon repo save (required for generator path)
+	s.mockDungeonRepo.EXPECT().
+		Save(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.SaveOutput{Success: true}, nil)
+
 	// Arrange - Mock encounter repo save
 	s.mockEncRepo.EXPECT().
 		Save(gomock.Any(), gomock.Any()).
@@ -399,12 +398,8 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_Success() {
 			s.Assert().NotNil(input.RoomData)
 			roomData, ok := input.RoomData.(*spatial.RoomData)
 			s.Assert().True(ok, "RoomData should be *spatial.RoomData")
-			s.Assert().Equal(input.EncounterID+"-room", roomData.ID)
 			s.Assert().Equal("dungeon", roomData.Type)
-			s.Assert().Equal(20, roomData.Width)
-			s.Assert().Equal(20, roomData.Height)
 			s.Assert().Equal(spatial.GridTypeHex, roomData.GridType)
-			s.Assert().NotNil(roomData.Entities)
 
 			// Verify initiative data is now saved
 			s.Assert().NotNil(input.InitiativeData, "InitiativeData should be present")
@@ -430,14 +425,14 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_Success() {
 	s.Assert().NotEmpty(output.EncounterID)
 	s.Assert().Contains(output.EncounterID, "enc-")
 
+	// Verify dungeon ID is present (generator was used)
+	s.Assert().NotEmpty(output.DungeonID)
+
 	// Verify room data in output
 	s.Assert().NotNil(output.Room)
 	roomData, ok := output.Room.(*spatial.RoomData)
 	s.Assert().True(ok, "Room should be *spatial.RoomData")
-	s.Assert().Equal(output.EncounterID+"-room", roomData.ID)
 	s.Assert().Equal("dungeon", roomData.Type)
-	s.Assert().Equal(20, roomData.Width)
-	s.Assert().Equal(20, roomData.Height)
 	s.Assert().Equal(spatial.GridTypeHex, roomData.GridType)
 
 	// Verify combat state in output
@@ -445,9 +440,9 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_Success() {
 	s.Assert().Equal(output.EncounterID, output.CombatState.EncounterID)
 	s.Assert().True(output.CombatState.CombatStarted)
 	s.Assert().False(output.CombatState.CombatEnded)
-	s.Assert().Len(output.CombatState.TurnOrder, 2) // 1 character + 1 goblin
+	s.Assert().GreaterOrEqual(len(output.CombatState.TurnOrder), 2) // At least 1 character + 1 monster
 
-	// Verify active turn is a player character (monsters are auto-skipped)
+	// Verify active turn index is valid
 	s.Require().GreaterOrEqual(output.CombatState.ActiveIndex, 0)
 	s.Require().Less(output.CombatState.ActiveIndex, len(output.CombatState.TurnOrder))
 	activeTurn := output.CombatState.TurnOrder[output.CombatState.ActiveIndex]
@@ -470,14 +465,21 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_SaveError() {
 		Get(gomock.Any(), characterrepo.GetInput{ID: "char-1"}).
 		Return(&characterrepo.GetOutput{
 			CharacterData: &character.Data{
-				ID: "char-1",
+				ID:        "char-1",
+				HitPoints: 10,
 				AbilityScores: shared.AbilityScores{
 					abilities.DEX: 14,
 				},
 			},
-		}, nil)
+		}, nil).
+		AnyTimes()
 
-	// Arrange - Mock repo save to return error
+	// Mock dungeon repo save (called before encounter save)
+	s.mockDungeonRepo.EXPECT().
+		Save(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.SaveOutput{Success: true}, nil)
+
+	// Arrange - Mock encounter repo save to return error
 	expectedError := fmt.Errorf("database error")
 	s.mockEncRepo.EXPECT().
 		Save(gomock.Any(), gomock.Any()).
@@ -495,35 +497,40 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_SaveError() {
 	s.Assert().ErrorIs(err, expectedError)
 }
 
-func (s *OrchestratorTestSuite) TestCreateDungeon_MinimalInput() {
-	// Test with empty CharacterIDs (dungeon with just goblin)
-	// Since there are no player characters, combat should end automatically
-	s.mockEncRepo.EXPECT().
-		Save(gomock.Any(), gomock.Any()).
-		Return(&encounterrepo.SaveOutput{Success: true}, nil)
-
-	// Expect Update call to save initiative after monster turns
-	s.mockEncRepo.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
-
+func (s *OrchestratorTestSuite) TestCreateDungeon_RequiresCharacters() {
+	// Test that empty CharacterIDs fails since dungeon generator requires at least one character
 	output, err := s.orchestrator.CreateDungeon(context.Background(), &CreateDungeonInput{
 		CharacterIDs: []string{},
 	})
 
-	s.Require().NoError(err)
-	s.Assert().NotEmpty(output.EncounterID)
-	s.Assert().NotNil(output.CombatState)
-	s.Assert().Len(output.CombatState.TurnOrder, 1) // Only goblin
-	// TODO: Combat should detect when there are no players and end automatically
-	// Currently monster will loop through initiative until max iterations
-	// This will be fixed in a follow-up PR
-	s.Assert().NotEmpty(output.MonsterTurns, "Monster should execute turns")
+	s.Require().Error(err)
+	s.Assert().Nil(output)
+	s.Assert().Contains(err.Error(), "party size must be greater than 0")
 }
 
 func (s *OrchestratorTestSuite) TestCreateDungeon_UniqueIDs() {
 	// Verify that multiple calls generate unique IDs
 	var capturedIDs []string
+
+	// Mock character repo for all three calls
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-1"}).
+		Return(&characterrepo.GetOutput{
+			CharacterData: &character.Data{
+				ID:        "char-1",
+				HitPoints: 10,
+				AbilityScores: shared.AbilityScores{
+					abilities.DEX: 14,
+				},
+			},
+		}, nil).
+		AnyTimes()
+
+	// Mock dungeon repo for all three calls
+	s.mockDungeonRepo.EXPECT().
+		Save(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.SaveOutput{Success: true}, nil).
+		Times(3)
 
 	s.mockEncRepo.EXPECT().
 		Save(gomock.Any(), gomock.Any()).
@@ -537,12 +544,12 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_UniqueIDs() {
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil).
-		Times(3)
+		AnyTimes()
 
 	// Create three encounters
 	for i := 0; i < 3; i++ {
 		output, err := s.orchestrator.CreateDungeon(context.Background(), &CreateDungeonInput{
-			CharacterIDs: []string{}, // Empty - just goblin
+			CharacterIDs: []string{"char-1"},
 		})
 		s.Require().NoError(err)
 		s.Assert().NotEmpty(output.EncounterID)
@@ -559,6 +566,25 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_UniqueIDs() {
 }
 
 func (s *OrchestratorTestSuite) TestCreateDungeon_SavesInitiativeData() {
+	// Mock character repo
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-1"}).
+		Return(&characterrepo.GetOutput{
+			CharacterData: &character.Data{
+				ID:        "char-1",
+				HitPoints: 10,
+				AbilityScores: shared.AbilityScores{
+					abilities.DEX: 14,
+				},
+			},
+		}, nil).
+		AnyTimes()
+
+	// Mock dungeon repo save
+	s.mockDungeonRepo.EXPECT().
+		Save(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.SaveOutput{Success: true}, nil)
+
 	// Verify that encounter is created with room data AND initiative data
 	s.mockEncRepo.EXPECT().
 		Save(gomock.Any(), gomock.Any()).
@@ -570,17 +596,18 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_SavesInitiativeData() {
 			// Verify initiative data is now saved
 			s.Assert().NotNil(input.InitiativeData, "InitiativeData should be present")
 			s.Assert().NotNil(input.InitiativeRolls, "InitiativeRolls should be present")
-			s.Assert().Len(input.InitiativeRolls, 1, "Should have 1 entity (goblin)")
+			s.Assert().GreaterOrEqual(len(input.InitiativeRolls), 2, "Should have at least 2 entities (1 char + monsters)")
 			return &encounterrepo.SaveOutput{Success: true}, nil
 		})
 
-	// Expect Update call to save initiative after monster turns (goblin goes first)
+	// Expect Update call to save initiative after monster turns
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
-		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
+		Return(&encounterrepo.UpdateOutput{Success: true}, nil).
+		AnyTimes()
 
 	output, err := s.orchestrator.CreateDungeon(context.Background(), &CreateDungeonInput{
-		CharacterIDs: []string{}, // Empty - just goblin
+		CharacterIDs: []string{"char-1"},
 	})
 
 	s.Require().NoError(err)
@@ -1963,6 +1990,11 @@ func (s *OrchestratorTestSuite) TestCreateDungeon_InitializesActionEconomy() {
 			},
 		}, nil).
 		AnyTimes()
+
+	// Mock dungeon repo save
+	s.mockDungeonRepo.EXPECT().
+		Save(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.SaveOutput{Success: true}, nil)
 
 	// Capture the save input to verify action economy
 	var capturedSave *encounterrepo.SaveInput

--- a/internal/orchestrators/encounter/service.go
+++ b/internal/orchestrators/encounter/service.go
@@ -336,6 +336,13 @@ type SetReadyOutput struct {
 type StartCombatInput struct {
 	EncounterID string // ID of the encounter
 	PlayerID    string // ID of the player requesting start (must be host)
+
+	// Dungeon generation options (all optional with sensible defaults)
+	ThemeID    string // Theme identifier (crypt, cave, bandit-lair) - defaults to crypt
+	Difficulty string // Difficulty level (easy, medium, hard, deadly) - defaults to easy
+	Length     string // Dungeon length (short, medium, long) - defaults to short
+	PartyLevel int    // Average party level for CR calculation - defaults to 1
+	Seed       int64  // Optional seed for reproducibility (0 = random)
 }
 
 // StartCombatOutput returns the initial combat state


### PR DESCRIPTION
## Summary
- StartCombat now uses dungeon generator instead of hardcoded goblins
- Monster types flow through CombatStartedEvent to client for proper texture rendering
- Spawn zone coordinates now use toolkit's converter for proper cube coordinates

## Changes
- **Orchestrator**: Rewrote StartCombat to generate dungeon with theme/difficulty/party size
- **Entities**: Added `MonsterState` struct and `Monsters` field to `CombatStartedEvent`
- **Handler**: Wired up monster conversion using `MonsterTypeFromID`
- **Feature generator**: Fixed coordinate conversion using `spatial.OffsetCoordinateToCube`
- **Budget**: Fixed allocation for small party sizes, added selector fallback

## Technical Notes
- Uses toolkit's `OffsetCoordinateToCube` for consistent cube coordinate conversion
- Monster placement still uses simple zone-based approach (future: use toolkit's spawn module)
- Removed unused `createGoblinData` function

## Test plan
- [x] All tests pass
- [x] Lint passes
- [x] Playtest confirms monsters appear on map with correct types
- [ ] Verify spawn positions are within room bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)