### PR TITLE
fix: OpenDoor monster positions are absolute, not room-local

### DIFF
--- a/internal/orchestrators/encounter/open_door_test.go
+++ b/internal/orchestrators/encounter/open_door_test.go
@@ -447,3 +447,101 @@ func (s *OpenDoorTestSuite) TestOpenDoor_BothRoomsRevealed_Error() {
 	s.Nil(output)
 	s.Contains(err.Error(), "both rooms already revealed")
 }
+
+// TestOpenDoor_MonsterPositions_AreAbsolute verifies that when a room with a non-zero origin is
+// revealed, the monster positions stored in the encounter Entities map are absolute dungeon-space
+// coordinates (room-local + origin), not room-local coordinates.
+//
+// Regression test for: bug: OpenDoor monster positions are room-local, not absolute (#460)
+func (s *OpenDoorTestSuite) TestOpenDoor_MonsterPositions_AreAbsolute() {
+	// Room 2 is offset from the dungeon origin: origin (0, -10, 10) in cube coords.
+	// The monster is at room-local position (3, 2) which maps to cube (X=3, Z=2).
+	// After adding the room origin the absolute cube position should be:
+	//   absX = 3 + 0  = 3
+	//   absZ = 2 + 10 = 12
+	//   absY = -absX - absZ = -3 - 12 = -15
+	const (
+		originX = 0
+		originZ = 10
+
+		localMonsterX = 3 // room-local offset X -> cube X
+		localMonsterZ = 2 // room-local offset Y -> cube Z
+
+		wantAbsX = localMonsterX + originX // 3
+		wantAbsZ = localMonsterZ + originZ // 12
+		wantAbsY = -wantAbsX - wantAbsZ   // -15
+	)
+
+	// Arrange: build a dungeon where room-2 has a non-zero origin.
+	testDungeon := s.createTestDungeon()
+	testDungeon.Rooms["room-2"].Encounter = &dungeon.Encounter{
+		Monsters: []dungeon.MonsterPlacement{
+			{
+				ID:        "mp-abs",
+				MonsterID: "skeleton",
+				// Room-local offset coords: X=cube X, Y=cube Z
+				Position: dungeon.Position{X: localMonsterX, Y: localMonsterZ},
+			},
+		},
+	}
+	testDungeon.RoomOrigins = map[string]dungeon.Position{
+		"room-2": {X: originX, Y: -originX - originZ, Z: originZ},
+	}
+
+	// The encounter data must have an Entities map so addMonstersToEntityMap does not skip.
+	var capturedEncData *encounterrepo.EncounterData
+	testEncounter := s.createTestEncounterData()
+	testEncounter.Entities = make(map[string]*entities.EntityStateData)
+
+	s.mockDungeonRepo.EXPECT().
+		Get(gomock.Any(), &dungeonrepo.GetInput{DungeonID: "dng-123"}).
+		Return(&dungeonrepo.GetOutput{Dungeon: testDungeon}, nil)
+
+	s.mockEncRepo.EXPECT().
+		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-123"}).
+		DoAndReturn(func(_ context.Context, _ *encounterrepo.GetInput) (*encounterrepo.GetOutput, error) {
+			capturedEncData = testEncounter
+			return &encounterrepo.GetOutput{Data: testEncounter}, nil
+		})
+
+	s.mockDungeonRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.UpdateOutput{Success: true}, nil)
+
+	s.mockEncRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&encounterrepo.UpdateOutput{}, nil)
+
+	// buildEncounterStateSnapshot calls GetByEncounterID to load dungeon context for the snapshot.
+	// Return the same dungeon (now updated with room-2 revealed) so the snapshot can be built.
+	s.mockDungeonRepo.EXPECT().
+		GetByEncounterID(gomock.Any(), &dungeonrepo.GetByEncounterIDInput{EncounterID: "enc-123"}).
+		Return(&dungeonrepo.GetOutput{Dungeon: testDungeon}, nil)
+
+	// Act
+	output, err := s.orchestrator.OpenDoor(s.ctx, &encounter.OpenDoorInput{
+		DungeonID:    "dng-123",
+		ConnectionID: "conn-1",
+	})
+
+	// Assert: OpenDoor itself should succeed.
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+
+	// The captured encounter data has been mutated in-place by addMonstersToEntityMap.
+	// The monster entity must carry absolute dungeon-space cube coordinates.
+	s.Require().NotNil(capturedEncData, "encounter data should have been captured")
+	s.Require().NotEmpty(capturedEncData.Entities, "entities map should not be empty after monster spawn")
+
+	monsterKey := "monster-room-2-mp-abs"
+	entity, ok := capturedEncData.Entities[monsterKey]
+	s.Require().True(ok, "entity %q should be present in Entities map", monsterKey)
+	s.Require().NotNil(entity.Position, "entity position should not be nil")
+
+	s.Equal(float64(wantAbsX), entity.Position.X,
+		"absolute X should be room-local (%d) + origin (%d) = %d", localMonsterX, originX, wantAbsX)
+	s.Equal(float64(wantAbsY), entity.Position.Y,
+		"absolute Y should satisfy cube constraint: -absX - absZ = %d", wantAbsY)
+	s.Equal(float64(wantAbsZ), entity.Position.Z,
+		"absolute Z should be room-local (%d) + origin (%d) = %d", localMonsterZ, originZ, wantAbsZ)
+}

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -3316,8 +3316,9 @@ func (o *Orchestrator) OpenDoor(
 		}
 	}
 
-	// 17. Add new monster entities to encounter Entities map for snapshot
-	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID)
+	// 17. Add new monster entities to encounter Entities map for snapshot.
+	// Pass the room origin so entity positions are stored as absolute dungeon-space coordinates.
+	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID, roomOriginFor(dng, revealedRoomID))
 
 	// Build snapshot for RoomRevealed event
 	roomRevealedStateData := o.buildEncounterStateSnapshot(ctx, dng.EncounterID, encOutput.Data, combatState)
@@ -5545,30 +5546,49 @@ func (o *Orchestrator) buildEncounterStateSnapshot(
 	return output.EncounterStateData
 }
 
+// roomOriginFor returns the absolute dungeon-space cube origin for the given room, or a zero
+// value if the dungeon has no stored origins or the room is not present in the map.
+func roomOriginFor(dng *entities.Dungeon, roomID string) dungeon.Position {
+	if dng.RoomOrigins == nil {
+		return dungeon.Position{}
+	}
+	return dng.RoomOrigins[roomID]
+}
+
 // addMonstersToEntityMap adds newly spawned monsters (from room reveal) to the encounter's
 // Entities map so that subsequent snapshot events include them.
+//
+// roomOrigin is the absolute dungeon-space cube position of the room. Monster placements
+// are stored in room-local offset coordinates (X = cube X, Y = cube Z), so the origin must
+// be added to produce the absolute position that the rest of the system expects.
 func (o *Orchestrator) addMonstersToEntityMap(
 	enc *encounterrepo.EncounterData,
 	monsters []MonsterInfo,
 	roomID string,
+	roomOrigin dungeon.Position,
 ) {
 	if enc == nil || enc.Entities == nil || len(monsters) == 0 {
 		return
 	}
 
 	for _, m := range monsters {
-		cubeX := int(m.Position.X)
-		cubeZ := int(m.Position.Y)
-		cubeY := -cubeX - cubeZ
+		// Monster positions in MonsterInfo use offset (2D) coords:
+		//   Position.X -> cube X axis
+		//   Position.Y -> cube Z axis
+		// Add the room origin (cube coords) to convert to absolute dungeon-space.
+		absX := int(m.Position.X) + roomOrigin.X
+		absZ := int(m.Position.Y) + roomOrigin.Z
+		absY := -absX - absZ // cube constraint: x + y + z = 0
+
 		monsterData := o.findMonsterData(enc, m.ID)
 		enc.Entities[m.ID] = &entities.EntityStateData{
 			EntityID:   m.ID,
 			EntityType: entities.EntityTypeMonster,
 			RoomID:     roomID,
 			Position: &entities.Position{
-				X: float64(cubeX),
-				Y: float64(cubeY),
-				Z: float64(cubeZ),
+				X: float64(absX),
+				Y: float64(absY),
+				Z: float64(absZ),
 			},
 			Size:        1,
 			ToolkitData: monsterData,


### PR DESCRIPTION
## Summary

Fixes #460

- Monster entity positions in the `EncounterStateData` snapshot were stored as room-local cube coordinates instead of absolute dungeon-space coordinates
- Monsters in room 2 (origin `(0,-10,10)`) appeared at `(0,0,0)` instead of their true absolute position
- Added a `roomOriginFor` helper to extract the room origin without raising `OpenDoor`'s cyclomatic complexity above the existing threshold
- Updated `addMonstersToEntityMap` to accept a `dungeon.Position` room origin and offset each monster's cube coords by it: `absX = localX + origin.X`, `absZ = localZ + origin.Z`, `absY = -absX - absZ`

## What is unchanged

- `MonsterInfo.Position` still carries room-local coords (used for `revealedSpatialRoom.CubeEntities` and `responseRoomData.Entities` — both room-local by design, offset by the separately-provided `RoomOrigin`/`RoomOffset`)
- The `RoomRevealedEvent.RevealedRoom` spatial data is room-local (client applies `RoomOrigin` to render it)

## Test plan

- [ ] `TestOpenDoor_MonsterPositions_AreAbsolute` — new regression test: opens a door to a room with origin `(0,-10,10)`, asserts entity positions are `absX=3, absZ=12, absY=-15` (not room-local `3, 2`)
- [ ] All existing `TestOpenDoorSuite` tests still pass
- [ ] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)