### PR TITLE
fix: Move AttackResult to entities for proper JSON serialization

### DIFF
--- a/internal/entities/encounter_events.go
+++ b/internal/entities/encounter_events.go
@@ -4,7 +4,9 @@ package entities
 import (
 	"time"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
@@ -148,11 +150,61 @@ type MovementCompletedEvent struct {
 	UpdatedRoom       *spatial.RoomData `json:"updated_room,omitempty"`
 }
 
+// AttackResult contains the full details of an attack resolution
+type AttackResult struct {
+	// Attack roll details
+	AttackRoll      int  `json:"attack_roll"`       // The d20 roll
+	AttackBonus     int  `json:"attack_bonus"`      // Total bonus applied
+	TotalAttack     int  `json:"total_attack"`      // Roll + bonus
+	TargetAC        int  `json:"target_ac"`         // Target's armor class
+	Hit             bool `json:"hit"`               // Did the attack hit?
+	Critical        bool `json:"critical"`          // Was it a critical hit?
+	IsNaturalTwenty bool `json:"is_natural_twenty"` // Natural 20
+	IsNaturalOne    bool `json:"is_natural_one"`    // Natural 1
+
+	// Damage details
+	DamageRolls []int       `json:"damage_rolls"` // Individual damage dice rolls
+	DamageBonus int         `json:"damage_bonus"` // Total damage bonus
+	TotalDamage int         `json:"total_damage"` // Final damage dealt
+	DamageType  damage.Type `json:"damage_type"`  // Type of damage (slashing, piercing, etc.)
+
+	// Detailed breakdown
+	Breakdown *DamageBreakdown `json:"breakdown,omitempty"` // Detailed damage breakdown (nil if attack missed)
+}
+
+// DamageBreakdown provides detailed component breakdown of damage calculation
+type DamageBreakdown struct {
+	Components  []DamageComponent `json:"components"`
+	AbilityUsed string            `json:"ability_used"` // Ability used for attack ("STR", "DEX", etc.)
+	TotalDamage int               `json:"total_damage"` // Sum of all components
+}
+
+// DamageComponent represents damage from one source
+type DamageComponent struct {
+	Source            string        `json:"source"`              // Type of damage source ("weapon", "ability", "feature", "monster_trait", etc.)
+	SourceRef         *core.Ref     `json:"source_ref"`          // Type-safe reference identifying the specific source
+	OriginalDiceRolls []int         `json:"original_dice_rolls"` // Dice values as first rolled
+	FinalDiceRolls    []int         `json:"final_dice_rolls"`    // Dice values after all rerolls
+	Rerolls           []RerollEvent `json:"rerolls,omitempty"`   // History of rerolls
+	FlatBonus         int           `json:"flat_bonus"`          // Flat modifier (0 if none)
+	DamageType        damage.Type   `json:"damage_type"`         // Type of damage (slashing, fire, radiant, etc.)
+	IsCritical        bool          `json:"is_critical"`         // Was this component doubled for crit?
+	Multiplier        float64       `json:"multiplier"`          // Multiplier for vulnerability (2.0), resistance (0.5), or immunity (0)
+}
+
+// RerollEvent tracks a single die reroll
+type RerollEvent struct {
+	DieIndex int    `json:"die_index"` // Which die was rerolled (0-based index in original_dice_rolls)
+	Before   int    `json:"before"`    // Value before reroll
+	After    int    `json:"after"`     // Value after reroll
+	Reason   string `json:"reason"`    // Feature that caused reroll (e.g., "great_weapon_fighting")
+}
+
 // AttackResolvedEvent is emitted when an attack is resolved
 type AttackResolvedEvent struct {
 	AttackerID    string             `json:"attacker_id"`
 	TargetID      string             `json:"target_id"`
-	Result        interface{}        `json:"result"`
+	Result        *AttackResult      `json:"result"`
 	TargetHP      int                `json:"target_hp"`                // HP after attack
 	TargetDead    bool               `json:"target_dead"`              // Whether target was killed
 	Room          *spatial.RoomData  `json:"room,omitempty"`           // Updated room with entity positions

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -798,10 +798,10 @@ func (h *Handler) convertToProtoEvent(event *entities.EncounterEvent) (*dnd5ev1a
 		if event.AttackResolved == nil {
 			return nil, fmt.Errorf("missing AttackResolved data for AttackResolvedEvent")
 		}
-		// Convert AttackResult if available (type assert from interface{})
+		// Convert AttackResult - now a concrete type, no type assertion needed
 		var attackResult *dnd5ev1alpha1.AttackResult
-		if result, ok := event.AttackResolved.Result.(*encounter.AttackResult); ok {
-			attackResult = convertAttackResultToProto(result)
+		if event.AttackResolved.Result != nil {
+			attackResult = convertAttackResultToProto(event.AttackResolved.Result)
 		}
 		protoEvent.Event = &dnd5ev1alpha1.EncounterEvent_AttackResolved{
 			AttackResolved: &dnd5ev1alpha1.AttackResolvedEvent{

--- a/internal/orchestrators/encounter/service.go
+++ b/internal/orchestrators/encounter/service.go
@@ -6,10 +6,8 @@ import (
 
 	pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
-	"github.com/KirkDiggler/rpg-toolkit/core"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 )
 
 // Type aliases to entities - these are the canonical types
@@ -137,57 +135,18 @@ type GrantedAction struct {
 	WeaponID string // Associated weapon (if applicable)
 }
 
-// AttackResult contains the outcome of an attack
-// TODO: Replace with toolkit combat.AttackResult when available
-// This mirrors the toolkit type structure for compatibility
-type AttackResult struct {
-	// Attack roll details
-	AttackRoll      int  // The d20 roll
-	AttackBonus     int  // Total bonus applied
-	TotalAttack     int  // Roll + bonus
-	TargetAC        int  // Target's armor class
-	Hit             bool // Did the attack hit?
-	Critical        bool // Was it a critical hit?
-	IsNaturalTwenty bool // Natural 20
-	IsNaturalOne    bool // Natural 1
+// AttackResult is an alias to entities.AttackResult for backwards compatibility
+// The canonical type is in entities to avoid circular imports and enable proper JSON serialization
+type AttackResult = entities.AttackResult
 
-	// Damage details
-	DamageRolls []int       // Individual damage dice rolls
-	DamageBonus int         // Total damage bonus
-	TotalDamage int         // Final damage dealt
-	DamageType  damage.Type // Type of damage (slashing, piercing, etc.)
+// DamageBreakdown is an alias to entities.DamageBreakdown
+type DamageBreakdown = entities.DamageBreakdown
 
-	// Detailed breakdown
-	Breakdown *DamageBreakdown // Detailed damage breakdown (nil if attack missed)
-}
+// DamageComponent is an alias to entities.DamageComponent
+type DamageComponent = entities.DamageComponent
 
-// DamageBreakdown provides detailed component breakdown of damage calculation
-type DamageBreakdown struct {
-	Components  []DamageComponent
-	AbilityUsed string // Ability used for attack ("STR", "DEX", etc.)
-	TotalDamage int    // Sum of all components
-}
-
-// DamageComponent represents damage from one source
-type DamageComponent struct {
-	Source            string        // Type of damage source ("weapon", "ability", "feature", "monster_trait", etc.)
-	SourceRef         *core.Ref     // Type-safe reference identifying the specific source
-	OriginalDiceRolls []int         // Dice values as first rolled
-	FinalDiceRolls    []int         // Dice values after all rerolls
-	Rerolls           []RerollEvent // History of rerolls
-	FlatBonus         int           // Flat modifier (0 if none)
-	DamageType        damage.Type   // Type of damage (slashing, fire, radiant, etc.)
-	IsCritical        bool          // Was this component doubled for crit?
-	Multiplier        float64       // Multiplier for vulnerability (2.0), resistance (0.5), or immunity (0)
-}
-
-// RerollEvent tracks a single die reroll
-type RerollEvent struct {
-	DieIndex int    // Which die was rerolled (0-based index in original_dice_rolls)
-	Before   int    // Value before reroll
-	After    int    // Value after reroll
-	Reason   string // Feature that caused reroll (e.g., "great_weapon_fighting")
-}
+// RerollEvent is an alias to entities.RerollEvent
+type RerollEvent = entities.RerollEvent
 
 // CreateDungeonInput contains parameters for creating a dungeon encounter
 type CreateDungeonInput struct {


### PR DESCRIPTION
## Summary

Fixes the root cause of #369 where combat events were missing attack result data for non-initiating players.

**The bug:** `AttackResolvedEvent.Result` was defined as `interface{}` which loses type information during JSON serialization through Redis pub/sub:

1. Orchestrator creates `Result: *encounter.AttackResult{...}`
2. JSON marshal → `{"result": {...}}` (type info lost)
3. JSON unmarshal → `Result: map[string]interface{}{...}` 
4. Type assertion `Result.(*encounter.AttackResult)` → **fails**, returns `nil`

**The fix:** Move `AttackResult` and related types to the `entities` package so we can use a concrete type instead of `interface{}`.

## Changes

- Move `AttackResult`, `DamageBreakdown`, `DamageComponent`, `RerollEvent` to entities
- Update `AttackResolvedEvent.Result` from `interface{}` to `*AttackResult`
- Add type aliases in orchestrator for backwards compatibility
- Simplify handler conversion (no more type assertion needed)

## Historical context

This `interface{}` was introduced in commit `16a9978` to break a circular import between `entities` and `orchestrators/encounter`. The proper fix (moving types to entities) was partially done in `eb985c1` but `AttackResult` was missed.

## Test plan

- [x] All existing tests pass
- [ ] Test multiplayer attack events now include Result data

🤖 Generated with [Claude Code](https://claude.com/claude-code)