### PR TITLE
fix: translate wall positions to absolute dungeon-space in buildRoomLayoutProto

### DIFF
--- a/internal/orchestrators/encounter/build_room_layout_proto_test.go
+++ b/internal/orchestrators/encounter/build_room_layout_proto_test.go
@@ -1,0 +1,160 @@
+package encounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
+)
+
+func TestBuildRoomLayoutProto_NilRoom(t *testing.T) {
+	result := buildRoomLayoutProto(nil, nil)
+	assert.Nil(t, result)
+}
+
+func TestBuildRoomLayoutProto_NilShape(t *testing.T) {
+	room := &dungeon.Room{ID: "room-1", Shape: nil}
+	result := buildRoomLayoutProto(room, nil)
+	assert.Nil(t, result)
+}
+
+func TestBuildRoomLayoutProto_WallsShiftedByOrigin(t *testing.T) {
+	// Room 2 has walls in room-local coordinates. With origin (5, -5, 0), the
+	// absolute positions must be offset by that origin.
+	room := &dungeon.Room{
+		ID: "room-2",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    5,
+			Height:   5,
+		},
+		Walls: []dungeon.WallSegment{
+			{
+				ID:                "wall-1",
+				Start:             dungeon.Position{X: 1, Y: -1, Z: 0},
+				End:               dungeon.Position{X: 2, Y: -2, Z: 0},
+				Type:              dungeon.WallTypeIndestructible,
+				BlocksMovement:    true,
+				BlocksLineOfSight: true,
+			},
+		},
+	}
+
+	// origin (5, -5, 0): X=5, Z=0, Y=-5 (derived from cube constraint -5-0).
+	origin := &dungeon.Position{X: 5, Y: -5, Z: 0}
+
+	result := buildRoomLayoutProto(room, origin)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Walls, 1)
+
+	wall := result.Walls[0]
+
+	// Start: local (1, -1, 0) + origin (5, 0) => absolute X=6, Z=0, Y=-6-0=-6
+	assert.Equal(t, 6.0, wall.Start.X, "Start.X should be local+origin.X")
+	assert.Equal(t, 0.0, wall.Start.Z, "Start.Z should be local+origin.Z")
+	assert.Equal(t, -6.0, wall.Start.Y, "Start.Y must satisfy cube constraint: -x-z")
+
+	// End: local (2, -2, 0) + origin (5, 0) => absolute X=7, Z=0, Y=-7-0=-7
+	assert.Equal(t, 7.0, wall.End.X, "End.X should be local+origin.X")
+	assert.Equal(t, 0.0, wall.End.Z, "End.Z should be local+origin.Z")
+	assert.Equal(t, -7.0, wall.End.Y, "End.Y must satisfy cube constraint: -x-z")
+
+	assert.Equal(t, "stone", wall.Material)
+	assert.True(t, wall.BlocksMovement)
+	assert.True(t, wall.BlocksLineOfSight)
+}
+
+func TestBuildRoomLayoutProto_WallsNilOriginPassThrough(t *testing.T) {
+	// When origin is nil the wall positions come through unchanged, but Y is still
+	// recomputed from the cube constraint.
+	room := &dungeon.Room{
+		ID: "room-1",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    3,
+			Height:   3,
+		},
+		Walls: []dungeon.WallSegment{
+			{
+				ID:    "wall-1",
+				Start: dungeon.Position{X: 2, Y: -3, Z: 1},
+				End:   dungeon.Position{X: 3, Y: -4, Z: 1},
+				Type:  dungeon.WallTypeDestructible,
+			},
+		},
+	}
+
+	result := buildRoomLayoutProto(room, nil)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Walls, 1)
+
+	wall := result.Walls[0]
+
+	// No origin: X and Z pass through, Y recomputed from cube constraint.
+	assert.Equal(t, 2.0, wall.Start.X)
+	assert.Equal(t, 1.0, wall.Start.Z)
+	assert.Equal(t, -3.0, wall.Start.Y, "Start.Y must satisfy cube constraint: -2-1=-3")
+
+	assert.Equal(t, 3.0, wall.End.X)
+	assert.Equal(t, 1.0, wall.End.Z)
+	assert.Equal(t, -4.0, wall.End.Y, "End.Y must satisfy cube constraint: -3-1=-4")
+
+	assert.Equal(t, "wood", wall.Material, "destructible walls use wood material")
+}
+
+func TestBuildRoomLayoutProto_OriginSetInProto(t *testing.T) {
+	room := &dungeon.Room{
+		ID: "room-3",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    4,
+			Height:   4,
+		},
+	}
+	origin := &dungeon.Position{X: 5, Y: -5, Z: 0}
+
+	result := buildRoomLayoutProto(room, origin)
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.Origin)
+	assert.Equal(t, 5.0, result.Origin.X)
+	assert.Equal(t, -5.0, result.Origin.Y)
+	assert.Equal(t, 0.0, result.Origin.Z)
+}
+
+func TestBuildRoomLayoutProto_MultipleWallsAllShifted(t *testing.T) {
+	// Verify that every wall in a multi-wall room gets the offset applied.
+	room := &dungeon.Room{
+		ID: "room-4",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    6,
+			Height:   6,
+		},
+		Walls: []dungeon.WallSegment{
+			{ID: "w1", Start: dungeon.Position{X: 0, Y: 0, Z: 0}, End: dungeon.Position{X: 1, Y: -1, Z: 0}},
+			{ID: "w2", Start: dungeon.Position{X: 1, Y: -1, Z: 0}, End: dungeon.Position{X: 2, Y: -1, Z: -1}},
+		},
+	}
+
+	origin := &dungeon.Position{X: 3, Y: -3, Z: 0}
+
+	result := buildRoomLayoutProto(room, origin)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Walls, 2)
+
+	// Wall 0: start (0,0,0) + origin(3,0) => (3,0) => Y=-3-0=-3
+	assert.Equal(t, 3.0, result.Walls[0].Start.X)
+	assert.Equal(t, 0.0, result.Walls[0].Start.Z)
+	assert.Equal(t, -3.0, result.Walls[0].Start.Y)
+
+	// Wall 1: end (2,-1,-1) + origin(3,0) => (5,-1) => Y=-5-(-1)=-4
+	assert.Equal(t, 5.0, result.Walls[1].End.X)
+	assert.Equal(t, -1.0, result.Walls[1].End.Z)
+	assert.Equal(t, -4.0, result.Walls[1].End.Y)
+}

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1091,7 +1091,9 @@ func (o *Orchestrator) convertToWallInfo(room *dungeon.Room) []WallInfo {
 
 // buildRoomLayoutProto converts a dungeon.Room and its absolute origin to a proto RoomLayout.
 // The origin is the room's position in dungeon-space; walls are stored in room-local coordinates
-// and are passed through as-is here (the client applies the origin offset for rendering).
+// and must be translated to absolute dungeon-space by adding the origin offset. The Y coordinate
+// is recomputed from the cube constraint (y = -x - z) after applying the offset, because origin.Y
+// is itself derived from that constraint and must not be added directly.
 //
 //nolint:gosec // G115: Game values are bounded by room size limits, no overflow risk
 func buildRoomLayoutProto(room *dungeon.Room, origin *dungeon.Position) *pb.RoomLayout {
@@ -1125,7 +1127,9 @@ func buildRoomLayoutProto(room *dungeon.Room, origin *dungeon.Position) *pb.Room
 		}
 	}
 
-	// Convert walls.
+	// Convert walls, translating room-local coordinates to absolute dungeon-space by adding the
+	// origin offset. Y is recomputed via the cube constraint (y = -x - z) rather than adding
+	// origin.Y directly, because origin.Y is itself derived from the same constraint.
 	var protoWalls []*apiv1alpha1.Wall
 	if len(room.Walls) > 0 {
 		protoWalls = make([]*apiv1alpha1.Wall, len(room.Walls))
@@ -1134,16 +1138,29 @@ func buildRoomLayoutProto(room *dungeon.Room, origin *dungeon.Position) *pb.Room
 			if w.Type == dungeon.WallTypeDestructible {
 				material = "wood"
 			}
+
+			startX := float64(w.Start.X)
+			startZ := float64(w.Start.Z)
+			endX := float64(w.End.X)
+			endZ := float64(w.End.Z)
+
+			if origin != nil {
+				startX += float64(origin.X)
+				startZ += float64(origin.Z)
+				endX += float64(origin.X)
+				endZ += float64(origin.Z)
+			}
+
 			protoWalls[i] = &apiv1alpha1.Wall{
 				Start: &apiv1alpha1.Position{
-					X: float64(w.Start.X),
-					Y: float64(w.Start.Y),
-					Z: float64(w.Start.Z),
+					X: startX,
+					Y: -startX - startZ,
+					Z: startZ,
 				},
 				End: &apiv1alpha1.Position{
-					X: float64(w.End.X),
-					Y: float64(w.End.Y),
-					Z: float64(w.End.Z),
+					X: endX,
+					Y: -endX - endZ,
+					Z: endZ,
 				},
 				Material:          material,
 				BlocksMovement:    w.BlocksMovement,


### PR DESCRIPTION
## Summary

- Walls in `dungeon.Room` are stored in room-local coordinates; `buildRoomLayoutProto` was passing them through unchanged, causing room 2's walls to render inside room 1's coordinate space
- Apply the room's origin offset to each wall's `Start` and `End` X/Z, then recompute Y from the cube constraint `y = -x - z` (same class of bug as #460 for monster positions)
- Corrected the misleading comment that said the client was responsible for applying the offset — the server must provide absolute coordinates in the snapshot

Fixes #462

## Test plan

- [ ] `TestBuildRoomLayoutProto_WallsShiftedByOrigin` — room with origin `(5, -5, 0)`, verifies wall start/end are offset correctly and Y satisfies cube constraint
- [ ] `TestBuildRoomLayoutProto_WallsNilOriginPassThrough` — nil origin leaves X/Z unchanged, Y still recomputed from constraint
- [ ] `TestBuildRoomLayoutProto_OriginSetInProto` — origin is still set on the proto layout field
- [ ] `TestBuildRoomLayoutProto_MultipleWallsAllShifted` — all walls in a multi-wall room get the offset
- [ ] `TestBuildRoomLayoutProto_NilRoom` / `TestBuildRoomLayoutProto_NilShape` — guard clause coverage
- [ ] `go test ./internal/orchestrators/encounter/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)