### PR TITLE
fix(encounter): route crypt theme to ThemeCrypt

### DIFF
--- a/internal/orchestrators/encounter/dungeon_mapper.go
+++ b/internal/orchestrators/encounter/dungeon_mapper.go
@@ -41,7 +41,7 @@ func mapTheme(themeID string) dungeon.Theme {
 	case "bandit-lair":
 		return dungeon.ThemeBanditLair
 	case "crypt":
-		return dungeon.ThemeDebugWalls // TODO: swap back to ThemeCrypt after wall UI testing
+		return dungeon.ThemeCrypt
 	case "debug-walls":
 		return dungeon.ThemeDebugWalls
 	default:

--- a/internal/orchestrators/encounter/dungeon_mapper_test.go
+++ b/internal/orchestrators/encounter/dungeon_mapper_test.go
@@ -35,8 +35,7 @@ func TestMapToGeneratorInput_ThemeCrypt(t *testing.T) {
 	result := MapToGeneratorInput(input)
 
 	require.NotNil(t, result)
-	// TODO: swap back to ThemeCrypt after wall UI testing
-	assert.Equal(t, dungeon.ThemeDebugWalls, result.Theme)
+	assert.Equal(t, dungeon.ThemeCrypt, result.Theme)
 }
 
 func TestMapToGeneratorInput_ThemeCave(t *testing.T) {


### PR DESCRIPTION
## Summary
- Restores \`mapTheme\` "crypt" routing from \`dungeon.ThemeDebugWalls\` back to \`dungeon.ThemeCrypt\`
- Updates the matching test assertion
- Closes #478

## Why

\`internal/orchestrators/encounter/dungeon_mapper.go:43\` had a TODO comment "swap back to ThemeCrypt after wall UI testing." The wall UI testing isn't in flight per the issue; restore the intended routing so crypt dungeons render correctly.

## Test plan
- [x] \`go test ./internal/orchestrators/encounter/...\` passes
- [x] \`go test -race\` clean
- [x] No new lint issues introduced (the pre-existing 65 main-branch issues are unchanged by this PR)
- [ ] CI green
- [ ] Wait for Copilot

## Wave 2

Independent of the coord-types refactor (#471) but tucked into Wave 2 as a small Wave 2 ride-along. Doesn't depend on the protos change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)