### PR TITLE
Update toolkit to core v0.10.0 and dnd5e v0.36.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.24.1
 
 require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221033839-629f1de2da69
-	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
+	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.34.2
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.36.1
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.3.1-0.20251218021904-e9530f960b23
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221033839-629f1de2da69 h1:Jl1u2/yz4btFkOpEuja0VYn32+1A/9ksu5K4MUFbUDY=
 github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251221033839-629f1de2da69/go.mod h1:nnvwwB7Z3PL+U/3XW25DYEojtMilVgkw39MG8y4F9ag=
-github.com/KirkDiggler/rpg-toolkit/core v0.9.6 h1:Mqd7jxxiXOfD0vQYzoOrtoa+fqKbVGIY5/Oo7pqbGBk=
-github.com/KirkDiggler/rpg-toolkit/core v0.9.6/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
+github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
@@ -12,8 +12,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.34.2 h1:3b5+B5+RCi5GNL474/5KVHaIyYiE3j1F42DpCmfQw+U=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.34.2/go.mod h1:EHwAU/BFTH9MyGXz1gfJDC5EPZHYOcHAX3oQeW58yvA=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.36.1 h1:8vuVFwqq/x4n4EPPB9lRs5nYlHoL616mzAZDDPMoqak=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.36.1/go.mod h1:LQNKzgrzk8MCvaiKUHff9YLh0ngFo/akda+WH8epct4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2 h1:warO6dvk/Ymyc3lnVU7x1xIM0T6dw7h6DQ8Clz4z/PI=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2/go.mod h1:IwhSpU197TgOvI/ZjnJMJabykFnivhCywj5gFENQV9c=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=


### PR DESCRIPTION
## Summary
- **core v0.10.0**: ResourceAccessor interface in core/resources
- **dnd5e v0.36.1**: Character creation now initializes class resources
  - RageCharges for barbarians (based on level)
  - Ki for monks (equal to level)
  - HitDice for all classes

## Root Cause Fixed
New barbarians had no rage charges because `draft.ToCharacter()` created an empty resources map but never populated it. The Rage feature checked for resources that didn't exist.

## Test plan
- [x] All rpg-api tests pass
- [x] Toolkit PR #500 merged with tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)