### PR TITLE
fix: Replace remaining interface{} fields in events

### DIFF
--- a/internal/entities/encounter_events.go
+++ b/internal/entities/encounter_events.go
@@ -124,9 +124,14 @@ type CombatStartedEvent struct {
 	MonsterTurns []*MonsterTurnCompletedEvent `json:"monster_turns,omitempty"` // Monster turns if monsters won initiative
 }
 
+// EncounterResult describes the outcome of an encounter
+type EncounterResult struct {
+	Reason string `json:"reason"` // "victory" (all monsters dead) or "defeat" (all players down)
+}
+
 // CombatEndedEvent is emitted when combat ends
 type CombatEndedEvent struct {
-	EncounterResult interface{} `json:"encounter_result"` // Victory or defeat
+	EncounterResult *EncounterResult `json:"encounter_result"` // Victory or defeat
 }
 
 // CombatPausedEvent is emitted when combat is paused
@@ -222,11 +227,11 @@ type GrantedActionInfo struct {
 
 // FeatureActivatedEvent is emitted when a combat feature is activated
 type FeatureActivatedEvent struct {
-	CharacterID   string      `json:"character_id"`
-	FeatureID     string      `json:"feature_id"`
-	Success       bool        `json:"success"`
-	Message       string      `json:"message"`
-	CharacterData interface{} `json:"character_data,omitempty"`
+	CharacterID   string          `json:"character_id"`
+	FeatureID     string          `json:"feature_id"`
+	Success       bool            `json:"success"`
+	Message       string          `json:"message"`
+	CharacterData *character.Data `json:"character_data,omitempty"`
 }
 
 // TurnEndedEvent is emitted when a turn ends

--- a/internal/orchestrators/encounter/service.go
+++ b/internal/orchestrators/encounter/service.go
@@ -216,10 +216,8 @@ type EndTurnOutput struct {
 	EncounterResult *EncounterResult     // Set if combat ended (victory or TPK)
 }
 
-// EncounterResult indicates combat has ended
-type EncounterResult struct {
-	Reason string // "victory" (all monsters dead) or "defeat" (all players down)
-}
+// EncounterResult is an alias to entities.EncounterResult
+type EncounterResult = entities.EncounterResult
 
 // TurnChangeEvent describes a turn transition
 type TurnChangeEvent struct {


### PR DESCRIPTION
## Summary

Follows up on #371 to fix the remaining `interface{}` fields that would cause JSON serialization issues through Redis pub/sub.

## Changes

- `CombatEndedEvent.EncounterResult`: `interface{}` → `*EncounterResult`
- `FeatureActivatedEvent.CharacterData`: `interface{}` → `*character.Data`
- Added `EncounterResult` type to entities
- Added type alias in orchestrator for backwards compatibility

## Verification

```bash
grep "interface{}" internal/entities/encounter_events.go
# (no output - all interface{} removed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)