### PR TITLE
fix: add shiftRoomToAbsolute to DungeonStart handler (#458)

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -115,6 +115,10 @@ func (h *Handler) DungeonStart(
 	room := convertRoomDataToProto(output.Room)
 	if room != nil {
 		room.Origin = dungeonPositionToProto(output.RoomOrigin)
+		// Shift walls and entities from room-local to dungeon-absolute coordinates.
+		// For the start room origin is (0,0,0) so this is a no-op, but keeping the
+		// call is required for consistency with OpenDoor and StartCombat.
+		shiftRoomToAbsolute(room)
 	}
 
 	return &dnd5ev1alpha1.DungeonStartResponse{

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
@@ -523,6 +523,74 @@ func (s *HandlerTestSuite) TestDungeonStart_EmptyRequest() {
 	s.Assert().Equal("enc-456-room", resp.Room.Id)
 }
 
+// TestDungeonStart_ShiftsEntitiesToAbsoluteCoordinates verifies that entity positions in the
+// response are shifted from room-local coordinates to dungeon-absolute coordinates.
+// This mirrors the same shift applied in OpenDoor and StartCombat.
+// For the start room, origin is always (0,0,0), but the handler must call shiftRoomToAbsolute
+// to remain consistent — if origin were ever non-zero (e.g. if dungeon layout changes),
+// the shift ensures correctness.
+func (s *HandlerTestSuite) TestDungeonStart_ShiftsEntitiesToAbsoluteCoordinates() {
+	// Room with a character in room-local hex cube coordinates.
+	// Cube coords: (1, -2, 1) — sum equals 0, so this is a valid cube coordinate.
+	localX, localY, localZ := 1, -2, 1
+	roomWithEntity := &spatial.RoomData{
+		ID:       "room-hex",
+		Type:     "dungeon",
+		Width:    10,
+		Height:   10,
+		GridType: spatial.GridTypeHex,
+		CubeEntities: map[string]spatial.EntityCubePlacement{
+			"char-1": {
+				EntityID:   "char-1",
+				EntityType: "character",
+				CubePosition: spatial.CubeCoordinate{
+					X: localX,
+					Y: localY,
+					Z: localZ,
+				},
+				Size:           1,
+				BlocksMovement: true,
+			},
+		},
+		Entities: make(map[string]spatial.EntityPlacement),
+	}
+
+	// Non-zero origin: the start room is at (5, 0, -5) in dungeon space.
+	// After shift, entity should be at (1+5, -2+0, 1-5) = (6, -2, -4).
+	originX, originY, originZ := 5, 0, -5
+	roomOrigin := &dungeon.Position{X: originX, Y: originY, Z: originZ}
+
+	s.mockService.EXPECT().
+		CreateDungeon(gomock.Any(), gomock.Any()).
+		Return(&encounter.CreateDungeonOutput{
+			EncounterID: "enc-shift-test",
+			Room:        roomWithEntity,
+			RoomOrigin:  roomOrigin,
+		}, nil)
+
+	resp, err := s.handler.DungeonStart(context.Background(), &dnd5ev1alpha1.DungeonStartRequest{
+		CharacterIds: []string{"char-1"},
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Room)
+
+	// Verify the origin is set correctly on the proto room.
+	s.Require().NotNil(resp.Room.Origin)
+	s.Assert().Equal(float64(originX), resp.Room.Origin.X)
+	s.Assert().Equal(float64(originY), resp.Room.Origin.Y)
+	s.Assert().Equal(float64(originZ), resp.Room.Origin.Z)
+
+	// Verify entity position has been shifted from room-local to dungeon-absolute.
+	entityPlacement, ok := resp.Room.Entities["char-1"]
+	s.Require().True(ok, "char-1 entity should be present in response room")
+	s.Require().NotNil(entityPlacement.Position)
+	s.Assert().Equal(float64(localX+originX), entityPlacement.Position.X, "entity X should be shifted by origin X")
+	s.Assert().Equal(float64(localY+originY), entityPlacement.Position.Y, "entity Y should be shifted by origin Y")
+	s.Assert().Equal(float64(localZ+originZ), entityPlacement.Position.Z, "entity Z should be shifted by origin Z")
+}
+
 // TestGetCombatState_Unimplemented tests that GetCombatState returns Unimplemented
 func (s *HandlerTestSuite) TestGetCombatState_Unimplemented() {
 	req := &dnd5ev1alpha1.GetCombatStateRequest{


### PR DESCRIPTION
## Summary

- `DungeonStart` set `room.Origin` but did not call `shiftRoomToAbsolute`, unlike `OpenDoor` (line 169) and `StartCombat` (line 577). This left entity and wall positions in room-local coordinates rather than dungeon-absolute coordinates.
- For the start room, origin is always `(0,0,0)` (BFS places it at origin), so the shift is a no-op today. The call is required for consistency and correctness if dungeon layout ever changes.
- Added `TestDungeonStart_ShiftsEntitiesToAbsoluteCoordinates` which uses a non-zero `(5,0,-5)` origin and verifies entity positions are correctly shifted to dungeon-absolute coordinates.

### Verification summary (Tasks 2–4 from issue)

**Task 2 — EncounterStateData snapshot after OpenDoor:** `buildEncounterStateSnapshot` fetches the dungeon fresh from the repository (line 5495) _after_ `OpenDoor` marks the new room as revealed (line 3203), so `buildRoomsMap` correctly iterates both the original and newly-revealed room. `CurrentRoomID` is NOT updated during OpenDoor — players remain in their current room, which is correct. Room origins come from `dng.RoomOrigins` in `buildRoomLayoutProto`. No bug found.

**Task 3 — Monster turns after OpenDoor:** New monsters are rolled for initiative (lines 3120–3141), merged into the existing order at the end of the current turn sequence (lines 3166–3188), and the initiative data is persisted (lines 3214–3220). On subsequent `EndTurn` calls these monsters will take turns normally. The TODO at line 3282 notes that monsters don't act _immediately_ on door open — this is expected D&D 5e behavior (new combatants join at end of round). No bug.

**Task 1 — StartCombat shift:** Already fixed in the recent main merge (line 577). The gap was `DungeonStart`, which this PR addresses.

## Test plan

- [x] `TestDungeonStart_ShiftsEntitiesToAbsoluteCoordinates` — verifies non-zero-origin shift
- [x] All existing `TestDungeonStart_*` tests continue to pass
- [x] `go test ./internal/handlers/dnd5e/v1alpha1/encounter/...` passes
- [x] `go test ./internal/orchestrators/encounter/...` passes
- [x] `go build ./...` passes

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)