### PR TITLE
fix: persist merged RoomData in OpenDoor so new monsters can be perceived

### DIFF
--- a/internal/orchestrators/encounter/open_door_test.go
+++ b/internal/orchestrators/encounter/open_door_test.go
@@ -307,7 +307,7 @@ func (s *OpenDoorTestSuite) TestOpenDoor_Success_RevealsRoom() {
 			return &dungeonrepo.UpdateOutput{Success: true}, nil
 		})
 
-	// Expect encounter update with new initiative order
+	// Expect encounter update with new initiative order and merged RoomData
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, input *encounterrepo.UpdateInput) (*encounterrepo.UpdateOutput, error) {
@@ -315,6 +315,17 @@ func (s *OpenDoorTestSuite) TestOpenDoor_Success_RevealsRoom() {
 			s.NotNil(input.InitiativeData, "initiative data should be updated")
 			// Should now have 3 entities (1 char + 2 skeletons)
 			s.Len(input.InitiativeData.Order, 3)
+			// RoomData must be persisted so monsters are visible to buildPerception on EndTurn
+			s.NotNil(input.RoomData, "RoomData must be persisted so new monsters can be perceived")
+			roomData, ok := input.RoomData.(*spatial.RoomData)
+			s.True(ok, "RoomData should be *spatial.RoomData")
+			if ok {
+				// Original character placement is preserved
+				s.Contains(roomData.CubeEntities, "char-1", "character position should be preserved in RoomData")
+				// New monsters are present so buildPerception can locate them
+				s.Contains(roomData.CubeEntities, "monster-room-2-mp-1", "new monster should be in RoomData")
+				s.Contains(roomData.CubeEntities, "monster-room-2-mp-2", "new monster should be in RoomData")
+			}
 			return &encounterrepo.UpdateOutput{}, nil
 		})
 
@@ -331,6 +342,66 @@ func (s *OpenDoorTestSuite) TestOpenDoor_Success_RevealsRoom() {
 	s.Equal("room-2", output.RevealedRoom.ID)
 	s.Len(output.Monsters, 2, "should have 2 monsters")
 	s.NotNil(output.CombatState)
+}
+
+func (s *OpenDoorTestSuite) TestOpenDoor_NewMonstersPersistedInRoomData() {
+	// Regression test: OpenDoor must persist RoomData containing new monster positions
+	// so that EndTurn's executeMonsterTurns -> buildPerception can find targets.
+	// Without this fix, monsters opened into via a door would see no enemies and stand idle.
+
+	// Arrange
+	testDungeon := s.createTestDungeon()
+	testEncounter := s.createTestEncounterData()
+
+	s.mockDungeonRepo.EXPECT().
+		Get(gomock.Any(), &dungeonrepo.GetInput{DungeonID: "dng-123"}).
+		Return(&dungeonrepo.GetOutput{Dungeon: testDungeon}, nil)
+
+	s.mockEncRepo.EXPECT().
+		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-123"}).
+		Return(&encounterrepo.GetOutput{Data: testEncounter}, nil)
+
+	s.mockDungeonRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.UpdateOutput{Success: true}, nil)
+
+	var capturedRoomData *spatial.RoomData
+	s.mockEncRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *encounterrepo.UpdateInput) (*encounterrepo.UpdateOutput, error) {
+			s.Require().NotNil(input.RoomData, "RoomData must not be nil: monsters would be invisible to EndTurn")
+			rd, ok := input.RoomData.(*spatial.RoomData)
+			s.Require().True(ok, "RoomData must be *spatial.RoomData")
+			capturedRoomData = rd
+			return &encounterrepo.UpdateOutput{}, nil
+		})
+
+	// Act
+	output, err := s.orchestrator.OpenDoor(s.ctx, &encounter.OpenDoorInput{
+		DungeonID:    "dng-123",
+		ConnectionID: "conn-1",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+
+	// The persisted RoomData must contain all entities needed for perception:
+	// - The character (so monsters can target them)
+	// - Each new monster (so buildPerception can locate their own position)
+	s.Require().NotNil(capturedRoomData)
+	s.Contains(capturedRoomData.CubeEntities, "char-1",
+		"character must remain in RoomData after OpenDoor so monsters can perceive them")
+
+	for _, m := range output.Monsters {
+		s.Contains(capturedRoomData.CubeEntities, m.ID,
+			"monster %q must be in persisted RoomData so it can perceive targets on EndTurn", m.ID)
+
+		placement := capturedRoomData.CubeEntities[m.ID]
+		s.Equal(m.ID, placement.EntityID)
+		s.Equal("monster", placement.EntityType)
+		// Cube constraint: x + y + z == 0
+		s.Equal(0, placement.CubePosition.X+placement.CubePosition.Y+placement.CubePosition.Z,
+			"cube coordinate must satisfy x+y+z=0 for monster %q", m.ID)
+	}
 }
 
 func (s *OpenDoorTestSuite) TestOpenDoor_RevealsCorrectRoom() {

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1295,6 +1295,41 @@ func (o *Orchestrator) placeMonsters(roomData *spatial.RoomData, room *dungeon.R
 	return monsters
 }
 
+// mergeNewRoomMonsters places monsters from a newly-revealed room into both the
+// revealed room's spatial data and the existing (current) RoomData. Merging into
+// the existing RoomData is required so that EndTurn's buildPerception can locate
+// new monsters when they take their turn; without this, monsters see no enemies.
+//
+// The coordinate conversion matches StartCombat: 2D position Y maps to cube Z,
+// and cube Y is derived from the x+y+z=0 constraint.
+//
+// Existing entries in currentRoomData are never overwritten to preserve character
+// positions that were already there before the door was opened.
+func mergeNewRoomMonsters(monsters []MonsterInfo, revealedRoom *spatial.RoomData, currentRoomData *spatial.RoomData) {
+	for _, m := range monsters {
+		cubeX := int(m.Position.X)
+		cubeZ := int(m.Position.Y) // Y in 2D maps to Z in cube coords
+		cubeY := -cubeX - cubeZ    // y = -x - z for valid cube coordinate
+
+		placement := spatial.EntityCubePlacement{
+			EntityID:          m.ID,
+			EntityType:        entityTypeMonster,
+			CubePosition:      spatial.CubeCoordinate{X: cubeX, Y: cubeY, Z: cubeZ},
+			Size:              1,
+			BlocksMovement:    true,
+			BlocksLineOfSight: false,
+		}
+
+		revealedRoom.CubeEntities[m.ID] = placement
+
+		// Only add to current room data if not already present; existing character
+		// positions must not be overwritten.
+		if _, exists := currentRoomData.CubeEntities[m.ID]; !exists {
+			currentRoomData.CubeEntities[m.ID] = placement
+		}
+	}
+}
+
 // findSafeFallbackPosition finds a position that is not on a wall or occupied
 // Searches outward from center until a valid position is found
 func findSafeFallbackPosition(room *dungeon.Room, roomData *spatial.RoomData) spatial.CubeCoordinate {
@@ -3206,7 +3241,13 @@ func (o *Orchestrator) OpenDoor(
 		return nil, fmt.Errorf("failed to update dungeon: %w", err)
 	}
 
-	// 11. Update encounter state with new initiative and boss monster IDs
+	// 11. Build spatial data for the revealed room and merge monster positions into
+	// the existing RoomData. This ensures monsters in the new room are present in the
+	// persisted RoomData so that buildPerception can locate them during EndTurn.
+	revealedSpatialRoom := o.convertToRoomData(dng.EncounterID, revealedRoom)
+	mergeNewRoomMonsters(monsters, revealedSpatialRoom, roomData)
+
+	// Update encounter state with new initiative, boss monster IDs, and merged RoomData.
 	// Merge new boss IDs with any existing ones
 	allBossIDs := make([]string, 0, len(encOutput.Data.BossMonsterIDs)+len(newBossMonsterIDs))
 	allBossIDs = append(allBossIDs, encOutput.Data.BossMonsterIDs...)
@@ -3217,6 +3258,7 @@ func (o *Orchestrator) OpenDoor(
 		InitiativeRolls: allRolls, // Persist merged rolls so EndTurn can re-sort at round start
 		Monsters:        encOutput.Data.Monsters,
 		BossMonsterIDs:  allBossIDs,
+		RoomData:        roomData, // Persist merged positions so monsters can be perceived on EndTurn
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update encounter: %w", err)
@@ -3296,25 +3338,8 @@ func (o *Orchestrator) OpenDoor(
 		})
 	}
 
-	// 16. Build revealed room spatial data for event (including monsters)
-	revealedSpatialRoom := o.convertToRoomData(dng.EncounterID, revealedRoom)
-
-	// Add monster placements to the spatial room data for the event
-	// This ensures the RoomRevealedEvent includes monsters, matching the OpenDoor response
-	for _, m := range monsters {
-		cubeX := int(m.Position.X)
-		cubeZ := int(m.Position.Y) // Y in 2D maps to Z in cube coords
-		cubeY := -cubeX - cubeZ    // y = -x - z for valid cube coordinate
-
-		revealedSpatialRoom.CubeEntities[m.ID] = spatial.EntityCubePlacement{
-			EntityID:          m.ID,
-			EntityType:        "monster",
-			CubePosition:      spatial.CubeCoordinate{X: cubeX, Y: cubeY, Z: cubeZ},
-			Size:              1,
-			BlocksMovement:    true,
-			BlocksLineOfSight: false,
-		}
-	}
+	// 16. revealedSpatialRoom was already built in step 11 with monsters placed in it.
+	// It is used directly for the RoomRevealedEvent below.
 
 	// 17. Add new monster entities to encounter Entities map for snapshot
 	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID)


### PR DESCRIPTION
## Summary

- After `OpenDoor` reveals a new room, monsters in that room were invisible to `buildPerception` during `EndTurn` because `RoomData` was never updated in the encounter repository — they saw no enemies and stood AFK.
- Extracted `mergeNewRoomMonsters` helper that places each new monster's cube position (using the same 2D-to-cube conversion as `StartCombat`) into both the revealed room's spatial data and the existing `RoomData`.
- The merged `RoomData` is now included in the `encRepo.Update` call, so all entity positions (characters from the current room + new monsters) survive across turns and are visible to `buildPerception`.

## Root Cause

`OpenDoor` at line ~3214 called `encRepo.Update` with `InitiativeData`, `Monsters`, and `BossMonsterIDs` — but omitted `RoomData`. `buildPerception` checks `roomData.CubeEntities[monsterID]` and returns empty enemies when the monster is absent, so new monsters never acted.

## Test Plan

- [x] `TestOpenDoor_Success_RevealsRoom` updated: now asserts `RoomData` is non-nil in the update and that both character and new monster positions are present
- [x] `TestOpenDoor_NewMonstersPersistedInRoomData` added: dedicated regression test verifying monster cube coordinates satisfy `x+y+z=0` and that character positions are preserved
- [x] All existing OpenDoor tests pass
- [x] Full test suite passes (`go test ./...`) including integration tests
- [x] `golangci-lint` clean on changed packages (pre-existing issues in other files only)

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)