### PR TITLE
refactor: migrate Monk tests to shared encounter helpers, fix log-and-pass

### DIFF
--- a/internal/integration/encounter/monk_test.go
+++ b/internal/integration/encounter/monk_test.go
@@ -225,14 +225,14 @@ func (s *MonkIntegrationSuite) TestMartialArts_CanAttackInCombat() {
 	s.T().Logf("  ✓ Found monster target: %s", targetMonsterID)
 
 	// 4. Attack with monk weapon
-	s.T().Log("Step 3: Attacking with monk weapon (shortsword)...")
+	s.T().Log("Step 4: Attacking with monk weapon (shortsword)...")
 	attackResp, err := s.server.EncounterClient.Attack(ctx, &dnd5ev1alpha1.AttackRequest{
 		EncounterId: encounterID,
 		AttackerId:  characterID,
 		TargetId:    targetMonsterID,
 	})
 	s.Require().NoError(err, "failed to resolve attack")
-	s.Assert().True(attackResp.GetSuccess(), "attack request should succeed: %s", attackResp.GetError())
+	s.Require().True(attackResp.GetSuccess(), "attack request should succeed: %s", attackResp.GetError())
 
 	result := attackResp.GetResult()
 	s.Require().NotNil(result, "attack result should not be nil")


### PR DESCRIPTION
## Context

Follow-up to PR #429. The Monk integration tests had the same two issues found during code review:

1. **Inline encounter setup** — copy-pasted CreateEncounter + SetReady + StartCombat instead of using shared helpers
2. **Log-and-pass** — `TestMartialArts_CanAttackInCombat` logged hit/miss but didn't assert anything meaningful

## Changes

- Replace inline encounter setup with `CreateEncounterAndStartCombat()` and `FindMonsterTarget()` from `helpers.go`
- Fix attack test to assert response structure (attack roll, total, AC all > 0)
- On hit: assert damage > 0, type set, breakdown present with components

## Result

- **-90 lines** of inline boilerplate
- **+31 lines** of real assertions
- All Monk tests passing (1 pass, 1 skip, 1 pass)

Part of the test coverage initiative (Phase 3 in `rpg-project/docs/ui-testing-plan/PLAN.md`).