### PR TITLE
feat(encounter): publish TurnEndEvent to character event buses

### DIFF
--- a/internal/orchestrators/encounter/event_publishing_test.go
+++ b/internal/orchestrators/encounter/event_publishing_test.go
@@ -495,10 +495,11 @@ func (s *EventPublishingTestSuite) TestMoveCharacter_PublishesMovementCompletedE
 func (s *EventPublishingTestSuite) TestEndTurn_PublishesTurnEndedEvent() {
 	// Arrange
 	encounterID := "enc-123"
+	characterID := "char-1"
 
 	initiativeData := &initiative.TrackerData{
 		Order: []initiative.EntityData{
-			{ID: "char-1", Type: "character"},
+			{ID: characterID, Type: "character"},
 			{ID: "char-2", Type: "character"},
 		},
 		Current: 0,
@@ -506,11 +507,32 @@ func (s *EventPublishingTestSuite) TestEndTurn_PublishesTurnEndedEvent() {
 	}
 
 	initiativeRolls := []initiative.Roll{
-		{Entity: initiative.NewParticipant("char-1", "character"), Roll: 18, Modifier: 2, Total: 20},
+		{Entity: initiative.NewParticipant(characterID, "character"), Roll: 18, Modifier: 2, Total: 20},
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
-	// Mock Get
+	// Create character data for turn-end event publishing
+	charData := &character.Data{
+		ID:               characterID,
+		Name:             "Test Character",
+		PlayerID:         "player-1",
+		Level:            1,
+		RaceID:           "human",
+		ClassID:          "fighter",
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    12,
+		MaxHitPoints: 12,
+	}
+
+	// Mock Get encounter
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: encounterID}).
 		Return(&encounterrepo.GetOutput{
@@ -521,7 +543,17 @@ func (s *EventPublishingTestSuite) TestEndTurn_PublishesTurnEndedEvent() {
 			},
 		}, nil)
 
-	// Mock Update
+	// Mock Get character for turn-end event publishing
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: characterID}).
+		Return(&characterrepo.GetOutput{CharacterData: charData}, nil)
+
+	// Mock Update character after turn-end event processing
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&characterrepo.UpdateOutput{}, nil)
+
+	// Mock Update encounter
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)
@@ -535,7 +567,7 @@ func (s *EventPublishingTestSuite) TestEndTurn_PublishesTurnEndedEvent() {
 
 			// Verify event data using typed field
 			s.Require().NotNil(input.Event.TurnEnded, "TurnEnded should be set")
-			s.Assert().Equal("char-1", input.Event.TurnEnded.PreviousEntityID)
+			s.Assert().Equal(characterID, input.Event.TurnEnded.PreviousEntityID)
 			s.Assert().Equal("char-2", input.Event.TurnEnded.NextEntityID)
 			s.Assert().Equal(1, input.Event.TurnEnded.Round)
 			s.Assert().False(input.Event.TurnEnded.NewRound)
@@ -787,11 +819,12 @@ func (s *EventPublishingTestSuite) TestLeaveEncounter_LastPlayer_PublishesBefore
 func (s *EventPublishingTestSuite) TestEndTurn_NewRound_SetsNewRoundFlag() {
 	// Arrange - last turn of round
 	encounterID := "enc-123"
+	characterID := "char-2" // This is the active entity (Current: 1)
 
 	initiativeData := &initiative.TrackerData{
 		Order: []initiative.EntityData{
 			{ID: "char-1", Type: "character"},
-			{ID: "char-2", Type: "character"},
+			{ID: characterID, Type: "character"},
 		},
 		Current: 1, // Last entity in order
 		Round:   1,
@@ -799,10 +832,31 @@ func (s *EventPublishingTestSuite) TestEndTurn_NewRound_SetsNewRoundFlag() {
 
 	initiativeRolls := []initiative.Roll{
 		{Entity: initiative.NewParticipant("char-1", "character"), Roll: 18, Modifier: 2, Total: 20},
-		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
+		{Entity: initiative.NewParticipant(characterID, "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
-	// Mock Get
+	// Create character data for turn-end event publishing
+	charData := &character.Data{
+		ID:               characterID,
+		Name:             "Test Character 2",
+		PlayerID:         "player-2",
+		Level:            1,
+		RaceID:           "human",
+		ClassID:          "fighter",
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    12,
+		MaxHitPoints: 12,
+	}
+
+	// Mock Get encounter
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: encounterID}).
 		Return(&encounterrepo.GetOutput{
@@ -813,7 +867,17 @@ func (s *EventPublishingTestSuite) TestEndTurn_NewRound_SetsNewRoundFlag() {
 			},
 		}, nil)
 
-	// Mock Update
+	// Mock Get character for turn-end event publishing
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: characterID}).
+		Return(&characterrepo.GetOutput{CharacterData: charData}, nil)
+
+	// Mock Update character after turn-end event processing
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&characterrepo.UpdateOutput{}, nil)
+
+	// Mock Update encounter
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
 		Return(&encounterrepo.UpdateOutput{Success: true}, nil)

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -196,6 +196,52 @@ func (o *Orchestrator) publishEvent(ctx context.Context, encounterID string, eve
 	}
 }
 
+// publishCharacterTurnEnd publishes a TurnEndEvent to the character's event bus.
+// This allows conditions like Rage and Sneak Attack to process turn-end logic.
+// The character is loaded with their persisted condition state, the event is published,
+// and the updated state is persisted back.
+func (o *Orchestrator) publishCharacterTurnEnd(ctx context.Context, characterID string, round int) error {
+	// 1. Load character data from repository
+	charOutput, err := o.charRepo.Get(ctx, characterrepo.GetInput{
+		ID: characterID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load character: %w", err)
+	}
+
+	// 2. Create fresh event bus and load character (conditions subscribe to bus)
+	bus := events.NewEventBus()
+	char, err := character.LoadFromData(ctx, charOutput.CharacterData, bus)
+	if err != nil {
+		return fmt.Errorf("failed to load character from data: %w", err)
+	}
+
+	// 3. Publish TurnEndEvent to the character's event bus
+	// Conditions like Rage subscribe to this and will:
+	// - Track turn count
+	// - Check if attack/damage occurred (Rage maintenance)
+	// - Reset per-turn flags (Sneak Attack)
+	turnEndTopic := dnd5eEvents.TurnEndTopic.On(bus)
+	err = turnEndTopic.Publish(ctx, dnd5eEvents.TurnEndEvent{
+		CharacterID: characterID,
+		Round:       round,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to publish turn end event: %w", err)
+	}
+
+	// 4. Persist updated character state (conditions may have changed)
+	updatedData := char.ToData()
+	_, err = o.charRepo.Update(ctx, characterrepo.UpdateInput{
+		CharacterData: updatedData,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to persist character state: %w", err)
+	}
+
+	return nil
+}
+
 // ResolveAttack implements the Service interface
 func (o *Orchestrator) ResolveAttack(ctx context.Context, input *ResolveAttackInput) (*ResolveAttackOutput, error) {
 	if input == nil {
@@ -1201,7 +1247,17 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 
 	// 5. Store previous state for turn change event
 	previousEntityID := activeEntity.EntityID
-	_ = initiativeData.Round // previousRound - stored but not currently used
+	previousRound := initiativeData.Round
+
+	// 5a. Publish TurnEndEvent to character's event bus (for Rage, Sneak Attack, etc.)
+	// This allows conditions to process turn end logic like checking for combat activity.
+	if activeEntity.EntityType == entityTypeCharacter {
+		if publishErr := o.publishCharacterTurnEnd(ctx, previousEntityID, previousRound); publishErr != nil {
+			// Log but don't fail - turn end events are important but not critical
+			// The turn will still advance; conditions just won't update
+			fmt.Printf("warning: failed to publish turn end event for character %s: %v\n", previousEntityID, publishErr)
+		}
+	}
 
 	// 6. Advance to next turn
 	newRound := false

--- a/internal/orchestrators/encounter/orchestrator_test.go
+++ b/internal/orchestrators/encounter/orchestrator_test.go
@@ -73,6 +73,39 @@ func TestOrchestratorSuite(t *testing.T) {
 	suite.Run(t, new(OrchestratorTestSuite))
 }
 
+// expectCharacterTurnEnd sets up mock expectations for the character repository
+// calls that happen during EndTurn's turn-end event publishing.
+// This is needed because EndTurn now publishes TurnEndEvent to character event buses.
+func (s *OrchestratorTestSuite) expectCharacterTurnEnd(characterID string) {
+	charData := &character.Data{
+		ID:               characterID,
+		Name:             "Test Character",
+		PlayerID:         "player-1",
+		Level:            1,
+		RaceID:           "human",
+		ClassID:          "fighter",
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    12,
+		MaxHitPoints: 12,
+	}
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: characterID}).
+		Return(&characterrepo.GetOutput{CharacterData: charData}, nil)
+
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&characterrepo.UpdateOutput{}, nil)
+}
+
 func (s *OrchestratorTestSuite) TestNew_Success() {
 	orch, err := New(&Config{
 		CharacterRepo: s.mockCharRepo,
@@ -1049,6 +1082,9 @@ func (s *OrchestratorTestSuite) TestEndTurn_Success() {
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-1")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1125,6 +1161,9 @@ func (s *OrchestratorTestSuite) TestEndTurn_AdvancesToNewRound() {
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
+	// Expect character turn-end event publishing for char-2 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-2")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1181,6 +1220,9 @@ func (s *OrchestratorTestSuite) TestEndTurn_SkipsMultipleMonsters() {
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-1")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1233,6 +1275,9 @@ func (s *OrchestratorTestSuite) TestEndTurn_SkipsMonstersAcrossRoundBoundary() {
 		{Entity: initiative.NewParticipant("goblin-2", "monster"), Roll: 18, Modifier: 2, Total: 20},
 		{Entity: initiative.NewParticipant("char-1", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
+
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-1")
 
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
@@ -1384,6 +1429,9 @@ func (s *OrchestratorTestSuite) TestEndTurn_UpdateError() {
 		Round:   1,
 	}
 
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-1")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1448,6 +1496,9 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithRoomData() {
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-1")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1503,6 +1554,27 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithPlayerID_OwnershipValid() {
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
+	// Character data used for both ownership validation and turn-end event publishing
+	charData := &character.Data{
+		ID:               "char-1",
+		Name:             "Test Character",
+		PlayerID:         "player-1", // Owned by player-1
+		Level:            1,
+		RaceID:           "human",
+		ClassID:          "fighter",
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    12,
+		MaxHitPoints: 12,
+	}
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1513,15 +1585,16 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithPlayerID_OwnershipValid() {
 			},
 		}, nil)
 
-	// Mock character lookup to verify ownership
+	// Mock character lookup - called twice: ownership validation and turn-end event publishing
 	s.mockCharRepo.EXPECT().
 		Get(gomock.Any(), characterrepo.GetInput{ID: "char-1"}).
-		Return(&characterrepo.GetOutput{
-			CharacterData: &character.Data{
-				ID:       "char-1",
-				PlayerID: "player-1", // Owned by player-1
-			},
-		}, nil)
+		Return(&characterrepo.GetOutput{CharacterData: charData}, nil).
+		Times(2)
+
+	// Mock character update after turn-end event processing
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&characterrepo.UpdateOutput{}, nil)
 
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -1668,7 +1741,7 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithPlayerID_CharacterLookupFails() 
 }
 
 func (s *OrchestratorTestSuite) TestEndTurn_WithoutPlayerID_SkipsValidation() {
-	// Arrange - backward compatibility: no PlayerID means no validation
+	// Arrange - backward compatibility: no PlayerID means no ownership validation
 	initiativeData := &initiative.TrackerData{
 		Order: []initiative.EntityData{
 			{ID: "char-1", Type: "character"},
@@ -1683,6 +1756,10 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithoutPlayerID_SkipsValidation() {
 		{Entity: initiative.NewParticipant("char-2", "character"), Roll: 10, Modifier: 1, Total: 11},
 	}
 
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	// Note: Ownership validation is skipped (no PlayerID), but turn-end event publishing still happens
+	s.expectCharacterTurnEnd("char-1")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{
@@ -1692,8 +1769,6 @@ func (s *OrchestratorTestSuite) TestEndTurn_WithoutPlayerID_SkipsValidation() {
 				InitiativeRolls: initiativeRolls,
 			},
 		}, nil)
-
-	// Note: No character repo call expected - validation is skipped
 
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
@@ -2005,6 +2080,10 @@ func (s *OrchestratorTestSuite) TestEndTurn_ResetsActionEconomy() {
 		},
 		Monsters: []*monster.Data{monster.NewGoblin("goblin-1").ToData()},
 	}
+
+	// Expect character turn-end event publishing for char-1 (whose turn is ending)
+	s.expectCharacterTurnEnd("char-1")
+
 	s.mockEncRepo.EXPECT().
 		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-1"}).
 		Return(&encounterrepo.GetOutput{Data: encData}, nil)


### PR DESCRIPTION
## Summary

- Publishes TurnEndEvent to character's event bus when their combat turn ends
- Enables conditions like Rage and Sneak Attack to process turn-end logic
- Character state is persisted after event processing (conditions may change)

Closes #351

## Implementation

Added `publishCharacterTurnEnd` method that:
1. Loads character from repository
2. Creates fresh event bus and loads character (conditions subscribe)
3. Publishes TurnEndEvent to the bus
4. Persists updated character state

Called from `EndTurn` when the active entity is a character. Errors are logged but don't fail the operation (turn-end events are important but not critical to combat flow).

## Test plan

- [x] TestEndTurn_Success - verifies character repo calls for turn-end publishing
- [x] TestEndTurn_AdvancesToNewRound - verifies publishing happens across round boundaries
- [x] TestEndTurn_SkipsMultipleMonsters - verifies no publishing for monster turns
- [x] TestEndTurn_PublishesTurnEndedEvent - verifies event publishing integration
- [x] All existing EndTurn tests updated to expect character repo calls

## Related

- Issue #260 (combat/room context) is blocked on rpg-toolkit#502 - will be addressed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)