### PR TITLE
fix: room 2 missing perimeter walls after OpenDoor (#465)

### DIFF
--- a/internal/components/dungeon/toolkit/perimeter.go
+++ b/internal/components/dungeon/toolkit/perimeter.go
@@ -147,14 +147,16 @@ func (g *PerimeterGenerator) createWallBeforeDoor(start, doorPos dungeon.Positio
 	doorGap := 1
 	var adjustedEnd dungeon.Position
 	if start.X == doorPos.X {
-		// Vertical wall
+		// Vertical wall: X is fixed, Y changes along the wall, Z follows from cube constraint
 		endX := doorPos.X
 		endY := doorPos.Y - doorGap
 		adjustedEnd = dungeon.Position{X: endX, Y: endY, Z: -endX - endY}
 	} else {
+		// Horizontal wall: Z is fixed (same as start.Z), X changes, Y follows from cube constraint.
+		// Using start.Z preserves the wall's row so the segment stays on the boundary line.
 		endX := doorPos.X - doorGap
-		endY := doorPos.Y
-		adjustedEnd = dungeon.Position{X: endX, Y: endY, Z: -endX - endY}
+		endZ := start.Z
+		adjustedEnd = dungeon.Position{X: endX, Y: -endX - endZ, Z: endZ}
 	}
 
 	return dungeon.WallSegment{
@@ -171,14 +173,16 @@ func (g *PerimeterGenerator) createWallAfterDoor(doorPos, end dungeon.Position, 
 	doorGap := 1
 	var adjustedStart dungeon.Position
 	if doorPos.X == end.X {
-		// Vertical wall
+		// Vertical wall: X is fixed, Y changes along the wall, Z follows from cube constraint
 		startX := doorPos.X
 		startY := doorPos.Y + doorGap
 		adjustedStart = dungeon.Position{X: startX, Y: startY, Z: -startX - startY}
 	} else {
+		// Horizontal wall: Z is fixed (same as end.Z), X changes, Y follows from cube constraint.
+		// Using end.Z preserves the wall's row so the segment stays on the boundary line.
 		startX := doorPos.X + doorGap
-		startY := doorPos.Y
-		adjustedStart = dungeon.Position{X: startX, Y: startY, Z: -startX - startY}
+		startZ := end.Z
+		adjustedStart = dungeon.Position{X: startX, Y: -startX - startZ, Z: startZ}
 	}
 
 	return dungeon.WallSegment{

--- a/internal/components/dungeon/toolkit/perimeter_test.go
+++ b/internal/components/dungeon/toolkit/perimeter_test.go
@@ -188,6 +188,101 @@ func (s *PerimeterGeneratorTestSuite) TestUpdatePerimeter_WithDoor() {
 	assert.Len(s.T(), result.DoorPositions, 1, "should have one door position")
 }
 
+// TestGenerate_HorizontalWallDoorSegmentsOnBoundary verifies that wall segments created around
+// a door on a horizontal (south or north) perimeter wall stay on the wall's Z-row.
+//
+// This is a regression test for issue #465 where the south-wall door segments had incorrect
+// Z-coordinates (Z=-1 and Z=+1 instead of Z=0), causing them to be rendered off the boundary
+// and appearing invisible to clients that expected boundary walls at Z=0.
+func (s *PerimeterGeneratorTestSuite) TestGenerate_HorizontalWallDoorSegmentsOnBoundary() {
+	// Use cube-coordinate bounds that match what the toolkit generates for a square room.
+	// offsetToCube(col, row) = {X:col, Y:-col-row, Z:row}
+	// For width=22, height=20 this matches the boss room size in the debug scenario.
+	width := 22
+	height := 20
+	// Bounds: BL, BR, TR, TL using offsetToCube
+	bl := dungeon.Position{X: 0, Y: 0, Z: 0}
+	br := dungeon.Position{X: width - 1, Y: -(width - 1), Z: 0}
+	tr := dungeon.Position{X: width - 1, Y: -(width - 1) - (height - 1), Z: height - 1}
+	tl := dungeon.Position{X: 0, Y: -(height - 1), Z: height - 1}
+
+	// Connection point at the midpoint of the south wall (Z=0 row).
+	// midX=10 for width=22: southDoorPos = offsetToCube(10,0) = {X:10, Y:-10, Z:0}
+	midX := (width - 1) / 2
+	southDoorPos := dungeon.Position{X: midX, Y: -midX, Z: 0}
+	southCP := dungeon.ConnectionPoint{
+		Name:      "south",
+		Position:  southDoorPos,
+		Direction: "south",
+		Type:      "door",
+	}
+
+	shape := &dungeon.Shape{
+		Bounds:           []dungeon.Position{bl, br, tr, tl},
+		ConnectionPoints: []dungeon.ConnectionPoint{southCP},
+		Width:            width,
+		Height:           height,
+	}
+
+	connections := []*dungeon.RoomConnection{
+		{
+			FromRoom:     "room-a",
+			ToRoom:       "room-b",
+			Type:         dungeon.ConnectionTypeDoor,
+			PhysicalHint: "south", // door on south wall
+		},
+	}
+
+	result := s.generator.Generate(&PerimeterInput{
+		Shape:       shape,
+		Connections: connections,
+	})
+
+	s.Require().NotNil(result)
+
+	// The south wall (segment 0, BL→BR) is split into two segments around the door.
+	// In the perimeter generator, these are the first two walls (perimeter_0 and perimeter_1).
+	// They must both lie entirely on Z=0 (the south boundary row).
+	//
+	// Pre-fix, the door-adjacent endpoints had Z=±1 because the Y-coordinate from the door
+	// position was incorrectly kept when only X was adjusted.
+	//
+	// We check this directly: perimeter_0 is the wall before the door (X ∈ [0, midX-1], Z=0)
+	// and perimeter_1 is the wall after the door (X ∈ [midX+1, width-1], Z=0).
+	s.Require().GreaterOrEqual(len(result.Walls), 2, "should have at least 2 walls for the split south wall")
+
+	wallBeforeDoor := result.Walls[0] // perimeter_0
+	wallAfterDoor := result.Walls[1]  // perimeter_1
+
+	// Both start and end of wall-before-door must be at Z=0
+	s.Assert().Equal(0, wallBeforeDoor.Start.Z,
+		"wall before door: Start.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallBeforeDoor.Start.Z, wallBeforeDoor.Start, wallBeforeDoor.End)
+	s.Assert().Equal(0, wallBeforeDoor.End.Z,
+		"wall before door: End.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallBeforeDoor.End.Z, wallBeforeDoor.Start, wallBeforeDoor.End)
+
+	// Both start and end of wall-after-door must be at Z=0
+	s.Assert().Equal(0, wallAfterDoor.Start.Z,
+		"wall after door: Start.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallAfterDoor.Start.Z, wallAfterDoor.Start, wallAfterDoor.End)
+	s.Assert().Equal(0, wallAfterDoor.End.Z,
+		"wall after door: End.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallAfterDoor.End.Z, wallAfterDoor.Start, wallAfterDoor.End)
+
+	// Also verify cube coordinate invariant (X+Y+Z=0) is maintained for all wall endpoints
+	for _, wall := range result.Walls {
+		s.Assert().Equal(0, wall.Start.X+wall.Start.Y+wall.Start.Z,
+			"Start cube invariant violated for wall %s: X(%d)+Y(%d)+Z(%d)=%d",
+			wall.ID, wall.Start.X, wall.Start.Y, wall.Start.Z,
+			wall.Start.X+wall.Start.Y+wall.Start.Z)
+		s.Assert().Equal(0, wall.End.X+wall.End.Y+wall.End.Z,
+			"End cube invariant violated for wall %s: X(%d)+Y(%d)+Z(%d)=%d",
+			wall.ID, wall.End.X, wall.End.Y, wall.End.Z,
+			wall.End.X+wall.End.Y+wall.End.Z)
+	}
+}
+
 func (s *PerimeterGeneratorTestSuite) TestUpdatePerimeter_NilInput() {
 	result := s.generator.UpdatePerimeter(nil)
 


### PR DESCRIPTION
## Summary

Fixes #465 — perimeter walls for room 2 (and any room with a south/north wall door) were missing after `OpenDoor` because the door-adjacent wall segments were placed at Z=±1 instead of Z=0, making them invisible to the renderer.

**Root cause:** In `createWallBeforeDoor` and `createWallAfterDoor`, the horizontal-wall branch kept `doorPos.Y` when adjusting X. Since cube coordinates require `X+Y+Z=0`, using the door's Y for a different X produced Z≠0. For the south wall (which sits at Z=0), the segment before the door got Z=+1 and the segment after got Z=-1.

**Fix:** Pin Z to the wall's own Z-row (`start.Z` for before-door, `end.Z` for after-door), then derive Y = -X - Z. This keeps all door-adjacent endpoints on the correct boundary row and preserves the cube invariant throughout.

**Regression test added:** `TestGenerate_HorizontalWallDoorSegmentsOnBoundary` in `perimeter_test.go`
- Uses cube-coordinate bounds matching actual toolkit output (width=22, height=20, matching the boss room in the debug scenario)
- Asserts Z=0 on both endpoints of `result.Walls[0]` (before-door segment) and `result.Walls[1]` (after-door segment)
- Verifies the cube invariant `X+Y+Z=0` holds for every wall endpoint

## Test plan

- [x] `TestGenerate_HorizontalWallDoorSegmentsOnBoundary` passes (new regression test)
- [x] Full `go test ./...` passes — all existing tests green
- [x] Lint count unchanged at 27 pre-existing issues (no new violations introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)