### PR TITLE
feat(encounter): include UpdatedCharacters in MonsterTurnCompletedEvent

### DIFF
--- a/internal/entities/encounter_events.go
+++ b/internal/entities/encounter_events.go
@@ -174,11 +174,12 @@ type TurnEndedEvent struct {
 
 // MonsterTurnCompletedEvent is emitted when a monster completes its turn
 type MonsterTurnCompletedEvent struct {
-	MonsterID   string                  `json:"monster_id"`
-	MonsterName string                  `json:"monster_name"`
-	Actions     []MonsterExecutedAction `json:"actions"`
-	Movement    []Position              `json:"movement"`
-	Room        *spatial.RoomData       `json:"room,omitempty"` // Updated room with entity positions
+	MonsterID         string                  `json:"monster_id"`
+	MonsterName       string                  `json:"monster_name"`
+	Actions           []MonsterExecutedAction `json:"actions"`
+	Movement          []Position              `json:"movement"`
+	Room              *spatial.RoomData       `json:"room,omitempty"`              // Updated room with entity positions
+	UpdatedCharacters []*character.Data       `json:"updated_characters,omitempty"` // Characters that took damage
 }
 
 // DungeonVictoryEvent is emitted when the boss is defeated

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -840,6 +840,13 @@ func (h *Handler) convertToProtoEvent(event *entities.EncounterEvent) (*dnd5ev1a
 				Z: pos.Z,
 			}
 		}
+		// Convert updated characters to proto
+		var updatedCharacters []*dnd5ev1alpha1.Character
+		for _, charData := range event.MonsterTurnCompleted.UpdatedCharacters {
+			if charData != nil {
+				updatedCharacters = append(updatedCharacters, characterhandler.ConvertCharacterDataToProto(charData))
+			}
+		}
 		protoEvent.Event = &dnd5ev1alpha1.EncounterEvent_MonsterTurnCompleted{
 			MonsterTurnCompleted: &dnd5ev1alpha1.MonsterTurnCompletedEvent{
 				MonsterTurn: &dnd5ev1alpha1.MonsterTurnResult{
@@ -848,7 +855,8 @@ func (h *Handler) convertToProtoEvent(event *entities.EncounterEvent) (*dnd5ev1a
 					Actions:      actions,
 					MovementPath: movementPath,
 				},
-				UpdatedRoom: convertRoomDataToProto(event.MonsterTurnCompleted.Room),
+				UpdatedCharacters: updatedCharacters,
+				UpdatedRoom:       convertRoomDataToProto(event.MonsterTurnCompleted.Room),
 			},
 		}
 

--- a/internal/orchestrators/encounter/monster_turns.go
+++ b/internal/orchestrators/encounter/monster_turns.go
@@ -158,6 +158,7 @@ func (o *Orchestrator) executeSingleMonsterTurn(
 	// The toolkit publishes AttackEvent but doesn't populate ExecutedAction.Details
 	// We need to resolve attacks ourselves based on action type
 	actions := make([]MonsterExecutedAction, len(turnResult.Actions))
+	damagedCharacterIDs := make(map[string]bool) // Track unique damaged characters
 	for i, action := range turnResult.Actions {
 		actions[i] = MonsterExecutedAction{
 			ActionID:   action.ActionID,
@@ -186,6 +187,9 @@ func (o *Orchestrator) executeSingleMonsterTurn(
 					newHP = 0 // HP can't go below 0
 				}
 				enc.CharacterHP[action.TargetID] = newHP
+
+				// Track this character as damaged for event broadcast
+				damagedCharacterIDs[action.TargetID] = true
 			}
 		}
 	}
@@ -210,12 +214,31 @@ func (o *Orchestrator) executeSingleMonsterTurn(
 		}
 	}
 
-	// 11. Create result
+	// 11. Load updated character data for damaged characters
+	var updatedCharacters []*character.Data
+	for charID := range damagedCharacterIDs {
+		charOutput, charErr := o.charRepo.Get(ctx, characterrepo.GetInput{ID: charID})
+		if charErr != nil {
+			// Log but don't fail - character data is supplementary
+			continue
+		}
+		if charOutput.CharacterData != nil {
+			// Update the HP in the character data to reflect damage taken
+			charData := charOutput.CharacterData
+			if newHP, exists := enc.CharacterHP[charID]; exists {
+				charData.HitPoints = newHP
+			}
+			updatedCharacters = append(updatedCharacters, charData)
+		}
+	}
+
+	// 12. Create result
 	result := &MonsterTurnResult{
-		MonsterID:   turnResult.MonsterID,
-		MonsterName: monsterData.Name,
-		Actions:     actions,
-		Movement:    movement,
+		MonsterID:         turnResult.MonsterID,
+		MonsterName:       monsterData.Name,
+		Actions:           actions,
+		Movement:          movement,
+		UpdatedCharacters: updatedCharacters,
 	}
 
 	return result, nil

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1360,11 +1360,12 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 	// Publish MonsterTurnCompleted events for each monster turn
 	for _, mt := range monsterTurns {
 		o.publishEvent(ctx, input.EncounterID, entities.EventTypeMonsterTurnCompleted, &entities.MonsterTurnCompletedEvent{
-			MonsterID:   mt.MonsterID,
-			MonsterName: mt.MonsterName,
-			Actions:     mt.Actions,
-			Movement:    mt.Movement,
-			Room:        turnEndedRoomData,
+			MonsterID:         mt.MonsterID,
+			MonsterName:       mt.MonsterName,
+			Actions:           mt.Actions,
+			Movement:          mt.Movement,
+			Room:              turnEndedRoomData,
+			UpdatedCharacters: mt.UpdatedCharacters,
 		})
 	}
 
@@ -2758,11 +2759,12 @@ func (o *Orchestrator) StartCombat(
 	// 19. Publish MonsterTurnCompleted events if monsters went first
 	for _, mt := range monsterTurns {
 		o.publishEvent(ctx, input.EncounterID, entities.EventTypeMonsterTurnCompleted, &entities.MonsterTurnCompletedEvent{
-			MonsterID:   mt.MonsterID,
-			MonsterName: mt.MonsterName,
-			Actions:     mt.Actions,
-			Movement:    mt.Movement,
-			Room:        roomData,
+			MonsterID:         mt.MonsterID,
+			MonsterName:       mt.MonsterName,
+			Actions:           mt.Actions,
+			Movement:          mt.Movement,
+			Room:              roomData,
+			UpdatedCharacters: mt.UpdatedCharacters,
 		})
 	}
 

--- a/internal/orchestrators/encounter/service.go
+++ b/internal/orchestrators/encounter/service.go
@@ -7,6 +7,7 @@ import (
 	pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 )
 
@@ -274,10 +275,11 @@ type ActivateFeatureOutput struct {
 // MonsterTurnResult represents the outcome of a monster's turn
 // This mirrors toolkit monster.TurnResult for handler layer use
 type MonsterTurnResult struct {
-	MonsterID   string                  // ID of the monster that took the turn
-	MonsterName string                  // Name for self-contained streaming
-	Actions     []MonsterExecutedAction // All actions taken this turn
-	Movement    []Position              // Path traversed during movement
+	MonsterID         string                  // ID of the monster that took the turn
+	MonsterName       string                  // Name for self-contained streaming
+	Actions           []MonsterExecutedAction // All actions taken this turn
+	Movement          []Position              // Path traversed during movement
+	UpdatedCharacters []*toolkitchar.Data     // Characters that took damage (with updated HP)
 }
 
 // MonsterExecutedAction is aliased from entities at the top of this file


### PR DESCRIPTION
## Summary
- Adds `UpdatedCharacters` field to `MonsterTurnCompletedEvent` entity and proto conversion
- Tracks characters damaged during monster attacks and loads their updated data
- Populates `UpdatedCharacters` in the event so clients can sync HP changes

Fixes #353

## Test plan
- [ ] Run existing tests to ensure no regressions
- [ ] Test in multiplayer: when monster attacks a character, the MonsterTurnCompletedEvent should include the damaged character with updated HP

🤖 Generated with [Claude Code](https://claude.com/claude-code)