### PR TITLE
fix: Include UpdatedRoom in MovementCompleted event

### DIFF
--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1193,6 +1193,7 @@ func (o *Orchestrator) MoveCharacter(ctx context.Context, input *MoveCharacterIn
 		},
 		MovementRemaining: movementRemaining,
 		StopReason:        "completed",
+		UpdatedRoom:       roomData,
 	})
 
 	// 10. Return success with updated position


### PR DESCRIPTION
## Summary

- Adds `UpdatedRoom: roomData` to the MovementCompletedEvent publication
- Fixes UI not updating entity positions after move actions
- Aligns with the pattern used by AttackResolvedEvent

## Root Cause

The `MovementCompletedEvent` was missing the `UpdatedRoom` field when published at `orchestrator.go:1186-1196`. The output returned to the caller included it (line 1208), but the event streamed to clients did not.

The client (`LobbyView.tsx:370-372`) checks for `event.updatedRoom` and calls `setRoom()` if present - but since it was never set, the grid never updated after movement.

## Test plan

- [x] `make pre-commit` passes
- [ ] Manual test: move a character and verify the hex grid updates position

🤖 Generated with [Claude Code](https://claude.com/claude-code)