### PR TITLE
feat: Support two-weapon fighting via AttackHand parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/KirkDiggler/rpg-api
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251224091623-f65e35559fdd
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260102051912-028dc289e557
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.38.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.38.1
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.3.1-0.20251218021904-e9530f960b23
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251224091623-f65e35559fdd h1:+8daIKhBC94+fj8TkRYeEA0lEisIID+DEKxWq5iyA1o=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20251224091623-f65e35559fdd/go.mod h1:oKePHWFHmXQnRlViAFBVNpgJlMsV7oxJu13SDr3h+Es=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260102051912-028dc289e557 h1:AIoLE5MKf2Grb8Vs/qg/fWEixnK2hsOVQMp3rlv0mBo=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260102051912-028dc289e557/go.mod h1:oKePHWFHmXQnRlViAFBVNpgJlMsV7oxJu13SDr3h+Es=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
@@ -12,8 +12,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.38.0 h1:zAT3CCgNupyQRCOSoRWESyTDQA8o/YVKWSYqltLRgNc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.38.0/go.mod h1:LQNKzgrzk8MCvaiKUHff9YLh0ngFo/akda+WH8epct4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.38.1 h1:450ECssJeiN4R5Mxx2OrOxpUW/Ktj/42qArqYyiz2do=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.38.1/go.mod h1:LQNKzgrzk8MCvaiKUHff9YLh0ngFo/akda+WH8epct4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2 h1:warO6dvk/Ymyc3lnVU7x1xIM0T6dw7h6DQ8Clz4z/PI=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2/go.mod h1:IwhSpU197TgOvI/ZjnJMJabykFnivhCywj5gFENQV9c=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/handlers/dnd5e/v1alpha1/encounter/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/converters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
@@ -994,4 +995,17 @@ func convertDoorInfoSliceToProto(doors []encounter.DoorInfo) []*dnd5ev1alpha1.Do
 		}
 	}
 	return result
+}
+
+// protoAttackHandToToolkit converts proto AttackHand enum to toolkit combat.AttackHand
+func protoAttackHandToToolkit(hand dnd5ev1alpha1.AttackHand) combat.AttackHand {
+	switch hand {
+	case dnd5ev1alpha1.AttackHand_ATTACK_HAND_OFF:
+		return combat.AttackHandOff
+	case dnd5ev1alpha1.AttackHand_ATTACK_HAND_MAIN:
+		return combat.AttackHandMain
+	default:
+		// UNSPECIFIED defaults to main hand behavior
+		return combat.AttackHandMain
+	}
 }

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -75,7 +75,8 @@ func (h *Handler) Attack(ctx context.Context, req *dnd5ev1alpha1.AttackRequest) 
 		EncounterID: req.GetEncounterId(),
 		AttackerID:  req.GetAttackerId(),
 		TargetID:    req.GetTargetId(),
-		WeaponID:    req.GetWeaponId(), // Optional
+		WeaponID:    req.GetWeaponId(),                             // Optional
+		AttackHand:  protoAttackHandToToolkit(req.GetAttackHand()), // For two-weapon fighting
 	}
 
 	// 3. Call service

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/KirkDiggler/rpg-api/internal/auth"
 	"github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 	encountermock "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/mock"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -116,6 +117,7 @@ func (s *HandlerTestSuite) TestAttack_Success() {
 			AttackerID:  "char-1",
 			TargetID:    "goblin-1",
 			WeaponID:    "",
+			AttackHand:  combat.AttackHandMain, // Default for unspecified
 		}).
 		Return(&encounter.ResolveAttackOutput{
 			Result:      expectedResult,
@@ -320,6 +322,7 @@ func (s *HandlerTestSuite) TestAttack_WithWeapon() {
 			AttackerID:  "char-1",
 			TargetID:    "goblin-1",
 			WeaponID:    "longsword",
+			AttackHand:  combat.AttackHandMain, // Default for unspecified
 		}).
 		Return(&encounter.ResolveAttackOutput{
 			Result:      expectedResult,

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -343,6 +343,7 @@ func (o *Orchestrator) ResolveAttack(ctx context.Context, input *ResolveAttackIn
 		ProficiencyBonus: char.GetProficiencyBonus(),
 		EventBus:         bus,
 		Roller:           o.roller,
+		AttackHand:       input.AttackHand, // For two-weapon fighting
 	})
 	if err != nil {
 		return nil, fmt.Errorf("combat resolution failed: %w", err)

--- a/internal/orchestrators/encounter/service.go
+++ b/internal/orchestrators/encounter/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 )
 
@@ -114,7 +115,8 @@ type ResolveAttackInput struct {
 	EncounterID string
 	AttackerID  string
 	TargetID    string
-	WeaponID    string // Optional, uses default weapon if empty
+	WeaponID    string            // Optional, uses default weapon if empty
+	AttackHand  combat.AttackHand // Which hand is attacking (main/off for TWF)
 }
 
 // ResolveAttackOutput returns attack results


### PR DESCRIPTION
## Summary

Closes #359 (Phase 2 - Attack Handler Changes)

Adds support for two-weapon fighting by passing `AttackHand` through the API to the toolkit's combat system.

## Changes

- **service.go**: Add `AttackHand` field to `ResolveAttackInput`
- **orchestrator.go**: Pass `AttackHand` to toolkit's `combat.ResolveAttack`
- **converters.go**: Add `protoAttackHandToToolkit` for proto enum mapping
- **handler.go**: Wire up proto `attack_hand` field
- **go.mod**: Update protos and toolkit dependencies

## Dependencies

- **Protos**: Updated to include `AttackHand` enum (PR #113)
- **Toolkit**: Updated to v0.38.1 with TWF validation (PR #510)

## How It Works

1. Client sends `AttackRequest` with `attack_hand: OFF`
2. Handler maps `ATTACK_HAND_OFF` → `combat.AttackHandOff`
3. Orchestrator passes `AttackHand` to toolkit
4. Toolkit validates:
   - Both weapons are light (or has Dual Wielder feat)
   - Bonus action is available
   - TwoWeaponContext is set
5. If valid, off-hand attack proceeds with TWF damage rules

## Test plan

- [x] All existing tests pass
- [x] Updated mock expectations to include `AttackHand`
- [x] `make pre-commit` passes

## Remaining Work (Phase 3-4)

- [ ] Validate character has weapon in off-hand slot
- [ ] Use weapon from off_hand slot when off-hand attack requested
- [ ] Consume bonus action on successful off-hand attack

🤖 Generated with [Claude Code](https://claude.com/claude-code)