### PR TITLE
Round 2: Multi-room dungeon rendering

### DIFF
--- a/internal/components/dungeon/toolkit/perimeter.go
+++ b/internal/components/dungeon/toolkit/perimeter.go
@@ -147,14 +147,16 @@ func (g *PerimeterGenerator) createWallBeforeDoor(start, doorPos dungeon.Positio
 	doorGap := 1
 	var adjustedEnd dungeon.Position
 	if start.X == doorPos.X {
-		// Vertical wall
+		// Vertical wall: X is fixed, Y changes along the wall, Z follows from cube constraint
 		endX := doorPos.X
 		endY := doorPos.Y - doorGap
 		adjustedEnd = dungeon.Position{X: endX, Y: endY, Z: -endX - endY}
 	} else {
+		// Horizontal wall: Z is fixed (same as start.Z), X changes, Y follows from cube constraint.
+		// Using start.Z preserves the wall's row so the segment stays on the boundary line.
 		endX := doorPos.X - doorGap
-		endY := doorPos.Y
-		adjustedEnd = dungeon.Position{X: endX, Y: endY, Z: -endX - endY}
+		endZ := start.Z
+		adjustedEnd = dungeon.Position{X: endX, Y: -endX - endZ, Z: endZ}
 	}
 
 	return dungeon.WallSegment{
@@ -171,14 +173,16 @@ func (g *PerimeterGenerator) createWallAfterDoor(doorPos, end dungeon.Position, 
 	doorGap := 1
 	var adjustedStart dungeon.Position
 	if doorPos.X == end.X {
-		// Vertical wall
+		// Vertical wall: X is fixed, Y changes along the wall, Z follows from cube constraint
 		startX := doorPos.X
 		startY := doorPos.Y + doorGap
 		adjustedStart = dungeon.Position{X: startX, Y: startY, Z: -startX - startY}
 	} else {
+		// Horizontal wall: Z is fixed (same as end.Z), X changes, Y follows from cube constraint.
+		// Using end.Z preserves the wall's row so the segment stays on the boundary line.
 		startX := doorPos.X + doorGap
-		startY := doorPos.Y
-		adjustedStart = dungeon.Position{X: startX, Y: startY, Z: -startX - startY}
+		startZ := end.Z
+		adjustedStart = dungeon.Position{X: startX, Y: -startX - startZ, Z: startZ}
 	}
 
 	return dungeon.WallSegment{

--- a/internal/components/dungeon/toolkit/perimeter_test.go
+++ b/internal/components/dungeon/toolkit/perimeter_test.go
@@ -188,6 +188,101 @@ func (s *PerimeterGeneratorTestSuite) TestUpdatePerimeter_WithDoor() {
 	assert.Len(s.T(), result.DoorPositions, 1, "should have one door position")
 }
 
+// TestGenerate_HorizontalWallDoorSegmentsOnBoundary verifies that wall segments created around
+// a door on a horizontal (south or north) perimeter wall stay on the wall's Z-row.
+//
+// This is a regression test for issue #465 where the south-wall door segments had incorrect
+// Z-coordinates (Z=-1 and Z=+1 instead of Z=0), causing them to be rendered off the boundary
+// and appearing invisible to clients that expected boundary walls at Z=0.
+func (s *PerimeterGeneratorTestSuite) TestGenerate_HorizontalWallDoorSegmentsOnBoundary() {
+	// Use cube-coordinate bounds that match what the toolkit generates for a square room.
+	// offsetToCube(col, row) = {X:col, Y:-col-row, Z:row}
+	// For width=22, height=20 this matches the boss room size in the debug scenario.
+	width := 22
+	height := 20
+	// Bounds: BL, BR, TR, TL using offsetToCube
+	bl := dungeon.Position{X: 0, Y: 0, Z: 0}
+	br := dungeon.Position{X: width - 1, Y: -(width - 1), Z: 0}
+	tr := dungeon.Position{X: width - 1, Y: -(width - 1) - (height - 1), Z: height - 1}
+	tl := dungeon.Position{X: 0, Y: -(height - 1), Z: height - 1}
+
+	// Connection point at the midpoint of the south wall (Z=0 row).
+	// midX=10 for width=22: southDoorPos = offsetToCube(10,0) = {X:10, Y:-10, Z:0}
+	midX := (width - 1) / 2
+	southDoorPos := dungeon.Position{X: midX, Y: -midX, Z: 0}
+	southCP := dungeon.ConnectionPoint{
+		Name:      "south",
+		Position:  southDoorPos,
+		Direction: "south",
+		Type:      "door",
+	}
+
+	shape := &dungeon.Shape{
+		Bounds:           []dungeon.Position{bl, br, tr, tl},
+		ConnectionPoints: []dungeon.ConnectionPoint{southCP},
+		Width:            width,
+		Height:           height,
+	}
+
+	connections := []*dungeon.RoomConnection{
+		{
+			FromRoom:     "room-a",
+			ToRoom:       "room-b",
+			Type:         dungeon.ConnectionTypeDoor,
+			PhysicalHint: "south", // door on south wall
+		},
+	}
+
+	result := s.generator.Generate(&PerimeterInput{
+		Shape:       shape,
+		Connections: connections,
+	})
+
+	s.Require().NotNil(result)
+
+	// The south wall (segment 0, BL→BR) is split into two segments around the door.
+	// In the perimeter generator, these are the first two walls (perimeter_0 and perimeter_1).
+	// They must both lie entirely on Z=0 (the south boundary row).
+	//
+	// Pre-fix, the door-adjacent endpoints had Z=±1 because the Y-coordinate from the door
+	// position was incorrectly kept when only X was adjusted.
+	//
+	// We check this directly: perimeter_0 is the wall before the door (X ∈ [0, midX-1], Z=0)
+	// and perimeter_1 is the wall after the door (X ∈ [midX+1, width-1], Z=0).
+	s.Require().GreaterOrEqual(len(result.Walls), 2, "should have at least 2 walls for the split south wall")
+
+	wallBeforeDoor := result.Walls[0] // perimeter_0
+	wallAfterDoor := result.Walls[1]  // perimeter_1
+
+	// Both start and end of wall-before-door must be at Z=0
+	s.Assert().Equal(0, wallBeforeDoor.Start.Z,
+		"wall before door: Start.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallBeforeDoor.Start.Z, wallBeforeDoor.Start, wallBeforeDoor.End)
+	s.Assert().Equal(0, wallBeforeDoor.End.Z,
+		"wall before door: End.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallBeforeDoor.End.Z, wallBeforeDoor.Start, wallBeforeDoor.End)
+
+	// Both start and end of wall-after-door must be at Z=0
+	s.Assert().Equal(0, wallAfterDoor.Start.Z,
+		"wall after door: Start.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallAfterDoor.Start.Z, wallAfterDoor.Start, wallAfterDoor.End)
+	s.Assert().Equal(0, wallAfterDoor.End.Z,
+		"wall after door: End.Z must be 0 (south wall row), got %d — wall: %+v → %+v",
+		wallAfterDoor.End.Z, wallAfterDoor.Start, wallAfterDoor.End)
+
+	// Also verify cube coordinate invariant (X+Y+Z=0) is maintained for all wall endpoints
+	for _, wall := range result.Walls {
+		s.Assert().Equal(0, wall.Start.X+wall.Start.Y+wall.Start.Z,
+			"Start cube invariant violated for wall %s: X(%d)+Y(%d)+Z(%d)=%d",
+			wall.ID, wall.Start.X, wall.Start.Y, wall.Start.Z,
+			wall.Start.X+wall.Start.Y+wall.Start.Z)
+		s.Assert().Equal(0, wall.End.X+wall.End.Y+wall.End.Z,
+			"End cube invariant violated for wall %s: X(%d)+Y(%d)+Z(%d)=%d",
+			wall.ID, wall.End.X, wall.End.Y, wall.End.Z,
+			wall.End.X+wall.End.Y+wall.End.Z)
+	}
+}
+
 func (s *PerimeterGeneratorTestSuite) TestUpdatePerimeter_NilInput() {
 	result := s.generator.UpdatePerimeter(nil)
 

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -115,6 +115,10 @@ func (h *Handler) DungeonStart(
 	room := convertRoomDataToProto(output.Room)
 	if room != nil {
 		room.Origin = dungeonPositionToProto(output.RoomOrigin)
+		// Shift walls and entities from room-local to dungeon-absolute coordinates.
+		// For the start room origin is (0,0,0) so this is a no-op, but keeping the
+		// call is required for consistency with OpenDoor and StartCombat.
+		shiftRoomToAbsolute(room)
 	}
 
 	return &dnd5ev1alpha1.DungeonStartResponse{

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
@@ -523,6 +523,74 @@ func (s *HandlerTestSuite) TestDungeonStart_EmptyRequest() {
 	s.Assert().Equal("enc-456-room", resp.Room.Id)
 }
 
+// TestDungeonStart_ShiftsEntitiesToAbsoluteCoordinates verifies that entity positions in the
+// response are shifted from room-local coordinates to dungeon-absolute coordinates.
+// This mirrors the same shift applied in OpenDoor and StartCombat.
+// For the start room, origin is always (0,0,0), but the handler must call shiftRoomToAbsolute
+// to remain consistent — if origin were ever non-zero (e.g. if dungeon layout changes),
+// the shift ensures correctness.
+func (s *HandlerTestSuite) TestDungeonStart_ShiftsEntitiesToAbsoluteCoordinates() {
+	// Room with a character in room-local hex cube coordinates.
+	// Cube coords: (1, -2, 1) — sum equals 0, so this is a valid cube coordinate.
+	localX, localY, localZ := 1, -2, 1
+	roomWithEntity := &spatial.RoomData{
+		ID:       "room-hex",
+		Type:     "dungeon",
+		Width:    10,
+		Height:   10,
+		GridType: spatial.GridTypeHex,
+		CubeEntities: map[string]spatial.EntityCubePlacement{
+			"char-1": {
+				EntityID:   "char-1",
+				EntityType: "character",
+				CubePosition: spatial.CubeCoordinate{
+					X: localX,
+					Y: localY,
+					Z: localZ,
+				},
+				Size:           1,
+				BlocksMovement: true,
+			},
+		},
+		Entities: make(map[string]spatial.EntityPlacement),
+	}
+
+	// Non-zero origin: the start room is at (5, 0, -5) in dungeon space.
+	// After shift, entity should be at (1+5, -2+0, 1-5) = (6, -2, -4).
+	originX, originY, originZ := 5, 0, -5
+	roomOrigin := &dungeon.Position{X: originX, Y: originY, Z: originZ}
+
+	s.mockService.EXPECT().
+		CreateDungeon(gomock.Any(), gomock.Any()).
+		Return(&encounter.CreateDungeonOutput{
+			EncounterID: "enc-shift-test",
+			Room:        roomWithEntity,
+			RoomOrigin:  roomOrigin,
+		}, nil)
+
+	resp, err := s.handler.DungeonStart(context.Background(), &dnd5ev1alpha1.DungeonStartRequest{
+		CharacterIds: []string{"char-1"},
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Room)
+
+	// Verify the origin is set correctly on the proto room.
+	s.Require().NotNil(resp.Room.Origin)
+	s.Assert().Equal(float64(originX), resp.Room.Origin.X)
+	s.Assert().Equal(float64(originY), resp.Room.Origin.Y)
+	s.Assert().Equal(float64(originZ), resp.Room.Origin.Z)
+
+	// Verify entity position has been shifted from room-local to dungeon-absolute.
+	entityPlacement, ok := resp.Room.Entities["char-1"]
+	s.Require().True(ok, "char-1 entity should be present in response room")
+	s.Require().NotNil(entityPlacement.Position)
+	s.Assert().Equal(float64(localX+originX), entityPlacement.Position.X, "entity X should be shifted by origin X")
+	s.Assert().Equal(float64(localY+originY), entityPlacement.Position.Y, "entity Y should be shifted by origin Y")
+	s.Assert().Equal(float64(localZ+originZ), entityPlacement.Position.Z, "entity Z should be shifted by origin Z")
+}
+
 // TestGetCombatState_Unimplemented tests that GetCombatState returns Unimplemented
 func (s *HandlerTestSuite) TestGetCombatState_Unimplemented() {
 	req := &dnd5ev1alpha1.GetCombatStateRequest{

--- a/internal/integration/encounter/open_door_test.go
+++ b/internal/integration/encounter/open_door_test.go
@@ -1,0 +1,583 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package encounter_integration provides integration tests for the OpenDoor → RoomRevealed pipeline.
+//
+// # What this tests
+//
+// The full event pipeline for OpenDoor:
+//
+//	orchestrator.publishEvent
+//	  → eventProcessor.Process
+//	    → Redis pub/sub (JSON serialize/deserialize via custom MarshalJSON/UnmarshalJSON)
+//	      → stream handler
+//	        → convertToProtoEvent
+//	          → gRPC stream.Send
+//	            → client Recv
+//
+// # Known concern
+//
+// RoomRevealedEvent.EncounterStateData is tagged json:"-" on the original struct.
+// A custom MarshalJSON/UnmarshalJSON in encounter_events_json.go encodes it as
+// base64 proto wire bytes. If that round-trip fails, the field arrives nil and the
+// test fails — which is exactly the bug we are trying to catch.
+//
+// A passing test proves the entire pipeline (including JSON serialization) is intact.
+// A failing test identifies where in the pipeline the event or its payload is lost.
+package encounter_integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/metadata"
+
+	apiv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/api/v1alpha1"
+	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+	dungeonrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
+	encounterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// ============================================================================
+// OPEN DOOR → ROOM REVEALED INTEGRATION TEST
+// ============================================================================
+
+// OpenDoorIntegrationSuite tests that calling OpenDoor causes a RoomRevealedEvent
+// to arrive on the encounter event stream with a populated EncounterStateData.
+type OpenDoorIntegrationSuite struct {
+	suite.Suite
+	ctx    context.Context
+	cancel context.CancelFunc
+	server *harness.TestServer
+}
+
+func TestOpenDoorIntegrationSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	suite.Run(t, new(OpenDoorIntegrationSuite))
+}
+
+func (s *OpenDoorIntegrationSuite) SetupSuite() {
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	var err error
+	s.server, err = harness.New(s.ctx, nil)
+	s.Require().NoError(err, "failed to create test server")
+
+	s.T().Log("=== OpenDoor Integration Test Server Ready ===")
+}
+
+func (s *OpenDoorIntegrationSuite) TearDownSuite() {
+	if s.server != nil {
+		s.server.Close()
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+func (s *OpenDoorIntegrationSuite) SetupTest() {
+	err := s.server.FlushRedis(s.ctx)
+	s.Require().NoError(err, "failed to flush redis")
+}
+
+func (s *OpenDoorIntegrationSuite) authCtx(playerID string) context.Context {
+	return metadata.AppendToOutgoingContext(s.ctx, "authorization", "Dev "+playerID)
+}
+
+// subscribeToOpenDoorStream opens a StreamEncounterEvents subscription and returns
+// a cancel function and a channel of events. The caller MUST call cancel() when done.
+func (s *OpenDoorIntegrationSuite) subscribeToOpenDoorStream(
+	playerID, encounterID string,
+) (cancel context.CancelFunc, eventsCh <-chan *dnd5ev1alpha1.EncounterEvent) {
+	streamCtx, streamCancel := context.WithCancel(s.authCtx(playerID))
+
+	stream, err := s.server.EncounterClient.StreamEncounterEvents(streamCtx,
+		&dnd5ev1alpha1.StreamEncounterEventsRequest{
+			EncounterId: encounterID,
+			PlayerId:    playerID,
+		},
+	)
+	s.Require().NoError(err, "failed to open encounter event stream")
+
+	ch := make(chan *dnd5ev1alpha1.EncounterEvent, 64)
+
+	go func() {
+		defer close(ch)
+		for {
+			event, recvErr := stream.Recv()
+			if recvErr != nil {
+				if streamCtx.Err() != nil {
+					return
+				}
+				s.T().Logf("  [stream] Recv error (unexpected): %v", recvErr)
+				return
+			}
+			select {
+			case ch <- event:
+			case <-streamCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return streamCancel, ch
+}
+
+// createFighterForOpenDoor creates a fully-specified fighter character.
+// Mirrors the pattern used in stream_entity_state_test.go.
+func (s *OpenDoorIntegrationSuite) createFighterForOpenDoor(playerID string) string {
+	ctx := s.authCtx(playerID)
+
+	createResp, err := s.server.CharacterClient.CreateDraft(ctx, &dnd5ev1alpha1.CreateDraftRequest{})
+	s.Require().NoError(err, "failed to create draft")
+	draftID := createResp.GetDraft().GetId()
+	s.Require().NotEmpty(draftID)
+
+	_, err = s.server.CharacterClient.UpdateName(ctx, &dnd5ev1alpha1.UpdateNameRequest{
+		DraftId: draftID,
+		Name:    "OpenDoor Test Fighter",
+	})
+	s.Require().NoError(err)
+
+	_, err = s.server.CharacterClient.UpdateRace(ctx, &dnd5ev1alpha1.UpdateRaceRequest{
+		DraftId: draftID,
+		Race:    dnd5ev1alpha1.Race_RACE_HUMAN,
+		RaceChoices: []*dnd5ev1alpha1.ChoiceData{
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_LANGUAGES,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_RACE,
+				Selection: &dnd5ev1alpha1.ChoiceData_Languages{
+					Languages: &dnd5ev1alpha1.LanguageSelection{
+						Languages: []dnd5ev1alpha1.Language{dnd5ev1alpha1.Language_LANGUAGE_DWARVISH},
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.server.CharacterClient.UpdateClass(ctx, &dnd5ev1alpha1.UpdateClassRequest{
+		DraftId: draftID,
+		Class:   dnd5ev1alpha1.Class_CLASS_FIGHTER,
+		ClassChoices: []*dnd5ev1alpha1.ChoiceData{
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_SKILLS,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				Selection: &dnd5ev1alpha1.ChoiceData_Skills{
+					Skills: &dnd5ev1alpha1.SkillSelection{
+						Skills: []dnd5ev1alpha1.Skill{
+							dnd5ev1alpha1.Skill_SKILL_ATHLETICS,
+							dnd5ev1alpha1.Skill_SKILL_PERCEPTION,
+						},
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_FIGHTING_STYLE,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				Selection: &dnd5ev1alpha1.ChoiceData_FightingStyle{
+					FightingStyle: &dnd5ev1alpha1.FightingStyleSelection{
+						Style: dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_DEFENSE,
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-armor",
+				OptionId: "fighter-armor-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-weapons-primary",
+				OptionId: "fighter-weapon-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{
+						Items: []*dnd5ev1alpha1.EquipmentSelectionItem{
+							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{
+								Weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGSWORD,
+							}},
+						},
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-weapons-secondary",
+				OptionId: "fighter-ranged-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-pack",
+				OptionId: "fighter-pack-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.server.CharacterClient.UpdateBackground(ctx, &dnd5ev1alpha1.UpdateBackgroundRequest{
+		DraftId:    draftID,
+		Background: dnd5ev1alpha1.Background_BACKGROUND_SOLDIER,
+	})
+	s.Require().NoError(err)
+
+	_, err = s.server.CharacterClient.UpdateAbilityScores(ctx, &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: draftID,
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_AbilityScores{
+			AbilityScores: &dnd5ev1alpha1.AbilityScores{
+				Strength:     15,
+				Dexterity:    14,
+				Constitution: 13,
+				Intelligence: 8,
+				Wisdom:       12,
+				Charisma:     10,
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	finalizeResp, err := s.server.CharacterClient.FinalizeDraft(ctx, &dnd5ev1alpha1.FinalizeDraftRequest{
+		DraftId: draftID,
+	})
+	s.Require().NoError(err, "failed to finalize draft")
+	s.Require().NotNil(finalizeResp.GetCharacter())
+	s.Require().NotEmpty(finalizeResp.GetCharacter().GetId())
+
+	return finalizeResp.GetCharacter().GetId()
+}
+
+// =============================================================================
+// TEST: OpenDoor publishes RoomRevealedEvent with EncounterStateData
+// =============================================================================
+
+func (s *OpenDoorIntegrationSuite) TestOpenDoor_RoomRevealedEvent_HasEncounterStateData() {
+	s.T().Log("=== TEST: OpenDoor → RoomRevealedEvent.EncounterStateData is populated on stream ===")
+
+	playerID := "open-door-test-player"
+	ctx := s.authCtx(playerID)
+
+	// 1. Create fighter character.
+	characterID := s.createFighterForOpenDoor(playerID)
+	s.T().Logf("  Created character: %s", characterID)
+
+	// 2. Create encounter and set player ready (but do NOT start combat yet).
+	createResp, err := s.server.EncounterClient.CreateEncounter(ctx,
+		&dnd5ev1alpha1.CreateEncounterRequest{
+			CharacterIds: []string{characterID},
+		},
+	)
+	s.Require().NoError(err)
+	encounterID := createResp.GetEncounterId()
+	s.Require().NotEmpty(encounterID)
+	s.T().Logf("  Created encounter: %s", encounterID)
+
+	_, err = s.server.EncounterClient.SetReady(ctx, &dnd5ev1alpha1.SetReadyRequest{
+		EncounterId: encounterID,
+		PlayerId:    playerID,
+		IsReady:     true,
+	})
+	s.Require().NoError(err)
+
+	// 3. Subscribe BEFORE starting combat to observe the full event stream.
+	cancelStream, eventsCh := s.subscribeToOpenDoorStream(playerID, encounterID)
+	defer cancelStream()
+
+	// Small delay to ensure the Redis subscription is active before we publish.
+	time.Sleep(100 * time.Millisecond)
+
+	// 4. Start combat — this generates a dungeon and returns dungeon_id + doors.
+	startResp, err := s.server.EncounterClient.StartCombat(ctx, &dnd5ev1alpha1.StartCombatRequest{
+		EncounterId: encounterID,
+		Theme:       dnd5ev1alpha1.DungeonTheme_DUNGEON_THEME_CRYPT,
+		Difficulty:  dnd5ev1alpha1.DungeonDifficulty_DUNGEON_DIFFICULTY_MEDIUM,
+		Length:      dnd5ev1alpha1.DungeonLength_DUNGEON_LENGTH_SHORT,
+	})
+	s.Require().NoError(err, "StartCombat should succeed")
+
+	dungeonID := startResp.GetDungeonId()
+	s.Require().NotEmpty(dungeonID, "StartCombatResponse.DungeonId must not be empty")
+	s.T().Logf("  Dungeon: %s", dungeonID)
+
+	doors := startResp.GetDoors()
+	s.Require().NotEmpty(doors, "StartCombatResponse.Doors must not be empty — no door to open")
+	s.T().Logf("  Available doors: %d", len(doors))
+
+	// Pick the first closed door that has a position.
+	var targetDoor *dnd5ev1alpha1.DoorInfo
+	for _, d := range doors {
+		if !d.GetIsOpen() && d.GetPosition() != nil {
+			targetDoor = d
+			break
+		}
+	}
+	s.Require().NotNil(targetDoor, "at least one closed door with position must exist after StartCombat")
+	s.T().Logf("  Target door: connectionId=%s position=%v physicalHint=%q",
+		targetDoor.GetConnectionId(),
+		targetDoor.GetPosition(),
+		targetDoor.GetPhysicalHint(),
+	)
+
+	doorPos := targetDoor.GetPosition()
+
+	// 5. Teleport character adjacent to the door via the encounter repository.
+	//
+	// Rooms can be 15-20 hexes wide and characters have only 30 feet (6 hexes) of
+	// movement per turn. Trying to walk the character across multiple combat turns
+	// is fragile: walls can block greedy movement, and monsters can kill the character.
+	//
+	// Instead we directly update the character's cube position in the encounter repo —
+	// the same pattern used in LevelUpMonkToLevel2. This is test infrastructure, not
+	// game mechanics, so using the repo directly is appropriate.
+	s.teleportCharacterAdjacentToDoor(ctx, encounterID, characterID, doorPos)
+
+	// 6. Call OpenDoor — this is the action that should publish the RoomRevealedEvent.
+	openResp, err := s.server.EncounterClient.OpenDoor(ctx, &dnd5ev1alpha1.OpenDoorRequest{
+		DungeonId:    dungeonID,
+		ConnectionId: targetDoor.GetConnectionId(),
+	})
+	s.Require().NoError(err, "OpenDoor should succeed after teleporting character adjacent to door")
+	s.Require().True(openResp.GetSuccess(), "OpenDoor response should indicate success")
+	s.T().Logf("  OpenDoor succeeded: encounterId=%s", openResp.GetEncounterId())
+
+	// 7. Collect events from the stream until we see a RoomRevealedEvent or time out.
+	events := collectEvents(s.T(), eventsCh, streamEventTimeout, func(e *dnd5ev1alpha1.EncounterEvent) bool {
+		return e.GetRoomRevealed() != nil
+	})
+
+	s.T().Logf("  Collected %d stream events", len(events))
+
+	// Log a summary of every event type received for diagnostics.
+	for i, e := range events {
+		switch {
+		case e.GetCombatStarted() != nil:
+			s.T().Logf("  Event[%d]: CombatStarted", i)
+		case e.GetMovementCompleted() != nil:
+			s.T().Logf("  Event[%d]: MovementCompleted entity=%s", i, e.GetMovementCompleted().GetEntityId())
+		case e.GetRoomRevealed() != nil:
+			r := e.GetRoomRevealed()
+			s.T().Logf("  Event[%d]: RoomRevealed dungeonId=%s connectionId=%s encStateDataNil=%v",
+				i, r.GetDungeonId(), r.GetConnectionId(), r.GetEncounterStateData() == nil)
+		case e.GetMonsterTurnCompleted() != nil:
+			s.T().Logf("  Event[%d]: MonsterTurnCompleted", i)
+		case e.GetTurnEnded() != nil:
+			s.T().Logf("  Event[%d]: TurnEnded", i)
+		case e.GetAttackResolved() != nil:
+			s.T().Logf("  Event[%d]: AttackResolved", i)
+		default:
+			s.T().Logf("  Event[%d]: other", i)
+		}
+	}
+
+	// 8. Assert: a RoomRevealedEvent MUST arrive — this is the critical pipeline assertion.
+	roomRevealedEvent, found := findEventOfType(events,
+		func(e *dnd5ev1alpha1.EncounterEvent) *dnd5ev1alpha1.RoomRevealedEvent {
+			return e.GetRoomRevealed()
+		},
+	)
+	s.Require().True(found,
+		"RoomRevealedEvent MUST arrive on the stream after OpenDoor — "+
+			"if it did not arrive, the event was silently dropped somewhere in the "+
+			"orchestrator → Redis pub/sub → stream handler pipeline")
+	s.T().Log("  Found RoomRevealedEvent")
+
+	// 9. Assert: event metadata matches what we requested.
+	s.Assert().Equal(dungeonID, roomRevealedEvent.GetDungeonId(),
+		"RoomRevealedEvent.DungeonId should match the dungeon we opened")
+	s.Assert().Equal(targetDoor.GetConnectionId(), roomRevealedEvent.GetConnectionId(),
+		"RoomRevealedEvent.ConnectionId should match the door we opened")
+
+	// 10. Assert: EncounterStateData survives the Redis JSON round-trip.
+	//
+	// This is THE critical assertion for the bug we are testing.
+	// If EncounterStateData is nil here the event was received but the proto payload
+	// was lost during JSON serialization/deserialization in the pub/sub round-trip.
+	stateData := roomRevealedEvent.GetEncounterStateData()
+	s.Require().NotNil(stateData,
+		"RoomRevealedEvent.EncounterStateData must not be nil — "+
+			"if nil, the custom MarshalJSON/UnmarshalJSON for RoomRevealedEvent failed "+
+			"to survive the Redis pub/sub JSON round-trip")
+	s.T().Log("  EncounterStateData is non-nil — JSON round-trip PASSED")
+
+	// 11. Assert: rooms are populated (start room + newly revealed room = 2).
+	rooms := stateData.GetRooms()
+	s.Assert().Len(rooms, 2,
+		"EncounterStateData.Rooms should have 2 entries (start room + revealed room)")
+	s.T().Logf("  EncounterStateData.Rooms count: %d", len(rooms))
+
+	// 12. Assert: at least one room has a non-zero origin (the revealed room is offset).
+	foundNonZeroOrigin := false
+	for roomID, room := range rooms {
+		origin := room.GetOrigin()
+		if origin != nil && (origin.GetX() != 0 || origin.GetY() != 0 || origin.GetZ() != 0) {
+			foundNonZeroOrigin = true
+			s.T().Logf("  Room %s has non-zero origin: (%.1f, %.1f, %.1f)",
+				roomID, origin.GetX(), origin.GetY(), origin.GetZ())
+		}
+	}
+	s.Assert().True(foundNonZeroOrigin,
+		"at least one room in EncounterStateData.Rooms should have a non-zero Origin "+
+			"(the revealed room is offset from (0,0,0) in dungeon-space)")
+
+	// 13. Assert: entities map is populated.
+	entities := stateData.GetEntities()
+	s.Assert().NotEmpty(entities,
+		"EncounterStateData.Entities should be non-empty (character + monsters from both rooms)")
+	s.T().Logf("  EncounterStateData.Entities count: %d", len(entities))
+
+	// 14. Assert: monster entities exist from the newly revealed room.
+	//
+	// When a door is opened, monsters from the revealed room are added to the
+	// encounter. Their positions should be absolute (offset by room origin),
+	// not the zero-origin (0,0,0) of the start room.
+	foundMonsterInRoom2 := false
+	for entityID, entity := range entities {
+		if entity.GetEntityType() == dnd5ev1alpha1.EntityType_ENTITY_TYPE_MONSTER {
+			pos := entity.GetPosition()
+			if pos != nil && (pos.GetX() != 0 || pos.GetY() != 0 || pos.GetZ() != 0) {
+				foundMonsterInRoom2 = true
+				s.T().Logf("  Monster %s in room 2 at absolute pos (%.1f, %.1f, %.1f)",
+					entityID, pos.GetX(), pos.GetY(), pos.GetZ())
+			}
+		}
+	}
+	s.Assert().True(foundMonsterInRoom2,
+		"at least one monster in EncounterStateData.Entities should have a non-zero position "+
+			"(monsters in the revealed room have positions offset by the room origin)")
+
+	s.T().Log("=== PASSED: OpenDoor → RoomRevealedEvent pipeline is working end-to-end ===")
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+// teleportCharacterAdjacentToDoor moves the character to be adjacent to the door
+// by directly updating the encounter repository's room data.
+//
+// This is test infrastructure, not game mechanics. We update the cube position
+// directly in the same way LevelUpMonkToLevel2 updates character data directly.
+// This avoids the fragility of multi-turn API-level movement (wall-blocked paths,
+// monster attacks, movement budget constraints).
+//
+// The door position is in dungeon-absolute coordinates. For the start room the
+// origin is (0,0,0), so room-local coordinates equal dungeon-absolute.
+// The proximity check uses cube distance <= 1, so placing the character ON the
+// door cell (distance 0) satisfies the check.
+func (s *OpenDoorIntegrationSuite) teleportCharacterAdjacentToDoor(
+	ctx context.Context,
+	encounterID, characterID string,
+	doorPos *apiv1alpha1.Position,
+) {
+	// 1. Load the dungeon to confirm the start room and its current state.
+	dungeonOutput, err := s.server.DungeonRepo.GetByEncounterID(ctx,
+		&dungeonrepo.GetByEncounterIDInput{EncounterID: encounterID},
+	)
+	s.Require().NoError(err, "teleportCharacterAdjacentToDoor: failed to load dungeon")
+	s.Require().NotNil(dungeonOutput.Dungeon, "teleportCharacterAdjacentToDoor: dungeon must not be nil")
+
+	// 2. Load encounter data to get the current room data.
+	encOutput, err := s.server.EncounterRepo.Get(ctx, &encounterrepo.GetInput{
+		EncounterID: encounterID,
+	})
+	s.Require().NoError(err, "teleportCharacterAdjacentToDoor: failed to load encounter")
+	s.Require().NotNil(encOutput.Data, "teleportCharacterAdjacentToDoor: encounter data must not be nil")
+
+	// 3. Cast room data to *spatial.RoomData (the type used by the hex grid).
+	roomData, ok := encOutput.Data.RoomData.(*spatial.RoomData)
+	s.Require().True(ok, "teleportCharacterAdjacentToDoor: RoomData must be *spatial.RoomData")
+	s.Require().NotNil(roomData, "teleportCharacterAdjacentToDoor: RoomData must not be nil")
+
+	// 4. Place the character directly on the door position.
+	//    Cube distance 0 satisfies the proximity check (distance <= 1).
+	//    If the door cell is blocked (occupied by monster), try its neighbors.
+	targetX := int(doorPos.GetX())
+	targetY := int(doorPos.GetY())
+	targetZ := int(doorPos.GetZ())
+
+	// Check if the door cell itself is occupied by a blocking entity.
+	doorOccupied := false
+	for id, placement := range roomData.CubeEntities {
+		if id != characterID && placement.BlocksMovement &&
+			placement.CubePosition.X == targetX &&
+			placement.CubePosition.Y == targetY &&
+			placement.CubePosition.Z == targetZ {
+			doorOccupied = true
+			break
+		}
+	}
+
+	if doorOccupied {
+		// Try the six hex neighbors of the door (all at distance 1).
+		placed := false
+		neighbors := [][3]int{
+			{targetX + 1, targetY - 1, targetZ},
+			{targetX - 1, targetY + 1, targetZ},
+			{targetX + 1, targetY, targetZ - 1},
+			{targetX - 1, targetY, targetZ + 1},
+			{targetX, targetY + 1, targetZ - 1},
+			{targetX, targetY - 1, targetZ + 1},
+		}
+		for _, n := range neighbors {
+			nx, ny, nz := n[0], n[1], n[2]
+			occupied := false
+			for id, placement := range roomData.CubeEntities {
+				if id != characterID && placement.BlocksMovement &&
+					placement.CubePosition.X == nx &&
+					placement.CubePosition.Y == ny &&
+					placement.CubePosition.Z == nz {
+					occupied = true
+					break
+				}
+			}
+			if !occupied {
+				targetX, targetY, targetZ = nx, ny, nz
+				placed = true
+				break
+			}
+		}
+		s.Require().True(placed, "teleportCharacterAdjacentToDoor: no unoccupied cell adjacent to door")
+	}
+
+	// 5. Update character's cube position in the room data.
+	existing, exists := roomData.CubeEntities[characterID]
+	entityType := "character"
+	if exists {
+		entityType = existing.EntityType
+	}
+	roomData.CubeEntities[characterID] = spatial.EntityCubePlacement{
+		EntityID:       characterID,
+		EntityType:     entityType,
+		CubePosition:   spatial.CubeCoordinate{X: targetX, Y: targetY, Z: targetZ},
+		Size:           1,
+		BlocksMovement: true,
+	}
+
+	s.T().Logf("  Teleported %s to (%d,%d,%d) — adjacent to door at (%d,%d,%d)",
+		characterID, targetX, targetY, targetZ,
+		int(doorPos.GetX()), int(doorPos.GetY()), int(doorPos.GetZ()))
+
+	// 6. Persist the updated room data back to the encounter repo.
+	_, err = s.server.EncounterRepo.Update(ctx, &encounterrepo.UpdateInput{
+		EncounterID: encounterID,
+		RoomData:    roomData,
+	})
+	s.Require().NoError(err, "teleportCharacterAdjacentToDoor: failed to update encounter with new position")
+}

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -60,6 +60,8 @@ type TestServer struct {
 	// Exposed for test setup (seeding data, etc.)
 	EncounterPublisher encounterpub.Publisher
 	CharacterRepo      characterrepo.Repository
+	EncounterRepo      encountersrepo.Repository
+	DungeonRepo        dungeonsrepo.Repository
 }
 
 // Config allows customization of the test server.
@@ -180,6 +182,8 @@ func (ts *TestServer) wireServices(cfg *Config) error {
 
 	encounterRepo := encountersrepo.NewInMemory()
 	dungeonRepo := dungeonsrepo.NewInMemory()
+	ts.EncounterRepo = encounterRepo
+	ts.DungeonRepo = dungeonRepo
 	dungeonGen := dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{})
 	encounterLogRepo := encounterlogrepo.NewInMemory(nil)
 

--- a/internal/orchestrators/encounter/build_room_layout_proto_test.go
+++ b/internal/orchestrators/encounter/build_room_layout_proto_test.go
@@ -1,0 +1,160 @@
+package encounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
+)
+
+func TestBuildRoomLayoutProto_NilRoom(t *testing.T) {
+	result := buildRoomLayoutProto(nil, nil)
+	assert.Nil(t, result)
+}
+
+func TestBuildRoomLayoutProto_NilShape(t *testing.T) {
+	room := &dungeon.Room{ID: "room-1", Shape: nil}
+	result := buildRoomLayoutProto(room, nil)
+	assert.Nil(t, result)
+}
+
+func TestBuildRoomLayoutProto_WallsShiftedByOrigin(t *testing.T) {
+	// Room 2 has walls in room-local coordinates. With origin (5, -5, 0), the
+	// absolute positions must be offset by that origin.
+	room := &dungeon.Room{
+		ID: "room-2",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    5,
+			Height:   5,
+		},
+		Walls: []dungeon.WallSegment{
+			{
+				ID:                "wall-1",
+				Start:             dungeon.Position{X: 1, Y: -1, Z: 0},
+				End:               dungeon.Position{X: 2, Y: -2, Z: 0},
+				Type:              dungeon.WallTypeIndestructible,
+				BlocksMovement:    true,
+				BlocksLineOfSight: true,
+			},
+		},
+	}
+
+	// origin (5, -5, 0): X=5, Z=0, Y=-5 (derived from cube constraint -5-0).
+	origin := &dungeon.Position{X: 5, Y: -5, Z: 0}
+
+	result := buildRoomLayoutProto(room, origin)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Walls, 1)
+
+	wall := result.Walls[0]
+
+	// Start: local (1, -1, 0) + origin (5, 0) => absolute X=6, Z=0, Y=-6-0=-6
+	assert.Equal(t, 6.0, wall.Start.X, "Start.X should be local+origin.X")
+	assert.Equal(t, 0.0, wall.Start.Z, "Start.Z should be local+origin.Z")
+	assert.Equal(t, -6.0, wall.Start.Y, "Start.Y must satisfy cube constraint: -x-z")
+
+	// End: local (2, -2, 0) + origin (5, 0) => absolute X=7, Z=0, Y=-7-0=-7
+	assert.Equal(t, 7.0, wall.End.X, "End.X should be local+origin.X")
+	assert.Equal(t, 0.0, wall.End.Z, "End.Z should be local+origin.Z")
+	assert.Equal(t, -7.0, wall.End.Y, "End.Y must satisfy cube constraint: -x-z")
+
+	assert.Equal(t, "stone", wall.Material)
+	assert.True(t, wall.BlocksMovement)
+	assert.True(t, wall.BlocksLineOfSight)
+}
+
+func TestBuildRoomLayoutProto_WallsNilOriginPassThrough(t *testing.T) {
+	// When origin is nil the wall positions come through unchanged, but Y is still
+	// recomputed from the cube constraint.
+	room := &dungeon.Room{
+		ID: "room-1",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    3,
+			Height:   3,
+		},
+		Walls: []dungeon.WallSegment{
+			{
+				ID:    "wall-1",
+				Start: dungeon.Position{X: 2, Y: -3, Z: 1},
+				End:   dungeon.Position{X: 3, Y: -4, Z: 1},
+				Type:  dungeon.WallTypeDestructible,
+			},
+		},
+	}
+
+	result := buildRoomLayoutProto(room, nil)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Walls, 1)
+
+	wall := result.Walls[0]
+
+	// No origin: X and Z pass through, Y recomputed from cube constraint.
+	assert.Equal(t, 2.0, wall.Start.X)
+	assert.Equal(t, 1.0, wall.Start.Z)
+	assert.Equal(t, -3.0, wall.Start.Y, "Start.Y must satisfy cube constraint: -2-1=-3")
+
+	assert.Equal(t, 3.0, wall.End.X)
+	assert.Equal(t, 1.0, wall.End.Z)
+	assert.Equal(t, -4.0, wall.End.Y, "End.Y must satisfy cube constraint: -3-1=-4")
+
+	assert.Equal(t, "wood", wall.Material, "destructible walls use wood material")
+}
+
+func TestBuildRoomLayoutProto_OriginSetInProto(t *testing.T) {
+	room := &dungeon.Room{
+		ID: "room-3",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    4,
+			Height:   4,
+		},
+	}
+	origin := &dungeon.Position{X: 5, Y: -5, Z: 0}
+
+	result := buildRoomLayoutProto(room, origin)
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.Origin)
+	assert.Equal(t, 5.0, result.Origin.X)
+	assert.Equal(t, -5.0, result.Origin.Y)
+	assert.Equal(t, 0.0, result.Origin.Z)
+}
+
+func TestBuildRoomLayoutProto_MultipleWallsAllShifted(t *testing.T) {
+	// Verify that every wall in a multi-wall room gets the offset applied.
+	room := &dungeon.Room{
+		ID: "room-4",
+		Shape: &dungeon.Shape{
+			GridType: dungeon.GridTypeHex,
+			Width:    6,
+			Height:   6,
+		},
+		Walls: []dungeon.WallSegment{
+			{ID: "w1", Start: dungeon.Position{X: 0, Y: 0, Z: 0}, End: dungeon.Position{X: 1, Y: -1, Z: 0}},
+			{ID: "w2", Start: dungeon.Position{X: 1, Y: -1, Z: 0}, End: dungeon.Position{X: 2, Y: -1, Z: -1}},
+		},
+	}
+
+	origin := &dungeon.Position{X: 3, Y: -3, Z: 0}
+
+	result := buildRoomLayoutProto(room, origin)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Walls, 2)
+
+	// Wall 0: start (0,0,0) + origin(3,0) => (3,0) => Y=-3-0=-3
+	assert.Equal(t, 3.0, result.Walls[0].Start.X)
+	assert.Equal(t, 0.0, result.Walls[0].Start.Z)
+	assert.Equal(t, -3.0, result.Walls[0].Start.Y)
+
+	// Wall 1: end (2,-1,-1) + origin(3,0) => (5,-1) => Y=-5-(-1)=-4
+	assert.Equal(t, 5.0, result.Walls[1].End.X)
+	assert.Equal(t, -1.0, result.Walls[1].End.Z)
+	assert.Equal(t, -4.0, result.Walls[1].End.Y)
+}

--- a/internal/orchestrators/encounter/open_door_test.go
+++ b/internal/orchestrators/encounter/open_door_test.go
@@ -540,7 +540,7 @@ func (s *OpenDoorTestSuite) TestOpenDoor_MonsterPositions_AreAbsolute() {
 
 		wantAbsX = localMonsterX + originX // 3
 		wantAbsZ = localMonsterZ + originZ // 12
-		wantAbsY = -wantAbsX - wantAbsZ   // -15
+		wantAbsY = -wantAbsX - wantAbsZ    // -15
 	)
 
 	// Arrange: build a dungeon where room-2 has a non-zero origin.

--- a/internal/orchestrators/encounter/open_door_test.go
+++ b/internal/orchestrators/encounter/open_door_test.go
@@ -447,3 +447,101 @@ func (s *OpenDoorTestSuite) TestOpenDoor_BothRoomsRevealed_Error() {
 	s.Nil(output)
 	s.Contains(err.Error(), "both rooms already revealed")
 }
+
+// TestOpenDoor_MonsterPositions_AreAbsolute verifies that when a room with a non-zero origin is
+// revealed, the monster positions stored in the encounter Entities map are absolute dungeon-space
+// coordinates (room-local + origin), not room-local coordinates.
+//
+// Regression test for: bug: OpenDoor monster positions are room-local, not absolute (#460)
+func (s *OpenDoorTestSuite) TestOpenDoor_MonsterPositions_AreAbsolute() {
+	// Room 2 is offset from the dungeon origin: origin (0, -10, 10) in cube coords.
+	// The monster is at room-local position (3, 2) which maps to cube (X=3, Z=2).
+	// After adding the room origin the absolute cube position should be:
+	//   absX = 3 + 0  = 3
+	//   absZ = 2 + 10 = 12
+	//   absY = -absX - absZ = -3 - 12 = -15
+	const (
+		originX = 0
+		originZ = 10
+
+		localMonsterX = 3 // room-local offset X -> cube X
+		localMonsterZ = 2 // room-local offset Y -> cube Z
+
+		wantAbsX = localMonsterX + originX // 3
+		wantAbsZ = localMonsterZ + originZ // 12
+		wantAbsY = -wantAbsX - wantAbsZ   // -15
+	)
+
+	// Arrange: build a dungeon where room-2 has a non-zero origin.
+	testDungeon := s.createTestDungeon()
+	testDungeon.Rooms["room-2"].Encounter = &dungeon.Encounter{
+		Monsters: []dungeon.MonsterPlacement{
+			{
+				ID:        "mp-abs",
+				MonsterID: "skeleton",
+				// Room-local offset coords: X=cube X, Y=cube Z
+				Position: dungeon.Position{X: localMonsterX, Y: localMonsterZ},
+			},
+		},
+	}
+	testDungeon.RoomOrigins = map[string]dungeon.Position{
+		"room-2": {X: originX, Y: -originX - originZ, Z: originZ},
+	}
+
+	// The encounter data must have an Entities map so addMonstersToEntityMap does not skip.
+	var capturedEncData *encounterrepo.EncounterData
+	testEncounter := s.createTestEncounterData()
+	testEncounter.Entities = make(map[string]*entities.EntityStateData)
+
+	s.mockDungeonRepo.EXPECT().
+		Get(gomock.Any(), &dungeonrepo.GetInput{DungeonID: "dng-123"}).
+		Return(&dungeonrepo.GetOutput{Dungeon: testDungeon}, nil)
+
+	s.mockEncRepo.EXPECT().
+		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-123"}).
+		DoAndReturn(func(_ context.Context, _ *encounterrepo.GetInput) (*encounterrepo.GetOutput, error) {
+			capturedEncData = testEncounter
+			return &encounterrepo.GetOutput{Data: testEncounter}, nil
+		})
+
+	s.mockDungeonRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.UpdateOutput{Success: true}, nil)
+
+	s.mockEncRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&encounterrepo.UpdateOutput{}, nil)
+
+	// buildEncounterStateSnapshot calls GetByEncounterID to load dungeon context for the snapshot.
+	// Return the same dungeon (now updated with room-2 revealed) so the snapshot can be built.
+	s.mockDungeonRepo.EXPECT().
+		GetByEncounterID(gomock.Any(), &dungeonrepo.GetByEncounterIDInput{EncounterID: "enc-123"}).
+		Return(&dungeonrepo.GetOutput{Dungeon: testDungeon}, nil)
+
+	// Act
+	output, err := s.orchestrator.OpenDoor(s.ctx, &encounter.OpenDoorInput{
+		DungeonID:    "dng-123",
+		ConnectionID: "conn-1",
+	})
+
+	// Assert: OpenDoor itself should succeed.
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+
+	// The captured encounter data has been mutated in-place by addMonstersToEntityMap.
+	// The monster entity must carry absolute dungeon-space cube coordinates.
+	s.Require().NotNil(capturedEncData, "encounter data should have been captured")
+	s.Require().NotEmpty(capturedEncData.Entities, "entities map should not be empty after monster spawn")
+
+	monsterKey := "monster-room-2-mp-abs"
+	entity, ok := capturedEncData.Entities[monsterKey]
+	s.Require().True(ok, "entity %q should be present in Entities map", monsterKey)
+	s.Require().NotNil(entity.Position, "entity position should not be nil")
+
+	s.Equal(float64(wantAbsX), entity.Position.X,
+		"absolute X should be room-local (%d) + origin (%d) = %d", localMonsterX, originX, wantAbsX)
+	s.Equal(float64(wantAbsY), entity.Position.Y,
+		"absolute Y should satisfy cube constraint: -absX - absZ = %d", wantAbsY)
+	s.Equal(float64(wantAbsZ), entity.Position.Z,
+		"absolute Z should be room-local (%d) + origin (%d) = %d", localMonsterZ, originZ, wantAbsZ)
+}

--- a/internal/orchestrators/encounter/open_door_test.go
+++ b/internal/orchestrators/encounter/open_door_test.go
@@ -307,7 +307,7 @@ func (s *OpenDoorTestSuite) TestOpenDoor_Success_RevealsRoom() {
 			return &dungeonrepo.UpdateOutput{Success: true}, nil
 		})
 
-	// Expect encounter update with new initiative order
+	// Expect encounter update with new initiative order and merged RoomData
 	s.mockEncRepo.EXPECT().
 		Update(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, input *encounterrepo.UpdateInput) (*encounterrepo.UpdateOutput, error) {
@@ -315,6 +315,17 @@ func (s *OpenDoorTestSuite) TestOpenDoor_Success_RevealsRoom() {
 			s.NotNil(input.InitiativeData, "initiative data should be updated")
 			// Should now have 3 entities (1 char + 2 skeletons)
 			s.Len(input.InitiativeData.Order, 3)
+			// RoomData must be persisted so monsters are visible to buildPerception on EndTurn
+			s.NotNil(input.RoomData, "RoomData must be persisted so new monsters can be perceived")
+			roomData, ok := input.RoomData.(*spatial.RoomData)
+			s.True(ok, "RoomData should be *spatial.RoomData")
+			if ok {
+				// Original character placement is preserved
+				s.Contains(roomData.CubeEntities, "char-1", "character position should be preserved in RoomData")
+				// New monsters are present so buildPerception can locate them
+				s.Contains(roomData.CubeEntities, "monster-room-2-mp-1", "new monster should be in RoomData")
+				s.Contains(roomData.CubeEntities, "monster-room-2-mp-2", "new monster should be in RoomData")
+			}
 			return &encounterrepo.UpdateOutput{}, nil
 		})
 
@@ -331,6 +342,66 @@ func (s *OpenDoorTestSuite) TestOpenDoor_Success_RevealsRoom() {
 	s.Equal("room-2", output.RevealedRoom.ID)
 	s.Len(output.Monsters, 2, "should have 2 monsters")
 	s.NotNil(output.CombatState)
+}
+
+func (s *OpenDoorTestSuite) TestOpenDoor_NewMonstersPersistedInRoomData() {
+	// Regression test: OpenDoor must persist RoomData containing new monster positions
+	// so that EndTurn's executeMonsterTurns -> buildPerception can find targets.
+	// Without this fix, monsters opened into via a door would see no enemies and stand idle.
+
+	// Arrange
+	testDungeon := s.createTestDungeon()
+	testEncounter := s.createTestEncounterData()
+
+	s.mockDungeonRepo.EXPECT().
+		Get(gomock.Any(), &dungeonrepo.GetInput{DungeonID: "dng-123"}).
+		Return(&dungeonrepo.GetOutput{Dungeon: testDungeon}, nil)
+
+	s.mockEncRepo.EXPECT().
+		Get(gomock.Any(), &encounterrepo.GetInput{EncounterID: "enc-123"}).
+		Return(&encounterrepo.GetOutput{Data: testEncounter}, nil)
+
+	s.mockDungeonRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(&dungeonrepo.UpdateOutput{Success: true}, nil)
+
+	var capturedRoomData *spatial.RoomData
+	s.mockEncRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *encounterrepo.UpdateInput) (*encounterrepo.UpdateOutput, error) {
+			s.Require().NotNil(input.RoomData, "RoomData must not be nil: monsters would be invisible to EndTurn")
+			rd, ok := input.RoomData.(*spatial.RoomData)
+			s.Require().True(ok, "RoomData must be *spatial.RoomData")
+			capturedRoomData = rd
+			return &encounterrepo.UpdateOutput{}, nil
+		})
+
+	// Act
+	output, err := s.orchestrator.OpenDoor(s.ctx, &encounter.OpenDoorInput{
+		DungeonID:    "dng-123",
+		ConnectionID: "conn-1",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+
+	// The persisted RoomData must contain all entities needed for perception:
+	// - The character (so monsters can target them)
+	// - Each new monster (so buildPerception can locate their own position)
+	s.Require().NotNil(capturedRoomData)
+	s.Contains(capturedRoomData.CubeEntities, "char-1",
+		"character must remain in RoomData after OpenDoor so monsters can perceive them")
+
+	for _, m := range output.Monsters {
+		s.Contains(capturedRoomData.CubeEntities, m.ID,
+			"monster %q must be in persisted RoomData so it can perceive targets on EndTurn", m.ID)
+
+		placement := capturedRoomData.CubeEntities[m.ID]
+		s.Equal(m.ID, placement.EntityID)
+		s.Equal("monster", placement.EntityType)
+		// Cube constraint: x + y + z == 0
+		s.Equal(0, placement.CubePosition.X+placement.CubePosition.Y+placement.CubePosition.Z,
+			"cube coordinate must satisfy x+y+z=0 for monster %q", m.ID)
+	}
 }
 
 func (s *OpenDoorTestSuite) TestOpenDoor_RevealsCorrectRoom() {

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1317,12 +1317,22 @@ func (o *Orchestrator) placeMonsters(roomData *spatial.RoomData, room *dungeon.R
 // the existing RoomData is required so that EndTurn's buildPerception can locate
 // new monsters when they take their turn; without this, monsters see no enemies.
 //
-// The coordinate conversion matches StartCombat: 2D position Y maps to cube Z,
-// and cube Y is derived from the x+y+z=0 constraint.
+// The coordinate conversion follows the same 2D-to-cube mapping used when adding
+// newly revealed room monsters into the entity map during door-opening: 2D
+// position Y maps to cube Z, and cube Y is derived from the x+y+z=0 constraint.
 //
 // Existing entries in currentRoomData are never overwritten to preserve character
 // positions that were already there before the door was opened.
 func mergeNewRoomMonsters(monsters []MonsterInfo, revealedRoom *spatial.RoomData, currentRoomData *spatial.RoomData) {
+	if revealedRoom == nil || currentRoomData == nil || len(monsters) == 0 {
+		return
+	}
+	if revealedRoom.CubeEntities == nil {
+		revealedRoom.CubeEntities = make(map[string]spatial.EntityCubePlacement)
+	}
+	if currentRoomData.CubeEntities == nil {
+		currentRoomData.CubeEntities = make(map[string]spatial.EntityCubePlacement)
+	}
 	for _, m := range monsters {
 		cubeX := int(m.Position.X)
 		cubeZ := int(m.Position.Y) // Y in 2D maps to Z in cube coords

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -3316,8 +3316,9 @@ func (o *Orchestrator) OpenDoor(
 		}
 	}
 
-	// 17. Add new monster entities to encounter Entities map for snapshot
-	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID)
+	// 17. Add new monster entities to encounter Entities map for snapshot.
+	// Pass the room origin so entity positions are stored as absolute dungeon-space coordinates.
+	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID, roomOriginFor(dng, revealedRoomID))
 
 	// Build snapshot for RoomRevealed event
 	roomRevealedStateData := o.buildEncounterStateSnapshot(ctx, dng.EncounterID, encOutput.Data, combatState)
@@ -5545,30 +5546,49 @@ func (o *Orchestrator) buildEncounterStateSnapshot(
 	return output.EncounterStateData
 }
 
+// roomOriginFor returns the absolute dungeon-space cube origin for the given room, or a zero
+// value if the dungeon has no stored origins or the room is not present in the map.
+func roomOriginFor(dng *entities.Dungeon, roomID string) dungeon.Position {
+	if dng.RoomOrigins == nil {
+		return dungeon.Position{}
+	}
+	return dng.RoomOrigins[roomID]
+}
+
 // addMonstersToEntityMap adds newly spawned monsters (from room reveal) to the encounter's
 // Entities map so that subsequent snapshot events include them.
+//
+// roomOrigin is the absolute dungeon-space cube position of the room. Monster placements
+// are stored in room-local offset coordinates (X = cube X, Y = cube Z), so the origin must
+// be added to produce the absolute position that the rest of the system expects.
 func (o *Orchestrator) addMonstersToEntityMap(
 	enc *encounterrepo.EncounterData,
 	monsters []MonsterInfo,
 	roomID string,
+	roomOrigin dungeon.Position,
 ) {
 	if enc == nil || enc.Entities == nil || len(monsters) == 0 {
 		return
 	}
 
 	for _, m := range monsters {
-		cubeX := int(m.Position.X)
-		cubeZ := int(m.Position.Y)
-		cubeY := -cubeX - cubeZ
+		// Monster positions in MonsterInfo use offset (2D) coords:
+		//   Position.X -> cube X axis
+		//   Position.Y -> cube Z axis
+		// Add the room origin (cube coords) to convert to absolute dungeon-space.
+		absX := int(m.Position.X) + roomOrigin.X
+		absZ := int(m.Position.Y) + roomOrigin.Z
+		absY := -absX - absZ // cube constraint: x + y + z = 0
+
 		monsterData := o.findMonsterData(enc, m.ID)
 		enc.Entities[m.ID] = &entities.EntityStateData{
 			EntityID:   m.ID,
 			EntityType: entities.EntityTypeMonster,
 			RoomID:     roomID,
 			Position: &entities.Position{
-				X: float64(cubeX),
-				Y: float64(cubeY),
-				Z: float64(cubeZ),
+				X: float64(absX),
+				Y: float64(absY),
+				Z: float64(absZ),
 			},
 			Size:        1,
 			ToolkitData: monsterData,

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1323,7 +1323,7 @@ func (o *Orchestrator) placeMonsters(roomData *spatial.RoomData, room *dungeon.R
 //
 // Existing entries in currentRoomData are never overwritten to preserve character
 // positions that were already there before the door was opened.
-func mergeNewRoomMonsters(monsters []MonsterInfo, revealedRoom *spatial.RoomData, currentRoomData *spatial.RoomData) {
+func mergeNewRoomMonsters(monsters []MonsterInfo, revealedRoom *spatial.RoomData, currentRoomData *spatial.RoomData, roomOrigin dungeon.Position) {
 	if revealedRoom == nil || currentRoomData == nil || len(monsters) == 0 {
 		return
 	}
@@ -1334,9 +1334,10 @@ func mergeNewRoomMonsters(monsters []MonsterInfo, revealedRoom *spatial.RoomData
 		currentRoomData.CubeEntities = make(map[string]spatial.EntityCubePlacement)
 	}
 	for _, m := range monsters {
-		cubeX := int(m.Position.X)
-		cubeZ := int(m.Position.Y) // Y in 2D maps to Z in cube coords
-		cubeY := -cubeX - cubeZ    // y = -x - z for valid cube coordinate
+		// Monster positions are room-local offset coords. Add room origin to get absolute.
+		cubeX := int(m.Position.X) + roomOrigin.X
+		cubeZ := int(m.Position.Y) + roomOrigin.Z // Y in 2D maps to Z in cube coords
+		cubeY := -cubeX - cubeZ                   // y = -x - z for valid cube coordinate
 
 		placement := spatial.EntityCubePlacement{
 			EntityID:          m.ID,
@@ -3272,7 +3273,7 @@ func (o *Orchestrator) OpenDoor(
 	// the existing RoomData. This ensures monsters in the new room are present in the
 	// persisted RoomData so that buildPerception can locate them during EndTurn.
 	revealedSpatialRoom := o.convertToRoomData(dng.EncounterID, revealedRoom)
-	mergeNewRoomMonsters(monsters, revealedSpatialRoom, roomData)
+	mergeNewRoomMonsters(monsters, revealedSpatialRoom, roomData, roomOriginFor(dng, revealedRoomID))
 
 	// Update encounter state with new initiative, boss monster IDs, and merged RoomData.
 	// Merge new boss IDs with any existing ones

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1295,6 +1295,41 @@ func (o *Orchestrator) placeMonsters(roomData *spatial.RoomData, room *dungeon.R
 	return monsters
 }
 
+// mergeNewRoomMonsters places monsters from a newly-revealed room into both the
+// revealed room's spatial data and the existing (current) RoomData. Merging into
+// the existing RoomData is required so that EndTurn's buildPerception can locate
+// new monsters when they take their turn; without this, monsters see no enemies.
+//
+// The coordinate conversion matches StartCombat: 2D position Y maps to cube Z,
+// and cube Y is derived from the x+y+z=0 constraint.
+//
+// Existing entries in currentRoomData are never overwritten to preserve character
+// positions that were already there before the door was opened.
+func mergeNewRoomMonsters(monsters []MonsterInfo, revealedRoom *spatial.RoomData, currentRoomData *spatial.RoomData) {
+	for _, m := range monsters {
+		cubeX := int(m.Position.X)
+		cubeZ := int(m.Position.Y) // Y in 2D maps to Z in cube coords
+		cubeY := -cubeX - cubeZ    // y = -x - z for valid cube coordinate
+
+		placement := spatial.EntityCubePlacement{
+			EntityID:          m.ID,
+			EntityType:        entityTypeMonster,
+			CubePosition:      spatial.CubeCoordinate{X: cubeX, Y: cubeY, Z: cubeZ},
+			Size:              1,
+			BlocksMovement:    true,
+			BlocksLineOfSight: false,
+		}
+
+		revealedRoom.CubeEntities[m.ID] = placement
+
+		// Only add to current room data if not already present; existing character
+		// positions must not be overwritten.
+		if _, exists := currentRoomData.CubeEntities[m.ID]; !exists {
+			currentRoomData.CubeEntities[m.ID] = placement
+		}
+	}
+}
+
 // findSafeFallbackPosition finds a position that is not on a wall or occupied
 // Searches outward from center until a valid position is found
 func findSafeFallbackPosition(room *dungeon.Room, roomData *spatial.RoomData) spatial.CubeCoordinate {
@@ -3206,7 +3241,13 @@ func (o *Orchestrator) OpenDoor(
 		return nil, fmt.Errorf("failed to update dungeon: %w", err)
 	}
 
-	// 11. Update encounter state with new initiative and boss monster IDs
+	// 11. Build spatial data for the revealed room and merge monster positions into
+	// the existing RoomData. This ensures monsters in the new room are present in the
+	// persisted RoomData so that buildPerception can locate them during EndTurn.
+	revealedSpatialRoom := o.convertToRoomData(dng.EncounterID, revealedRoom)
+	mergeNewRoomMonsters(monsters, revealedSpatialRoom, roomData)
+
+	// Update encounter state with new initiative, boss monster IDs, and merged RoomData.
 	// Merge new boss IDs with any existing ones
 	allBossIDs := make([]string, 0, len(encOutput.Data.BossMonsterIDs)+len(newBossMonsterIDs))
 	allBossIDs = append(allBossIDs, encOutput.Data.BossMonsterIDs...)
@@ -3217,6 +3258,7 @@ func (o *Orchestrator) OpenDoor(
 		InitiativeRolls: allRolls, // Persist merged rolls so EndTurn can re-sort at round start
 		Monsters:        encOutput.Data.Monsters,
 		BossMonsterIDs:  allBossIDs,
+		RoomData:        roomData, // Persist merged positions so monsters can be perceived on EndTurn
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update encounter: %w", err)
@@ -3296,25 +3338,8 @@ func (o *Orchestrator) OpenDoor(
 		})
 	}
 
-	// 16. Build revealed room spatial data for event (including monsters)
-	revealedSpatialRoom := o.convertToRoomData(dng.EncounterID, revealedRoom)
-
-	// Add monster placements to the spatial room data for the event
-	// This ensures the RoomRevealedEvent includes monsters, matching the OpenDoor response
-	for _, m := range monsters {
-		cubeX := int(m.Position.X)
-		cubeZ := int(m.Position.Y) // Y in 2D maps to Z in cube coords
-		cubeY := -cubeX - cubeZ    // y = -x - z for valid cube coordinate
-
-		revealedSpatialRoom.CubeEntities[m.ID] = spatial.EntityCubePlacement{
-			EntityID:          m.ID,
-			EntityType:        "monster",
-			CubePosition:      spatial.CubeCoordinate{X: cubeX, Y: cubeY, Z: cubeZ},
-			Size:              1,
-			BlocksMovement:    true,
-			BlocksLineOfSight: false,
-		}
-	}
+	// 16. revealedSpatialRoom was already built in step 11 with monsters placed in it.
+	// It is used directly for the RoomRevealedEvent below.
 
 	// 17. Add new monster entities to encounter Entities map for snapshot
 	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID)

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -1091,7 +1091,9 @@ func (o *Orchestrator) convertToWallInfo(room *dungeon.Room) []WallInfo {
 
 // buildRoomLayoutProto converts a dungeon.Room and its absolute origin to a proto RoomLayout.
 // The origin is the room's position in dungeon-space; walls are stored in room-local coordinates
-// and are passed through as-is here (the client applies the origin offset for rendering).
+// and must be translated to absolute dungeon-space by adding the origin offset. The Y coordinate
+// is recomputed from the cube constraint (y = -x - z) after applying the offset, because origin.Y
+// is itself derived from that constraint and must not be added directly.
 //
 //nolint:gosec // G115: Game values are bounded by room size limits, no overflow risk
 func buildRoomLayoutProto(room *dungeon.Room, origin *dungeon.Position) *pb.RoomLayout {
@@ -1125,7 +1127,9 @@ func buildRoomLayoutProto(room *dungeon.Room, origin *dungeon.Position) *pb.Room
 		}
 	}
 
-	// Convert walls.
+	// Convert walls, translating room-local coordinates to absolute dungeon-space by adding the
+	// origin offset. Y is recomputed via the cube constraint (y = -x - z) rather than adding
+	// origin.Y directly, because origin.Y is itself derived from the same constraint.
 	var protoWalls []*apiv1alpha1.Wall
 	if len(room.Walls) > 0 {
 		protoWalls = make([]*apiv1alpha1.Wall, len(room.Walls))
@@ -1134,16 +1138,29 @@ func buildRoomLayoutProto(room *dungeon.Room, origin *dungeon.Position) *pb.Room
 			if w.Type == dungeon.WallTypeDestructible {
 				material = "wood"
 			}
+
+			startX := float64(w.Start.X)
+			startZ := float64(w.Start.Z)
+			endX := float64(w.End.X)
+			endZ := float64(w.End.Z)
+
+			if origin != nil {
+				startX += float64(origin.X)
+				startZ += float64(origin.Z)
+				endX += float64(origin.X)
+				endZ += float64(origin.Z)
+			}
+
 			protoWalls[i] = &apiv1alpha1.Wall{
 				Start: &apiv1alpha1.Position{
-					X: float64(w.Start.X),
-					Y: float64(w.Start.Y),
-					Z: float64(w.Start.Z),
+					X: startX,
+					Y: -startX - startZ,
+					Z: startZ,
 				},
 				End: &apiv1alpha1.Position{
-					X: float64(w.End.X),
-					Y: float64(w.End.Y),
-					Z: float64(w.End.Z),
+					X: endX,
+					Y: -endX - endZ,
+					Z: endZ,
 				},
 				Material:          material,
 				BlocksMovement:    w.BlocksMovement,

--- a/internal/processors/event/processor.go
+++ b/internal/processors/event/processor.go
@@ -5,6 +5,7 @@ package event
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/KirkDiggler/rpg-api/internal/apierr"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
@@ -74,11 +75,14 @@ func (p *processor) Process(ctx context.Context, input *ProcessInput) (*ProcessO
 
 	// 2. Publish to subscribers (for real-time updates)
 	// Publish failures don't fail the operation - persistence is source of truth
-	// In production, might want to log, retry, or queue failed publishes
-	_, _ = p.publisher.Publish(ctx, &encounter.PublishInput{
+	_, pubErr := p.publisher.Publish(ctx, &encounter.PublishInput{
 		EncounterID: input.EncounterID,
 		Event:       input.Event,
 	})
+	if pubErr != nil {
+		fmt.Printf("[EventProcessor] PUBLISH FAILED for %s event (encounter %s): %v\n",
+			input.Event.Type, input.EncounterID, pubErr)
+	}
 
 	// Use the EventID from the repository response - repo is source of truth
 	return &ProcessOutput{EventID: appendOutput.EventID}, nil


### PR DESCRIPTION
## Summary
Consolidated fix for multi-room dungeon rendering. Player can open a door and see room 2 render correctly with walls, monsters, and working combat.

**Fixes:** #458, #460, #462, #464, #465

### Changes
- **DungeonStart shift** — add `shiftRoomToAbsolute` for coordinate consistency
- **Monster positions** — offset by room origin in entity snapshot (was room-local)
- **Wall positions** — offset by room origin in `buildRoomLayoutProto` (was room-local)
- **Monster perception** — persist merged RoomData on OpenDoor so monsters can perceive targets
- **Perimeter walls** — fix cube coordinate bug in door-adjacent wall segment generation
- **Nil guards** — add CubeEntities nil checks in `mergeNewRoomMonsters` (Copilot feedback)

### Acceptance Criteria
- [ ] Player opens door while in room 1 — room 2 renders at correct offset
- [ ] Both rooms visible as contiguous hex grid
- [ ] New room's monsters appear at correct absolute positions
- [ ] New room's monsters take turns in initiative order
- [ ] Room 2 has outer/perimeter walls
- [ ] Door icon updates to show open state

## Test plan
- [ ] All existing tests pass (verified locally)
- [ ] New tests: DungeonStart shift, monster absolute positions, wall absolute positions, perimeter wall cube invariant, RoomData persistence
- [ ] Manual playtest: open door, verify room 2 renders, monsters fight

🤖 Generated with [Claude Code](https://claude.com/claude-code)