### PR TITLE
feat: Add complete feature and condition enum mappings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-api
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221025741-626cbe915ef0
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221033839-629f1de2da69
 	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221025741-626cbe915ef0 h1:BjLcF4gr1TUIkCFZrl+LZzpJSJO/CvGrEoBi/vpH1Rs=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221025741-626cbe915ef0/go.mod h1:nnvwwB7Z3PL+U/3XW25DYEojtMilVgkw39MG8y4F9ag=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221033839-629f1de2da69 h1:Jl1u2/yz4btFkOpEuja0VYn32+1A/9ksu5K4MUFbUDY=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221033839-629f1de2da69/go.mod h1:nnvwwB7Z3PL+U/3XW25DYEojtMilVgkw39MG8y4F9ag=
 github.com/KirkDiggler/rpg-toolkit/core v0.9.6 h1:Mqd7jxxiXOfD0vQYzoOrtoa+fqKbVGIY5/Oo7pqbGBk=
 github.com/KirkDiggler/rpg-toolkit/core v0.9.6/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2832,6 +2832,12 @@ func conditionIDToEnum(id string) dnd5ev1alpha1.ConditionId {
 		return dnd5ev1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_TWO_WEAPON_FIGHTING
 	case refs.Conditions.FightingStyleGreatWeaponFighting().ID:
 		return dnd5ev1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_GREAT_WEAPON_FIGHTING
+	case refs.Conditions.FightingStyleArchery().ID:
+		return dnd5ev1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_ARCHERY
+	case refs.Conditions.FightingStyleDefense().ID:
+		return dnd5ev1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_DEFENSE
+	case refs.Conditions.FightingStyleProtection().ID:
+		return dnd5ev1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_PROTECTION
 	case refs.Conditions.UnarmoredDefense().ID:
 		return dnd5ev1alpha1.ConditionId_CONDITION_ID_UNARMORED_DEFENSE
 	case refs.Conditions.ImprovedCritical().ID:
@@ -2863,6 +2869,20 @@ func conditionIDToDisplayName(id string) string {
 		return "Fighting Style: Two-Weapon Fighting"
 	case refs.Conditions.FightingStyleGreatWeaponFighting().ID:
 		return "Fighting Style: Great Weapon Fighting"
+	case refs.Conditions.FightingStyleArchery().ID:
+		return "Fighting Style: Archery"
+	case refs.Conditions.FightingStyleDefense().ID:
+		return "Fighting Style: Defense"
+	case refs.Conditions.FightingStyleProtection().ID:
+		return "Fighting Style: Protection"
+	case refs.Conditions.UnarmoredDefense().ID:
+		return "Unarmored Defense"
+	case refs.Conditions.ImprovedCritical().ID:
+		return "Improved Critical"
+	case refs.Conditions.MartialArts().ID:
+		return "Martial Arts"
+	case refs.Conditions.UnarmoredMovement().ID:
+		return "Unarmored Movement"
 	default:
 		// Convert snake_case to Title Case as fallback
 		return toTitleCase(id)
@@ -2874,6 +2894,27 @@ func conditionIDToDisplayName(id string) string {
 // that don't have toolkit refs yet (breath_weapon, hellish_rebuke, etc.)
 func featureIDToEnum(id string) dnd5ev1alpha1.FeatureId {
 	switch id {
+	// Barbarian features
+	case refs.Features.Rage().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE
+	// Fighter features
+	case refs.Features.SecondWind().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_SECOND_WIND
+	case refs.Features.ActionSurge().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_ACTION_SURGE
+	// Rogue features
+	case refs.Features.SneakAttack().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_SNEAK_ATTACK
+	// Paladin features
+	case refs.Features.DivineSmite().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_DIVINE_SMITE
+	// Monk features
+	case refs.Features.FlurryOfBlows().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_FLURRY_OF_BLOWS
+	case refs.Features.PatientDefense().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_PATIENT_DEFENSE
+	case refs.Features.StepOfTheWind().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_STEP_OF_THE_WIND
 	case refs.Features.DeflectMissiles().ID:
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_DEFLECT_MISSILES
 	// Features below don't have toolkit refs yet - magic strings until toolkit adds them
@@ -2890,7 +2931,6 @@ func featureIDToEnum(id string) dnd5ev1alpha1.FeatureId {
 	case "starry_form_archer":
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_STARRY_FORM_ARCHER
 	default:
-		// Features like rage, second_wind, action_surge don't have enum values yet
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED
 	}
 }

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -247,9 +247,9 @@ func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_WithFeatures() {
 	require.NotEmpty(s.T(), result.Features, "Features should be populated")
 	assert.Len(s.T(), result.Features, 1, "Should have 1 feature")
 
-	// Check feature details - Id is now FeatureId enum (UNSPECIFIED since rage has no enum value yet)
+	// Check feature details - Id is FeatureId enum (RAGE extracted from ref "dnd5e:features:rage")
 	rageFeature := result.Features[0]
-	assert.Equal(s.T(), dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED, rageFeature.Id)
+	assert.Equal(s.T(), dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE, rageFeature.Id)
 	assert.Equal(s.T(), "Rage", rageFeature.Name)
 	assert.Equal(s.T(), "class", rageFeature.Source)
 	// Verify raw JSON is passed through
@@ -296,7 +296,8 @@ func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_InvalidFeatureJSON
 	// Verify only valid feature is included
 	require.NotNil(s.T(), result, "Result should not be nil")
 	assert.Len(s.T(), result.Features, 1, "Should have 1 valid feature")
-	assert.Equal(s.T(), dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED, result.Features[0].Id)
+	// RAGE extracted from ref "dnd5e:features:rage"
+	assert.Equal(s.T(), dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE, result.Features[0].Id)
 	assert.Equal(s.T(), "Rage", result.Features[0].Name)
 }
 
@@ -322,8 +323,8 @@ func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_FeatureWithToolkit
 
 	require.NotNil(s.T(), result, "Result should not be nil")
 	require.Len(s.T(), result.Features, 1, "Should have 1 feature")
-	// Id is now FeatureId enum - rage doesn't have an enum value yet so it's UNSPECIFIED
-	assert.Equal(s.T(), dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED, result.Features[0].Id)
+	// Id is now FeatureId enum - rage maps to FEATURE_ID_RAGE
+	assert.Equal(s.T(), dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE, result.Features[0].Id)
 	assert.Equal(s.T(), "Rage", result.Features[0].Name)
 	// Verify raw JSON is passed through for UI
 	assert.NotEmpty(s.T(), result.Features[0].FeatureData)

--- a/internal/handlers/dnd5e/v1alpha1/encounter/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/converters.go
@@ -684,15 +684,34 @@ func conditionRefToProto(ref *core.Ref) dnd5ev1alpha1.ConditionId {
 	}
 }
 
-// featureRefToProto converts toolkit feature ref to proto FeatureId enum using pointer comparison.
-// Falls back to string comparison for unknown refs.
-// Note: Not all toolkit features have proto enum values yet (e.g., Rage, SecondWind).
+// featureRefToProto converts toolkit feature ref to proto FeatureId enum.
+// Uses toolkit refs for type-safe comparison where available.
 func featureRefToProto(ref *core.Ref) dnd5ev1alpha1.FeatureId {
-	// Fast path: pointer comparison with singleton refs
-	// (Currently no singleton features have corresponding proto enums)
-
-	// Slow path: string comparison for unknown refs
 	switch ref.ID {
+	// Barbarian features
+	case refs.Features.Rage().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE
+	// Fighter features
+	case refs.Features.SecondWind().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_SECOND_WIND
+	case refs.Features.ActionSurge().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_ACTION_SURGE
+	// Rogue features
+	case refs.Features.SneakAttack().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_SNEAK_ATTACK
+	// Paladin features
+	case refs.Features.DivineSmite().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_DIVINE_SMITE
+	// Monk features
+	case refs.Features.FlurryOfBlows().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_FLURRY_OF_BLOWS
+	case refs.Features.PatientDefense().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_PATIENT_DEFENSE
+	case refs.Features.StepOfTheWind().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_STEP_OF_THE_WIND
+	case refs.Features.DeflectMissiles().ID:
+		return dnd5ev1alpha1.FeatureId_FEATURE_ID_DEFLECT_MISSILES
+	// Features below don't have toolkit refs yet - magic strings until toolkit adds them
 	case "breath_weapon":
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_BREATH_WEAPON
 	case "hellish_rebuke":
@@ -703,12 +722,55 @@ func featureRefToProto(ref *core.Ref) dnd5ev1alpha1.FeatureId {
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_WRATH_OF_THE_STORM
 	case "destructive_wrath":
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_DESTRUCTIVE_WRATH
-	case "deflect_missiles":
-		return dnd5ev1alpha1.FeatureId_FEATURE_ID_DEFLECT_MISSILES
 	case "starry_form_archer":
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_STARRY_FORM_ARCHER
 	default:
 		return dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED
+	}
+}
+
+// featureEnumToID converts a proto FeatureId enum to the toolkit feature ID string.
+// This is the reverse of featureRefToProto.
+func featureEnumToID(featureID dnd5ev1alpha1.FeatureId) string {
+	switch featureID {
+	// Barbarian features
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE:
+		return refs.Features.Rage().ID
+	// Fighter features
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_SECOND_WIND:
+		return refs.Features.SecondWind().ID
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_ACTION_SURGE:
+		return refs.Features.ActionSurge().ID
+	// Rogue features
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_SNEAK_ATTACK:
+		return refs.Features.SneakAttack().ID
+	// Paladin features
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_DIVINE_SMITE:
+		return refs.Features.DivineSmite().ID
+	// Monk features
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_FLURRY_OF_BLOWS:
+		return refs.Features.FlurryOfBlows().ID
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_PATIENT_DEFENSE:
+		return refs.Features.PatientDefense().ID
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_STEP_OF_THE_WIND:
+		return refs.Features.StepOfTheWind().ID
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_DEFLECT_MISSILES:
+		return refs.Features.DeflectMissiles().ID
+	// Features without toolkit refs
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_BREATH_WEAPON:
+		return "breath_weapon"
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_HELLISH_REBUKE:
+		return "hellish_rebuke"
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_RADIANCE_OF_DAWN:
+		return "radiance_of_dawn"
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_WRATH_OF_THE_STORM:
+		return "wrath_of_the_storm"
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_DESTRUCTIVE_WRATH:
+		return "destructive_wrath"
+	case dnd5ev1alpha1.FeatureId_FEATURE_ID_STARRY_FORM_ARCHER:
+		return "starry_form_archer"
+	default:
+		return ""
 	}
 }
 

--- a/internal/handlers/dnd5e/v1alpha1/encounter/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/converters_test.go
@@ -223,10 +223,17 @@ func (s *ConvertersTestSuite) TestFeatureRefToProto_SlowPath() {
 }
 
 func (s *ConvertersTestSuite) TestFeatureRefToProto_Unknown() {
-	// Rage and SecondWind don't have proto enums yet
-	unknownRef := &core.Ref{Module: refs.Module, Type: refs.TypeFeatures, ID: "rage"}
+	// Test that unknown features return UNSPECIFIED
+	unknownRef := &core.Ref{Module: refs.Module, Type: refs.TypeFeatures, ID: "unknown_feature"}
 	result := featureRefToProto(unknownRef)
 	s.Equal(dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED, result)
+}
+
+func (s *ConvertersTestSuite) TestFeatureRefToProto_Rage() {
+	// Rage now has a proto enum value
+	rageRef := &core.Ref{Module: refs.Module, Type: refs.TypeFeatures, ID: refs.Features.Rage().ID}
+	result := featureRefToProto(rageRef)
+	s.Equal(dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE, result)
 }
 
 // =============================================================================
@@ -582,7 +589,7 @@ func (s *ConvertersTestSuite) TestConvertDamageComponentToProto_VulnerabilityMul
 	s.Require().NotNil(result)
 	s.Require().NotNil(result.Multiplier)
 	s.Equal(float32(2.0), *result.Multiplier)
-	s.Equal("monster_trait", result.Source)
+	s.Equal("monster_trait", result.Source) //nolint:staticcheck // TODO: migrate to source_ref
 }
 
 func (s *ConvertersTestSuite) TestConvertDamageComponentToProto_ImmunityMultiplier() {

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -356,15 +356,21 @@ func (h *Handler) ActivateFeature(
 	if req.GetCharacterId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "character_id is required")
 	}
-	if req.GetFeatureId() == "" {
+	if req.GetFeatureId() == dnd5ev1alpha1.FeatureId_FEATURE_ID_UNSPECIFIED {
 		return nil, status.Error(codes.InvalidArgument, "feature_id is required")
+	}
+
+	// Convert enum to toolkit feature ID string
+	featureID := featureEnumToID(req.GetFeatureId())
+	if featureID == "" {
+		return nil, status.Error(codes.InvalidArgument, "unsupported feature_id")
 	}
 
 	// 2. Create service input
 	input := &encounter.ActivateFeatureInput{
 		EncounterID: req.GetEncounterId(),
 		CharacterID: req.GetCharacterId(),
-		FeatureID:   req.GetFeatureId(),
+		FeatureID:   featureID,
 	}
 
 	// 3. Call service

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
@@ -919,7 +919,7 @@ func (s *HandlerTestSuite) TestActivateFeature_Success() {
 	resp, err := s.handler.ActivateFeature(context.Background(), &dnd5ev1alpha1.ActivateFeatureRequest{
 		EncounterId: "enc-1",
 		CharacterId: "char-1",
-		FeatureId:   "rage",
+		FeatureId:   dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE,
 	})
 
 	// Assert
@@ -948,7 +948,7 @@ func (s *HandlerTestSuite) TestActivateFeature_FeatureNotFound() {
 	resp, err := s.handler.ActivateFeature(context.Background(), &dnd5ev1alpha1.ActivateFeatureRequest{
 		EncounterId: "enc-1",
 		CharacterId: "char-1",
-		FeatureId:   "rage",
+		FeatureId:   dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE,
 	})
 
 	// Assert
@@ -977,7 +977,7 @@ func (s *HandlerTestSuite) TestActivateFeature_CannotActivate() {
 	resp, err := s.handler.ActivateFeature(context.Background(), &dnd5ev1alpha1.ActivateFeatureRequest{
 		EncounterId: "enc-1",
 		CharacterId: "char-1",
-		FeatureId:   "rage",
+		FeatureId:   dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE,
 	})
 
 	// Assert
@@ -992,7 +992,7 @@ func (s *HandlerTestSuite) TestActivateFeature_MissingEncounterId() {
 	// Act
 	resp, err := s.handler.ActivateFeature(context.Background(), &dnd5ev1alpha1.ActivateFeatureRequest{
 		CharacterId: "char-1",
-		FeatureId:   "rage",
+		FeatureId:   dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE,
 	})
 
 	// Assert
@@ -1010,7 +1010,7 @@ func (s *HandlerTestSuite) TestActivateFeature_MissingCharacterId() {
 	// Act
 	resp, err := s.handler.ActivateFeature(context.Background(), &dnd5ev1alpha1.ActivateFeatureRequest{
 		EncounterId: "enc-1",
-		FeatureId:   "rage",
+		FeatureId:   dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE,
 	})
 
 	// Assert
@@ -1056,7 +1056,7 @@ func (s *HandlerTestSuite) TestActivateFeature_ServiceError() {
 	resp, err := s.handler.ActivateFeature(context.Background(), &dnd5ev1alpha1.ActivateFeatureRequest{
 		EncounterId: "enc-1",
 		CharacterId: "char-1",
-		FeatureId:   "rage",
+		FeatureId:   dnd5ev1alpha1.FeatureId_FEATURE_ID_RAGE,
 	})
 
 	// Assert


### PR DESCRIPTION
## Summary
- Add missing condition mappings for fighting styles (archery, defense, protection)
- Add feature mappings for all implemented features (rage, second_wind, action_surge, flurry_of_blows, patient_defense, step_of_the_wind, sneak_attack, divine_smite, deflect_missiles)
- Add `featureEnumToID` converter for handler to translate enum → toolkit ID
- Update `ActivateFeature` handler to use `FeatureId` enum instead of string
- Update tests to expect proper enum values
- Update proto dependency to latest generated version

## Context
This aligns the API with [rpg-dnd5e-web PR #286](https://github.com/KirkDiggler/rpg-dnd5e-web/pull/286) which moved to enum-based feature/condition matching. The frontend now expects features and conditions to return proper enum IDs rather than `UNSPECIFIED`.

## Changes by File
- `character/converters.go`: Added 3 missing condition mappings (archery, defense, protection) and 9 feature mappings
- `encounter/converters.go`: Same feature mappings + new `featureEnumToID` reverse converter
- `encounter/handler.go`: Updated to use `FeatureId` enum and convert to toolkit ID string
- `*_test.go`: Updated test expectations to match new enum values

## Test plan
- [x] All existing tests pass
- [x] Tests updated to verify enum values are correctly returned
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)