### PR TITLE
fix(encounter): persist combined RoomData on OpenDoor (#464)

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler.go
@@ -246,13 +246,24 @@ func (h *Handler) GetEncounterState(
 		response.CombatState = convertCombatStateToProto(output.CombatState, gridType, hexOrientation)
 	}
 
-	// Convert room and add walls + origin (same pattern as StartCombat)
+	// Convert room and add walls + origin.
+	//
+	// We must NOT call applyOriginToEntities here. Per the post-OpenDoor
+	// coordinate-space contract (#491), encounter RoomData.CubeEntities is
+	// stored in dungeon-absolute coordinates, and convertRoomDataToProto for
+	// hex grids passes them through directly. Applying the room origin here
+	// would shift entity positions by the origin a SECOND time, double-shifting
+	// any newly revealed monsters whenever CurrentRoomID is at a non-origin
+	// room (the start-room case looks correct only because origin is (0,0,0)).
+	//
+	// Origin is set on the proto for client-side reference (e.g. rendering the
+	// room frame) but is no longer applied to entity positions on this path.
+	// Same rule the OpenDoor path follows at handler.go:163.
 	if output.Room != nil {
 		response.Room = convertRoomDataToProto(output.Room)
 		if response.Room != nil {
 			response.Room.Walls = convertWallsToProto(output.Walls)
 			response.Room.Origin = dungeonPositionToProto(output.RoomOrigin)
-			applyOriginToEntities(response.Room)
 		}
 	}
 

--- a/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/encounter/handler_test.go
@@ -1439,6 +1439,74 @@ func (s *HandlerTestSuite) TestGetEncounterState_PlayerNotInEncounter() {
 	s.Assert().Equal(codes.PermissionDenied, st.Code())
 }
 
+// TestGetEncounterState_DoesNotDoubleShiftAbsoluteEntities is the handler-side
+// regression for Copilot review item 3184901652 on PR #491. Per the
+// post-OpenDoor coordinate-space contract established by that PR, encounter
+// RoomData.CubeEntities is dungeon-absolute. The handler previously called
+// applyOriginToEntities here which would shift entity positions by the room
+// origin a SECOND time (visible whenever the room origin is non-zero — the
+// start-room case happened to look correct only because origin is (0,0,0)).
+// This test feeds the handler a room whose entities are already at absolute
+// coords AND a non-zero room origin, then asserts the response entity
+// positions are unchanged from the orchestrator-supplied positions.
+func (s *HandlerTestSuite) TestGetEncounterState_DoesNotDoubleShiftAbsoluteEntities() {
+	encounterID := "enc-491"
+	playerID := "player-1"
+
+	// Orchestrator returns absolute CubeEntities AND a non-zero RoomOrigin.
+	// If the handler still called applyOriginToEntities, the proto position
+	// would become (25+20, 5+0) = (45, 5).
+	const absoluteX, absoluteZ = 25, 5
+	roomData := &spatial.RoomData{
+		ID:       "enc-491-room-1",
+		Type:     "dungeon",
+		Width:    20,
+		Height:   20,
+		GridType: spatial.GridTypeHex,
+		CubeEntities: map[string]spatial.EntityCubePlacement{
+			"monster-room-2-mp-1": {
+				EntityID:   "monster-room-2-mp-1",
+				EntityType: "monster",
+				CubePosition: spatial.CubeCoordinate{
+					X: absoluteX,
+					Y: -absoluteX - absoluteZ,
+					Z: absoluteZ,
+				},
+			},
+		},
+	}
+	roomOrigin := &dungeon.AbsolutePosition{X: 20, Y: -20, Z: 0}
+
+	s.mockService.EXPECT().
+		GetEncounterState(gomock.Any(), &encounter.GetEncounterStateInput{
+			EncounterID: encounterID,
+			PlayerID:    playerID,
+		}).
+		Return(&encounter.GetEncounterStateOutput{
+			EncounterID: encounterID,
+			State:       "active",
+			Room:        roomData,
+			RoomOrigin:  roomOrigin,
+		}, nil)
+
+	resp, err := s.handler.GetEncounterState(context.Background(), &dnd5ev1alpha1.GetEncounterStateRequest{
+		EncounterId: encounterID,
+		PlayerId:    playerID,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Room)
+	s.Require().NotNil(resp.Room.Origin, "Origin must still be returned for client reference")
+
+	placement, ok := resp.Room.Entities["monster-room-2-mp-1"]
+	s.Require().True(ok, "entity must round-trip through the handler")
+	s.Require().NotNil(placement.Position)
+	s.Equal(int32(absoluteX), placement.Position.X,
+		"entity X must NOT be shifted by room origin — orchestrator returns absolute (#491)")
+	s.Equal(int32(absoluteZ), placement.Position.Z,
+		"entity Z must NOT be shifted by room origin — orchestrator returns absolute (#491)")
+}
+
 // =============================================================================
 // convertToProtoEvent Tests - MovementCompleted with Walls
 // =============================================================================

--- a/internal/orchestrators/encounter/open_door_perception_test.go
+++ b/internal/orchestrators/encounter/open_door_perception_test.go
@@ -5,6 +5,7 @@ package encounter
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -25,16 +26,30 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// Test fixture constants reused across the suite's tests.
+const (
+	testDungeonID    = "dng-464"
+	testEncounterID  = "enc-464"
+	testConnectionID = "conn-1-2"
+	testRoom1ID      = "room-1"
+	testRoom2ID      = "room-2"
+	testCharID       = "char-hero"
+)
+
 // OpenDoorPerceptionTestSuite verifies that after OpenDoor reveals a new room,
 // the persisted encounter RoomData includes the new monsters so that later
 // perception (executeMonsterTurns -> buildPerception) can find player
-// characters as targets.
+// characters as targets, and that downstream consumers respect the
+// post-OpenDoor coordinate-space contract (CubeEntities are dungeon-absolute,
+// no re-translation on the read path).
 //
 // Bug context: KirkDiggler/rpg-api#464 — OpenDoor previously persisted
 // Monsters and InitiativeData but NOT RoomData. The next EndTurn would call
 // buildPerception with the stale single-room RoomData; the new monsters were
 // not in CubeEntities, perception returned an empty enemy list, and the new
-// monsters skipped their turns.
+// monsters skipped their turns. Copilot review on PR #491 surfaced four
+// related double-shift / persistence bugs along the same code path; this
+// suite covers the regression checks for all of them.
 type OpenDoorPerceptionTestSuite struct {
 	suite.Suite
 	ctx          context.Context
@@ -73,6 +88,135 @@ func (s *OpenDoorPerceptionTestSuite) TearDownTest() {
 	s.ctrl.Finish()
 }
 
+// seedTwoRoomScenario sets up a two-room dungeon (room-1 at origin, room-2
+// at the supplied absolute origin) connected by a north door, with a single
+// skeleton in room-2's encounter and the character standing adjacent to the
+// door in room-1. Optionally adds an obstacle to room-2 if obstacleID is
+// non-empty; the obstacle is placed at obstacleLocal (room-local cube coords).
+func (s *OpenDoorPerceptionTestSuite) seedTwoRoomScenario(
+	room2Origin dungeon.AbsolutePosition,
+	obstacleID string,
+	obstacleLocal dungeon.LocalPosition,
+) {
+	s.T().Helper()
+
+	dng := &entities.Dungeon{
+		ID:          testDungeonID,
+		EncounterID: testEncounterID,
+		Connections: []*environments.ConnectionEdge{
+			{
+				ID:            testConnectionID,
+				FromRoomID:    testRoom1ID,
+				ToRoomID:      testRoom2ID,
+				Bidirectional: true,
+				Type:          "north door",
+			},
+		},
+		StartRoomID:   testRoom1ID,
+		CurrentRoomID: testRoom1ID,
+		RevealedRooms: map[string]bool{testRoom1ID: true},
+		OpenDoors:     map[string]bool{},
+		RoomOrigins: map[string]dungeon.AbsolutePosition{
+			testRoom1ID: dungeon.NewAbsolutePosition(0, 0),
+			testRoom2ID: room2Origin,
+		},
+		Rooms: map[string]*dungeon.Room{
+			testRoom1ID: {
+				ID:    testRoom1ID,
+				Shape: &dungeon.Shape{Width: 20, Height: 20},
+			},
+			testRoom2ID: {
+				ID:    testRoom2ID,
+				Shape: &dungeon.Shape{Width: 15, Height: 15},
+				Encounter: &dungeon.Encounter{
+					Monsters: []dungeon.MonsterPlacement{
+						{
+							ID:        "mp-1",
+							MonsterID: "skeleton",
+							Position:  dungeon.NewLocalPosition(5, 5),
+						},
+					},
+				},
+			},
+		},
+		State: entities.DungeonStateActive,
+	}
+	if obstacleID != "" {
+		dng.Rooms[testRoom2ID].Features = &dungeon.FeatureLayout{
+			Obstacles: []dungeon.Obstacle{
+				{
+					ID:                obstacleID,
+					Type:              dungeon.ObstacleTypePillar,
+					Position:          obstacleLocal,
+					BlocksMovement:    true,
+					BlocksLineOfSight: true,
+				},
+			},
+		}
+	}
+	_, err := s.dungeonRepo.Save(s.ctx, &dungeonsrepo.SaveInput{Dungeon: dng})
+	s.Require().NoError(err)
+
+	// Seed encounter with the character placed adjacent to the north door
+	// in room-1 (door at x=10, z=0 — character at x=10, z=1 is one hex away).
+	charCube := spatial.CubeCoordinate{X: 10, Y: -11, Z: 1}
+	startRoomData := &spatial.RoomData{
+		ID:       testEncounterID + "-" + testRoom1ID,
+		Type:     "dungeon",
+		Width:    20,
+		Height:   20,
+		GridType: spatial.GridTypeHex,
+		CubeEntities: map[string]spatial.EntityCubePlacement{
+			testCharID: {
+				EntityID:       testCharID,
+				EntityType:     entityTypeCharacter,
+				CubePosition:   charCube,
+				Size:           1,
+				BlocksMovement: true,
+			},
+		},
+	}
+	charAbs := dungeon.NewAbsolutePosition(charCube.X, charCube.Z)
+	_, err = s.encRepo.Save(s.ctx, &encountersrepo.SaveInput{
+		EncounterID: testEncounterID,
+		RoomData:    startRoomData,
+		InitiativeData: &initiative.TrackerData{
+			Order: []initiative.EntityData{
+				{ID: testCharID, Type: entityTypeCharacter},
+			},
+			Current: 0,
+			Round:   1,
+		},
+		InitiativeRolls: []initiative.Roll{
+			{
+				Entity:   initiative.NewParticipant(testCharID, entityTypeCharacter),
+				Roll:     13,
+				Modifier: 2,
+				Total:    15,
+			},
+		},
+		Monsters: []*monster.Data{},
+		// Seed the Entities map with the character so addMonstersToEntityMap
+		// has a non-nil map to mutate (matches StartCombat's behavior).
+		Entities: map[string]*entities.EntityStateData{
+			testCharID: {
+				EntityID:   testCharID,
+				EntityType: entities.EntityTypeCharacter,
+				RoomID:     testRoom1ID,
+				Position:   &charAbs,
+				Size:       1,
+			},
+		},
+		// Seed lobby so GetEncounterState's player-presence check passes.
+		State: encountersrepo.StateActive,
+		Players: map[string]*encountersrepo.Player{
+			"player-1": {PlayerID: "player-1", CharacterID: testCharID},
+		},
+		HostID: "player-1",
+	})
+	s.Require().NoError(err)
+}
+
 // TestOpenDoor_PersistsRoomDataSoNewMonstersPerceiveCharacters reproduces
 // issue #464: it seeds a two-room dungeon with a character in the start room,
 // opens the door to room 2, and then asserts that the persisted RoomData
@@ -88,113 +232,18 @@ func (s *OpenDoorPerceptionTestSuite) TearDownTest() {
 // monsters at their dungeon-absolute positions. buildPerception finds the
 // character as an enemy, with a finite distance.
 func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsRoomDataSoNewMonstersPerceiveCharacters() {
-	const (
-		dungeonID    = "dng-464"
-		encounterID  = "enc-464"
-		connectionID = "conn-1-2"
-		room1ID      = "room-1"
-		room2ID      = "room-2"
-		charID       = "char-hero"
-	)
-
 	// Room-2 origin is offset in dungeon-absolute space so we can verify
 	// translation (room-local 5,5 -> absolute origin + (5,5)).
 	room2Origin := dungeon.NewAbsolutePosition(20, 0)
-
-	// Seed dungeon: two rooms connected by a north door, room-1 revealed.
-	dng := &entities.Dungeon{
-		ID:          dungeonID,
-		EncounterID: encounterID,
-		Connections: []*environments.ConnectionEdge{
-			{
-				ID:            connectionID,
-				FromRoomID:    room1ID,
-				ToRoomID:      room2ID,
-				Bidirectional: true,
-				Type:          "north door",
-			},
-		},
-		StartRoomID:   room1ID,
-		CurrentRoomID: room1ID,
-		RevealedRooms: map[string]bool{room1ID: true},
-		OpenDoors:     map[string]bool{},
-		RoomOrigins: map[string]dungeon.AbsolutePosition{
-			room1ID: dungeon.NewAbsolutePosition(0, 0),
-			room2ID: room2Origin,
-		},
-		Rooms: map[string]*dungeon.Room{
-			room1ID: {
-				ID:    room1ID,
-				Shape: &dungeon.Shape{Width: 20, Height: 20},
-			},
-			room2ID: {
-				ID:    room2ID,
-				Shape: &dungeon.Shape{Width: 15, Height: 15},
-				Encounter: &dungeon.Encounter{
-					Monsters: []dungeon.MonsterPlacement{
-						{
-							ID:        "mp-1",
-							MonsterID: "skeleton",
-							Position:  dungeon.NewLocalPosition(5, 5),
-						},
-					},
-				},
-			},
-		},
-		State: entities.DungeonStateActive,
-	}
-	_, err := s.dungeonRepo.Save(s.ctx, &dungeonsrepo.SaveInput{Dungeon: dng})
-	s.Require().NoError(err)
-
-	// Seed encounter with the character placed adjacent to the north door
-	// in room-1 (door at x=10, z=0 — character at x=10, z=1 is one hex away).
-	charCube := spatial.CubeCoordinate{X: 10, Y: -11, Z: 1}
-	startRoomData := &spatial.RoomData{
-		ID:       encounterID + "-" + room1ID,
-		Type:     "dungeon",
-		Width:    20,
-		Height:   20,
-		GridType: spatial.GridTypeHex,
-		CubeEntities: map[string]spatial.EntityCubePlacement{
-			charID: {
-				EntityID:       charID,
-				EntityType:     entityTypeCharacter,
-				CubePosition:   charCube,
-				Size:           1,
-				BlocksMovement: true,
-			},
-		},
-	}
-	_, err = s.encRepo.Save(s.ctx, &encountersrepo.SaveInput{
-		EncounterID: encounterID,
-		RoomData:    startRoomData,
-		InitiativeData: &initiative.TrackerData{
-			Order: []initiative.EntityData{
-				{ID: charID, Type: entityTypeCharacter},
-			},
-			Current: 0,
-			Round:   1,
-		},
-		InitiativeRolls: []initiative.Roll{
-			{
-				Entity:   initiative.NewParticipant(charID, entityTypeCharacter),
-				Roll:     13,
-				Modifier: 2,
-				Total:    15,
-			},
-		},
-		Monsters: []*monster.Data{},
-		Entities: map[string]*entities.EntityStateData{},
-	})
-	s.Require().NoError(err)
+	s.seedTwoRoomScenario(room2Origin, "", dungeon.LocalPosition{})
 
 	// One d20 roll for initiative of the new skeleton.
 	s.roller.EXPECT().Roll(gomock.Any(), 20).Return(11, nil)
 
 	// Act: open the door to room-2.
 	output, err := s.orchestrator.OpenDoor(s.ctx, &OpenDoorInput{
-		DungeonID:    dungeonID,
-		ConnectionID: connectionID,
+		DungeonID:    testDungeonID,
+		ConnectionID: testConnectionID,
 	})
 	s.Require().NoError(err, "OpenDoor should succeed")
 	s.Require().NotNil(output)
@@ -203,7 +252,7 @@ func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsRoomDataSoNewMonsters
 
 	// Reload the persisted encounter and verify RoomData carries the new
 	// monster so perception can find the character.
-	getOut, err := s.encRepo.Get(s.ctx, &encountersrepo.GetInput{EncounterID: encounterID})
+	getOut, err := s.encRepo.Get(s.ctx, &encountersrepo.GetInput{EncounterID: testEncounterID})
 	s.Require().NoError(err)
 	persistedData := getOut.Data
 	s.Require().NotNil(persistedData)
@@ -214,7 +263,8 @@ func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsRoomDataSoNewMonsters
 	s.Require().NotNil(persistedRoom.CubeEntities)
 
 	// Sanity: the existing character is still in the persisted RoomData.
-	charPlacement, hasChar := persistedRoom.CubeEntities[charID]
+	charCube := spatial.CubeCoordinate{X: 10, Y: -11, Z: 1}
+	charPlacement, hasChar := persistedRoom.CubeEntities[testCharID]
 	s.Require().True(hasChar, "persisted RoomData should still contain the character")
 	s.Equal(charCube, charPlacement.CubePosition, "character position should be unchanged")
 
@@ -242,7 +292,7 @@ func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsRoomDataSoNewMonsters
 	perception := buildPerception(
 		persistedRoom,
 		newMonsterID,
-		[]string{charID},
+		[]string{testCharID},
 		persistedData.Monsters,
 		nil, // walls not relevant for this assertion
 	)
@@ -250,6 +300,183 @@ func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsRoomDataSoNewMonsters
 	s.Require().Len(perception.Enemies, 1,
 		"the new monster must perceive the character as an enemy after OpenDoor — "+
 			"if this fails, the monster will appear AFK on its turn (issue #464)")
-	s.Equal(charID, perception.Enemies[0].Entity.GetID())
+	s.Equal(testCharID, perception.Enemies[0].Entity.GetID())
 	s.Greater(perception.Enemies[0].Distance, 0, "distance to character should be positive")
+}
+
+// TestOpenDoor_PersistsEntitiesMapForPostReloadSnapshots covers Copilot review
+// item 3184901637: addMonstersToEntityMap mutates encOutput.Data.Entities
+// in-memory, but the encRepo.Update call must include Entities so a
+// post-reload GetEncounterState -> buildEncounterStateSnapshot still sees the
+// newly-revealed monsters. Without persisting Entities, late-join clients
+// would receive a snapshot that omits the room-2 monsters.
+func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsEntitiesMapForPostReloadSnapshots() {
+	room2Origin := dungeon.NewAbsolutePosition(20, 0)
+	s.seedTwoRoomScenario(room2Origin, "", dungeon.LocalPosition{})
+
+	s.roller.EXPECT().Roll(gomock.Any(), 20).Return(11, nil)
+
+	output, err := s.orchestrator.OpenDoor(s.ctx, &OpenDoorInput{
+		DungeonID:    testDungeonID,
+		ConnectionID: testConnectionID,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(output.Monsters, 1)
+	newMonsterID := output.Monsters[0].ID
+
+	// Reload from the repo and verify the Entities map has the new monster.
+	getOut, err := s.encRepo.Get(s.ctx, &encountersrepo.GetInput{EncounterID: testEncounterID})
+	s.Require().NoError(err)
+
+	esd, ok := getOut.Data.Entities[newMonsterID]
+	s.Require().True(ok,
+		"newly-revealed monster must be persisted in the Entities map so "+
+			"GetEncounterState -> buildEncounterStateSnapshot includes it after reload")
+	s.Equal(entities.EntityTypeMonster, esd.EntityType)
+	s.Equal(testRoom2ID, esd.RoomID, "EntityStateData.RoomID should be the revealed room")
+	s.Require().NotNil(esd.Position, "EntityStateData.Position must be populated")
+	// Position is dungeon-absolute (20+5, 0+5) = (25, 5) per NewAbsolutePosition.
+	s.Equal(dungeon.NewAbsolutePosition(25, 5), *esd.Position,
+		"EntityStateData.Position must be dungeon-absolute")
+}
+
+// TestOpenDoor_BringsObstaclesFromRevealedRoom covers Copilot review item
+// 3184901660: convertToRoomData copies room.Features.Obstacles into
+// CubeEntities at StartCombat; the OpenDoor merge must do the same so that
+// movement-collision (executeMove / MoveCharacter, which iterates
+// CubeEntities and checks BlocksMovement) sees blocking features in the
+// newly-revealed room.
+func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_BringsObstaclesFromRevealedRoom() {
+	const obstacleID = "pillar-1"
+	room2Origin := dungeon.NewAbsolutePosition(20, 0)
+	// Obstacle at room-2 local (3, 4); expected dungeon-absolute is (23, 4).
+	obstacleLocal := dungeon.NewLocalPosition(3, 4)
+	s.seedTwoRoomScenario(room2Origin, obstacleID, obstacleLocal)
+
+	s.roller.EXPECT().Roll(gomock.Any(), 20).Return(11, nil)
+
+	_, err := s.orchestrator.OpenDoor(s.ctx, &OpenDoorInput{
+		DungeonID:    testDungeonID,
+		ConnectionID: testConnectionID,
+	})
+	s.Require().NoError(err)
+
+	getOut, err := s.encRepo.Get(s.ctx, &encountersrepo.GetInput{EncounterID: testEncounterID})
+	s.Require().NoError(err)
+	persistedRoom, ok := getOut.Data.RoomData.(*spatial.RoomData)
+	s.Require().True(ok)
+
+	placement, hasObstacle := persistedRoom.CubeEntities[obstacleID]
+	s.Require().True(hasObstacle,
+		"obstacles from the revealed room must be added to the combined RoomData "+
+			"so movement-collision can check BlocksMovement against them")
+	s.Equal(entityTypeObstacle, placement.EntityType)
+	s.True(placement.BlocksMovement, "obstacle must keep BlocksMovement so collision check fires")
+	s.True(placement.BlocksLineOfSight, "obstacle BlocksLineOfSight should also be carried through")
+
+	// Obstacle was at room-2 local (3, 4); room-2 origin is (20, 0) absolute,
+	// so the persisted absolute position should be (23, 4).
+	expectedAbs := dungeon.NewAbsolutePosition(room2Origin.X+3, room2Origin.Z+4)
+	s.Equal(spatial.CubeCoordinate{X: expectedAbs.X, Y: expectedAbs.Y, Z: expectedAbs.Z},
+		placement.CubePosition,
+		"obstacle must be persisted in dungeon-absolute coords like the new monsters")
+}
+
+// TestSyncMonsterPositionFromRoom_DoesNotDoubleShift covers Copilot review
+// item 3184901620: under the post-OpenDoor contract CubeEntities are
+// dungeon-absolute, so syncMonsterPositionFromRoom must copy the cube
+// straight into EntityStateData.Position without LocalToAbsolute. Previously
+// the function called localToAbsoluteOrLocal(module, roomID, ...) which
+// would shift by the room origin a SECOND time once CurrentRoomID advanced
+// to a non-origin room.
+func (s *OpenDoorPerceptionTestSuite) TestSyncMonsterPositionFromRoom_DoesNotDoubleShift() {
+	// Simulate post-OpenDoor state: a monster lives in room-2, so its
+	// CubeEntities position is dungeon-absolute (25, -30, 5).
+	const monsterID = "monster-room-2-mp-1"
+	absPos := dungeon.NewAbsolutePosition(25, 5) // (25, -30, 5)
+	roomData := &spatial.RoomData{
+		GridType: spatial.GridTypeHex,
+		CubeEntities: map[string]spatial.EntityCubePlacement{
+			monsterID: {
+				EntityID:     monsterID,
+				EntityType:   entityTypeMonster,
+				CubePosition: spatial.CubeCoordinate{X: absPos.X, Y: absPos.Y, Z: absPos.Z},
+			},
+		},
+	}
+	entityMap := map[string]*entities.EntityStateData{
+		monsterID: {
+			EntityID:   monsterID,
+			EntityType: entities.EntityTypeMonster,
+			RoomID:     testRoom2ID,
+		},
+	}
+
+	// Sync. Under the new contract, no module/roomID is passed and no
+	// re-translation is applied.
+	syncMonsterPositionFromRoom(entityMap, monsterID, roomData)
+
+	s.Require().NotNil(entityMap[monsterID].Position)
+	s.Equal(absPos, *entityMap[monsterID].Position,
+		"syncMonsterPositionFromRoom must pass the absolute cube through unchanged — "+
+			"no LocalToAbsolute against CurrentRoomID, which would double-shift "+
+			"a monster whose CubeEntities position is already absolute (#491)")
+}
+
+// TestGetEncounterState_DoesNotDoubleShiftRevealedRoomMonsters covers
+// Copilot review item 3184901652: GetEncounterState returns the persisted
+// (absolute) RoomData, and the handler previously called applyOriginToEntities
+// which would add the room origin a second time. Even though the start room
+// is at origin so the regression isn't visible in the simple case, the
+// orchestrator return should be in absolute and the handler must preserve
+// that without further translation.
+//
+// We exercise the orchestrator side here (verifying GetEncounterState's Room
+// is absolute) so any handler-side double-shift that ships the same proto
+// without applyOriginToEntities will keep matching reality. The handler-side
+// rule is documented at internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+// around line 250 and exercised by handler_test.go's
+// TestGetEncounterState_DoesNotDoubleShiftAbsoluteEntities.
+func (s *OpenDoorPerceptionTestSuite) TestGetEncounterState_DoesNotDoubleShiftRevealedRoomMonsters() {
+	room2Origin := dungeon.NewAbsolutePosition(20, 0)
+	s.seedTwoRoomScenario(room2Origin, "", dungeon.LocalPosition{})
+
+	// GetEncounterState calls buildPartyFromPlayers which loads character
+	// data. Return an error from charRepo so the party member is built
+	// without CharacterData — we don't care about character details here,
+	// only the Room contract.
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("not seeded")).
+		AnyTimes()
+
+	s.roller.EXPECT().Roll(gomock.Any(), 20).Return(11, nil)
+	openOut, err := s.orchestrator.OpenDoor(s.ctx, &OpenDoorInput{
+		DungeonID:    testDungeonID,
+		ConnectionID: testConnectionID,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(openOut.Monsters, 1)
+	newMonsterID := openOut.Monsters[0].ID
+
+	stateOut, err := s.orchestrator.GetEncounterState(s.ctx, &GetEncounterStateInput{
+		EncounterID: testEncounterID,
+		PlayerID:    "player-1",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(stateOut)
+	s.Require().NotNil(stateOut.Room, "GetEncounterState must include Room while combat is active")
+
+	stateRoom, ok := stateOut.Room.(*spatial.RoomData)
+	s.Require().True(ok)
+
+	monsterPlacement, hasMonster := stateRoom.CubeEntities[newMonsterID]
+	s.Require().True(hasMonster, "GetEncounterState's Room must include the revealed-room monster")
+
+	expectedAbs := dungeon.NewAbsolutePosition(room2Origin.X+5, room2Origin.Z+5)
+	s.Equal(spatial.CubeCoordinate{X: expectedAbs.X, Y: expectedAbs.Y, Z: expectedAbs.Z},
+		monsterPlacement.CubePosition,
+		"GetEncounterState must return dungeon-absolute CubeEntities — "+
+			"the handler relies on this contract to NOT call applyOriginToEntities, "+
+			"which would otherwise double-shift the monster's position (#491)")
 }

--- a/internal/orchestrators/encounter/open_door_perception_test.go
+++ b/internal/orchestrators/encounter/open_door_perception_test.go
@@ -1,0 +1,255 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	dicemock "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/initiative"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-api/internal/components/dungeon"
+	dungeontoolkit "github.com/KirkDiggler/rpg-api/internal/components/dungeon/toolkit"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	dungeonsrepo "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
+	encountersrepo "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
+
+	"go.uber.org/mock/gomock"
+)
+
+// OpenDoorPerceptionTestSuite verifies that after OpenDoor reveals a new room,
+// the persisted encounter RoomData includes the new monsters so that later
+// perception (executeMonsterTurns -> buildPerception) can find player
+// characters as targets.
+//
+// Bug context: KirkDiggler/rpg-api#464 — OpenDoor previously persisted
+// Monsters and InitiativeData but NOT RoomData. The next EndTurn would call
+// buildPerception with the stale single-room RoomData; the new monsters were
+// not in CubeEntities, perception returned an empty enemy list, and the new
+// monsters skipped their turns.
+type OpenDoorPerceptionTestSuite struct {
+	suite.Suite
+	ctx          context.Context
+	ctrl         *gomock.Controller
+	mockCharRepo *charactermock.MockRepository
+	encRepo      *encountersrepo.InMemoryRepository
+	dungeonRepo  *dungeonsrepo.InMemoryRepository
+	roller       *dicemock.MockRoller
+	orchestrator *Orchestrator
+}
+
+func TestOpenDoorPerceptionTestSuite(t *testing.T) {
+	suite.Run(t, new(OpenDoorPerceptionTestSuite))
+}
+
+func (s *OpenDoorPerceptionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
+	s.encRepo = encountersrepo.NewInMemory()
+	s.dungeonRepo = dungeonsrepo.NewInMemory()
+	s.roller = dicemock.NewMockRoller(s.ctrl)
+
+	orc, err := New(&Config{
+		CharacterRepo: s.mockCharRepo,
+		EncounterRepo: s.encRepo,
+		DungeonRepo:   s.dungeonRepo,
+		DungeonGen:    dungeontoolkit.CreateGenerator(&dungeontoolkit.ToolkitConfig{}),
+		Roller:        s.roller,
+	})
+	s.Require().NoError(err)
+	s.orchestrator = orc
+}
+
+func (s *OpenDoorPerceptionTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// TestOpenDoor_PersistsRoomDataSoNewMonstersPerceiveCharacters reproduces
+// issue #464: it seeds a two-room dungeon with a character in the start room,
+// opens the door to room 2, and then asserts that the persisted RoomData
+// contains the newly spawned monsters in dungeon-absolute coordinates so
+// buildPerception can find the character as an enemy.
+//
+// Before the fix: OpenDoor's encRepo.Update omits RoomData, so the
+// persisted CubeEntities still only contain the character. buildPerception
+// for the new monster falls into the "monsterPlacement not found" branch
+// and returns zero enemies — the monster appears AFK on its turn.
+//
+// After the fix: OpenDoor builds a combined RoomData that includes the new
+// monsters at their dungeon-absolute positions. buildPerception finds the
+// character as an enemy, with a finite distance.
+func (s *OpenDoorPerceptionTestSuite) TestOpenDoor_PersistsRoomDataSoNewMonstersPerceiveCharacters() {
+	const (
+		dungeonID    = "dng-464"
+		encounterID  = "enc-464"
+		connectionID = "conn-1-2"
+		room1ID      = "room-1"
+		room2ID      = "room-2"
+		charID       = "char-hero"
+	)
+
+	// Room-2 origin is offset in dungeon-absolute space so we can verify
+	// translation (room-local 5,5 -> absolute origin + (5,5)).
+	room2Origin := dungeon.NewAbsolutePosition(20, 0)
+
+	// Seed dungeon: two rooms connected by a north door, room-1 revealed.
+	dng := &entities.Dungeon{
+		ID:          dungeonID,
+		EncounterID: encounterID,
+		Connections: []*environments.ConnectionEdge{
+			{
+				ID:            connectionID,
+				FromRoomID:    room1ID,
+				ToRoomID:      room2ID,
+				Bidirectional: true,
+				Type:          "north door",
+			},
+		},
+		StartRoomID:   room1ID,
+		CurrentRoomID: room1ID,
+		RevealedRooms: map[string]bool{room1ID: true},
+		OpenDoors:     map[string]bool{},
+		RoomOrigins: map[string]dungeon.AbsolutePosition{
+			room1ID: dungeon.NewAbsolutePosition(0, 0),
+			room2ID: room2Origin,
+		},
+		Rooms: map[string]*dungeon.Room{
+			room1ID: {
+				ID:    room1ID,
+				Shape: &dungeon.Shape{Width: 20, Height: 20},
+			},
+			room2ID: {
+				ID:    room2ID,
+				Shape: &dungeon.Shape{Width: 15, Height: 15},
+				Encounter: &dungeon.Encounter{
+					Monsters: []dungeon.MonsterPlacement{
+						{
+							ID:        "mp-1",
+							MonsterID: "skeleton",
+							Position:  dungeon.NewLocalPosition(5, 5),
+						},
+					},
+				},
+			},
+		},
+		State: entities.DungeonStateActive,
+	}
+	_, err := s.dungeonRepo.Save(s.ctx, &dungeonsrepo.SaveInput{Dungeon: dng})
+	s.Require().NoError(err)
+
+	// Seed encounter with the character placed adjacent to the north door
+	// in room-1 (door at x=10, z=0 — character at x=10, z=1 is one hex away).
+	charCube := spatial.CubeCoordinate{X: 10, Y: -11, Z: 1}
+	startRoomData := &spatial.RoomData{
+		ID:       encounterID + "-" + room1ID,
+		Type:     "dungeon",
+		Width:    20,
+		Height:   20,
+		GridType: spatial.GridTypeHex,
+		CubeEntities: map[string]spatial.EntityCubePlacement{
+			charID: {
+				EntityID:       charID,
+				EntityType:     entityTypeCharacter,
+				CubePosition:   charCube,
+				Size:           1,
+				BlocksMovement: true,
+			},
+		},
+	}
+	_, err = s.encRepo.Save(s.ctx, &encountersrepo.SaveInput{
+		EncounterID: encounterID,
+		RoomData:    startRoomData,
+		InitiativeData: &initiative.TrackerData{
+			Order: []initiative.EntityData{
+				{ID: charID, Type: entityTypeCharacter},
+			},
+			Current: 0,
+			Round:   1,
+		},
+		InitiativeRolls: []initiative.Roll{
+			{
+				Entity:   initiative.NewParticipant(charID, entityTypeCharacter),
+				Roll:     13,
+				Modifier: 2,
+				Total:    15,
+			},
+		},
+		Monsters: []*monster.Data{},
+		Entities: map[string]*entities.EntityStateData{},
+	})
+	s.Require().NoError(err)
+
+	// One d20 roll for initiative of the new skeleton.
+	s.roller.EXPECT().Roll(gomock.Any(), 20).Return(11, nil)
+
+	// Act: open the door to room-2.
+	output, err := s.orchestrator.OpenDoor(s.ctx, &OpenDoorInput{
+		DungeonID:    dungeonID,
+		ConnectionID: connectionID,
+	})
+	s.Require().NoError(err, "OpenDoor should succeed")
+	s.Require().NotNil(output)
+	s.Require().Len(output.Monsters, 1, "should spawn one skeleton in room-2")
+	newMonsterID := output.Monsters[0].ID
+
+	// Reload the persisted encounter and verify RoomData carries the new
+	// monster so perception can find the character.
+	getOut, err := s.encRepo.Get(s.ctx, &encountersrepo.GetInput{EncounterID: encounterID})
+	s.Require().NoError(err)
+	persistedData := getOut.Data
+	s.Require().NotNil(persistedData)
+	s.Require().NotNil(persistedData.RoomData, "RoomData must be persisted by OpenDoor")
+
+	persistedRoom, ok := persistedData.RoomData.(*spatial.RoomData)
+	s.Require().True(ok, "persisted RoomData should be *spatial.RoomData")
+	s.Require().NotNil(persistedRoom.CubeEntities)
+
+	// Sanity: the existing character is still in the persisted RoomData.
+	charPlacement, hasChar := persistedRoom.CubeEntities[charID]
+	s.Require().True(hasChar, "persisted RoomData should still contain the character")
+	s.Equal(charCube, charPlacement.CubePosition, "character position should be unchanged")
+
+	// Bug check: the new monster must be present in the persisted RoomData
+	// using dungeon-absolute coordinates so cross-room perception works.
+	monsterPlacement, hasMonster := persistedRoom.CubeEntities[newMonsterID]
+	s.Require().True(hasMonster,
+		"persisted RoomData must contain the new monster %s — without this, "+
+			"buildPerception returns zero enemies and the monster skips its turn",
+		newMonsterID)
+	s.Equal(entityTypeMonster, monsterPlacement.EntityType)
+
+	// The skeleton was placed at room-2 local (5, 5). Room-2 origin is
+	// (20, 0) absolute, so the persisted absolute position should be (25, 5).
+	expectedAbs := dungeon.NewAbsolutePosition(
+		room2Origin.X+5, // local X + room origin X
+		room2Origin.Z+5, // local Z + room origin Z
+	)
+	s.Equal(spatial.CubeCoordinate{X: expectedAbs.X, Y: expectedAbs.Y, Z: expectedAbs.Z},
+		monsterPlacement.CubePosition,
+		"new monster must be persisted in dungeon-absolute coords")
+
+	// Behavioral assertion: with the persisted RoomData, buildPerception
+	// for the new monster must find the character as an enemy.
+	perception := buildPerception(
+		persistedRoom,
+		newMonsterID,
+		[]string{charID},
+		persistedData.Monsters,
+		nil, // walls not relevant for this assertion
+	)
+	s.Require().NotNil(perception)
+	s.Require().Len(perception.Enemies, 1,
+		"the new monster must perceive the character as an enemy after OpenDoor — "+
+			"if this fails, the monster will appear AFK on its turn (issue #464)")
+	s.Equal(charID, perception.Enemies[0].Entity.GetID())
+	s.Greater(perception.Enemies[0].Distance, 0, "distance to character should be positive")
+}

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -936,9 +936,11 @@ func (o *Orchestrator) createDungeonWithGenerator(
 
 		// Sync monster positions from roomData into entity map before persisting.
 		// Start room is at origin (0,0,0); construct a Module for forward-compat.
-		startCombatModule := moduleFromDungeon(dungeonEntity)
+		// CubeEntities are dungeon-absolute under the post-OpenDoor contract
+		// (#491); syncMonsterPositionFromRoom passes the cube position
+		// through to EntityStateData.Position without re-translation.
 		for _, mt := range monsterTurns {
-			syncMonsterPositionFromRoom(entityMap, mt.MonsterID, roomData, startCombatModule, generatedDungeon.StartRoom)
+			syncMonsterPositionFromRoom(entityMap, mt.MonsterID, roomData)
 		}
 		// Sync damaged character HP into entity map so events carry updated HP
 		syncCharacterHPFromMonsterTurns(entityMap, monsterTurns)
@@ -1045,7 +1047,7 @@ func (o *Orchestrator) convertToRoomData(encounterID string, room *dungeon.Room)
 		for _, obstacle := range room.Features.Obstacles {
 			roomData.CubeEntities[obstacle.ID] = spatial.EntityCubePlacement{
 				EntityID:       obstacle.ID,
-				EntityType:     "obstacle",
+				EntityType:     entityTypeObstacle,
 				CubePosition:   spatial.CubeCoordinate{X: obstacle.Position.X, Y: obstacle.Position.Y, Z: obstacle.Position.Z},
 				Size:           1,
 				BlocksMovement: obstacle.BlocksMovement,
@@ -1950,28 +1952,18 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 		o.checkAndHandleFailure(ctx, input.EncounterID, encOutput.Data)
 	}
 
-	// 9. Sync monster positions from roomData into entity map before persisting
+	// 9. Sync monster positions from roomData into entity map before persisting.
+	// CubeEntities are dungeon-absolute under the post-OpenDoor contract (#491);
+	// syncMonsterPositionFromRoom passes them through to EntityStateData.Position
+	// without re-translation, so we no longer need the Module/roomID lookup.
 	var persistRoomData *spatial.RoomData
 	if encOutput.Data.RoomData != nil {
 		if rd, ok := encOutput.Data.RoomData.(*spatial.RoomData); ok {
 			persistRoomData = rd
 		}
 	}
-	var endTurnSyncModule *dungeon.Module
-	var endTurnSyncRoomID string
-	if o.dungeonRepo != nil {
-		if dungeonOutput, dungeonErr := o.dungeonRepo.GetByEncounterID(ctx, &dungeonrepo.GetByEncounterIDInput{
-			EncounterID: input.EncounterID,
-		}); dungeonErr == nil && dungeonOutput.Dungeon != nil {
-			endTurnSyncModule = moduleFromDungeon(dungeonOutput.Dungeon)
-			endTurnSyncRoomID = dungeonOutput.Dungeon.CurrentRoomID
-			if endTurnSyncRoomID == "" {
-				endTurnSyncRoomID = dungeonOutput.Dungeon.StartRoomID
-			}
-		}
-	}
 	for _, mt := range monsterTurns {
-		syncMonsterPositionFromRoom(encOutput.Data.Entities, mt.MonsterID, persistRoomData, endTurnSyncModule, endTurnSyncRoomID)
+		syncMonsterPositionFromRoom(encOutput.Data.Entities, mt.MonsterID, persistRoomData)
 	}
 	// Sync damaged character HP into entity map so MonsterTurnCompleted events carry updated HP
 	syncCharacterHPFromMonsterTurns(encOutput.Data.Entities, monsterTurns)
@@ -2030,11 +2022,12 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 		}
 	}
 
-	// 11b. Load dungeon to get walls and room origin for the current room
+	// 11b. Load dungeon to get walls and room origin for the current room.
+	// Module/roomID are no longer needed for syncMonsterPositionFromRoom (CubeEntities
+	// are dungeon-absolute under the post-OpenDoor contract, see #491), so we only
+	// load what the published events still need.
 	var dungeonWalls []dungeon.WallSegment
 	var turnRoomOrigin *dungeon.AbsolutePosition
-	var turnModule *dungeon.Module
-	var turnRoomID string
 	if o.dungeonRepo != nil {
 		dungeonOutput, dungeonErr := o.dungeonRepo.GetByEncounterID(ctx, &dungeonrepo.GetByEncounterIDInput{
 			EncounterID: input.EncounterID,
@@ -2042,12 +2035,10 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 		if dungeonErr == nil && dungeonOutput.Dungeon != nil {
 			dungeonEntity := dungeonOutput.Dungeon
 			turnRoomOrigin = getCurrentRoomOrigin(dungeonEntity)
-			turnModule = moduleFromDungeon(dungeonEntity)
 			currentRoomID := dungeonEntity.CurrentRoomID
 			if currentRoomID == "" {
 				currentRoomID = dungeonEntity.StartRoomID
 			}
-			turnRoomID = currentRoomID
 			if currentRoom := dungeonEntity.GetRoom(currentRoomID); currentRoom != nil {
 				dungeonWalls = currentRoom.Walls
 			}
@@ -2096,7 +2087,8 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 	for _, mt := range monsterTurns {
 		// Sync monster's updated position from room data into the Entities map before building proto.
 		// executeMonsterTurns updates roomData.CubeEntities but not encOutput.Data.Entities.
-		syncMonsterPositionFromRoom(encOutput.Data.Entities, mt.MonsterID, turnEndedRoomData, turnModule, turnRoomID)
+		// CubeEntities are dungeon-absolute under the post-OpenDoor contract (#491).
+		syncMonsterPositionFromRoom(encOutput.Data.Entities, mt.MonsterID, turnEndedRoomData)
 
 		// Build per-monster updated entities: the monster + any damaged characters
 		var mtUpdatedEntities []*pb.EntityState
@@ -2155,6 +2147,7 @@ func (o *Orchestrator) EndTurn(ctx context.Context, input *EndTurnInput) (*EndTu
 const (
 	entityTypeCharacter = "character"
 	entityTypeMonster   = "monster"
+	entityTypeObstacle  = "obstacle"
 )
 
 // Stop reasons for movement
@@ -3248,22 +3241,34 @@ func (o *Orchestrator) OpenDoor(
 	// monster (let alone any cross-room targets), so the new monster perceived
 	// zero enemies and skipped its turn — appearing AFK.
 	//
-	// We build a unified RoomData whose CubeEntities live in dungeon-absolute
-	// cube coordinates so a monster from room N can perceive a character from
-	// room M. The existing CubeEntities are carried forward as-is: in the
-	// common case the start room is at origin (0,0,0) so start-local equals
-	// absolute, and after the first OpenDoor the persisted CubeEntities are
-	// already in absolute coords so further OpenDoor calls keep merging
-	// correctly.
+	// Coordinate-space contract established by this PR: post-OpenDoor encounter
+	// RoomData.CubeEntities holds dungeon-absolute cube coordinates. Consumers
+	// MUST NOT re-translate. The existing CubeEntities are carried forward
+	// as-is — pre-OpenDoor we know the start room is at origin so its
+	// CubeEntities are already absolute by construction. After the first
+	// OpenDoor merges new monsters at absolute coordinates, the persisted
+	// CubeEntities stay in absolute thereafter, so further OpenDoor calls keep
+	// merging correctly.
 	combinedRoomData := buildCombinedRoomDataAfterOpenDoor(
 		encOutput.Data.RoomData,
 		dng.EncounterID,
 		revealedRoom,
+		revealedRoomID,
+		dngModule,
 		monsters,
 	)
 
-	// 11. Update encounter state with new initiative, boss monster IDs, and the
-	// combined RoomData so subsequent perception sees all revealed-room entities.
+	// Mutate the in-memory Entities map BEFORE persisting so the Update below
+	// includes the newly-revealed monsters. addMonstersToEntityMap fills in
+	// EntityStateData for each new monster using its dungeon-absolute Position.
+	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID)
+
+	// 11. Update encounter state with new initiative, boss monster IDs, the
+	// combined RoomData (so perception sees all revealed-room entities), and
+	// the Entities map (so post-reload snapshots via GetEncounterState ->
+	// buildEncounterStateSnapshot include the newly-revealed monsters too —
+	// without this, late-join / refresh would rebuild from a stale Entities
+	// map and miss the revealed-room monsters entirely).
 	// Merge new boss IDs with any existing ones
 	allBossIDs := make([]string, 0, len(encOutput.Data.BossMonsterIDs)+len(newBossMonsterIDs))
 	allBossIDs = append(allBossIDs, encOutput.Data.BossMonsterIDs...)
@@ -3275,6 +3280,7 @@ func (o *Orchestrator) OpenDoor(
 		Monsters:        encOutput.Data.Monsters,
 		BossMonsterIDs:  allBossIDs,
 		RoomData:        combinedRoomData,
+		Entities:        encOutput.Data.Entities,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update encounter: %w", err)
@@ -3393,8 +3399,9 @@ func (o *Orchestrator) OpenDoor(
 		}
 	}
 
-	// 17. Add new monster entities to encounter Entities map for snapshot
-	o.addMonstersToEntityMap(encOutput.Data, monsters, revealedRoomID)
+	// 17. (Entities map was mutated earlier, before encRepo.Update at step 11,
+	// so the newly-revealed monsters are persisted and visible to post-reload
+	// snapshots — see comment at step 11.)
 
 	// Build snapshot for RoomRevealed event
 	roomRevealedStateData := o.buildEncounterStateSnapshot(ctx, dng.EncounterID, encOutput.Data, combatState)
@@ -3924,10 +3931,10 @@ func (o *Orchestrator) StartCombat( //nolint:gocyclo // Large orchestration func
 		combatState.ActiveIndex = encData.InitiativeData.Current
 		combatState.Round = encData.InitiativeData.Round
 
-		// Sync monster positions from roomData into entity map before persisting
-		startCombatModule := moduleFromDungeon(dungeonEntity)
+		// Sync monster positions from roomData into entity map before persisting.
+		// CubeEntities are dungeon-absolute under the post-OpenDoor contract (#491).
 		for _, mt := range monsterTurns {
-			syncMonsterPositionFromRoom(entityMap, mt.MonsterID, roomData, startCombatModule, generatedDungeon.StartRoom)
+			syncMonsterPositionFromRoom(entityMap, mt.MonsterID, roomData)
 		}
 
 		_, err = o.encRepo.Update(ctx, &encounterrepo.UpdateInput{
@@ -4029,12 +4036,12 @@ func (o *Orchestrator) StartCombat( //nolint:gocyclo // Large orchestration func
 	// Sync damaged character HP into entity map so MonsterTurnCompleted events carry updated HP
 	syncCharacterHPFromMonsterTurns(entityMap, monsterTurns)
 	startCombatStateProto := entities.CombatStateToProto(combatState)
-	startCombatPostModule := moduleFromDungeon(dungeonEntity)
 	for _, mt := range monsterTurns {
 		// Sync monster's updated position from room data into the entity map before building proto.
 		// entityMap was built before executeMonsterTurns, so positions may be stale.
 		// roomData.CubeEntities has the authoritative post-movement positions.
-		syncMonsterPositionFromRoom(entityMap, mt.MonsterID, roomData, startCombatPostModule, generatedDungeon.StartRoom)
+		// CubeEntities are dungeon-absolute under the post-OpenDoor contract (#491).
+		syncMonsterPositionFromRoom(entityMap, mt.MonsterID, roomData)
 
 		// Build per-monster updated entities from the entity map
 		var mtUpdatedEntities []*pb.EntityState
@@ -5466,15 +5473,17 @@ func (o *Orchestrator) executeMove(
 // roomData.CubeEntities but not the entity map, so this sync is needed before building
 // entity state protos for MonsterTurnCompleted events.
 //
-// roomData.CubeEntities holds room-local cube coordinates; module + roomID
-// translate them to dungeon-absolute via Module.LocalToAbsolute. Pass a nil
-// module for the single-room start case (origin (0,0,0)).
+// Coordinate-space contract: as of #491, encounter RoomData.CubeEntities holds
+// dungeon-absolute cube coordinates. EntityStateData.Position is also stored
+// in dungeon-absolute. We therefore copy the cube position straight through
+// without any LocalToAbsolute translation. The module/roomID parameters were
+// previously used to re-translate from a room-local CubeEntities; doing so
+// under the new contract would shift by the room origin a SECOND time once
+// CurrentRoomID advances to a non-origin room (Copilot review on PR #491).
 func syncMonsterPositionFromRoom(
 	entityMap map[string]*entities.EntityStateData,
 	monsterID string,
 	roomData *spatial.RoomData,
-	module *dungeon.Module,
-	roomID string,
 ) {
 	if entityMap == nil || roomData == nil {
 		return
@@ -5484,7 +5493,15 @@ func syncMonsterPositionFromRoom(
 		return
 	}
 	if placement, exists := roomData.CubeEntities[monsterID]; exists {
-		esd.Position = localToAbsoluteOrLocal(module, roomID, cubeToLocalPosition(placement.CubePosition))
+		// CubeEntities are dungeon-absolute under the post-OpenDoor contract.
+		// EntityStateData.Position is also absolute. Pass the cube coordinate
+		// through directly — no LocalToAbsolute translation.
+		abs := dungeon.AbsolutePosition{
+			X: placement.CubePosition.X,
+			Y: placement.CubePosition.Y,
+			Z: placement.CubePosition.Z,
+		}
+		esd.Position = &abs
 	}
 }
 
@@ -5714,24 +5731,37 @@ func (o *Orchestrator) addMonstersToEntityMap(
 
 // buildCombinedRoomDataAfterOpenDoor builds a *spatial.RoomData that carries
 // CubeEntities for every revealed room in the encounter so that perception
-// (executeMonsterTurns -> buildPerception) can find targets across rooms.
+// (executeMonsterTurns -> buildPerception) and movement-collision can find
+// targets and obstacles across rooms.
 //
-// Strategy:
-//   - The existing encounter RoomData is carried forward as-is. In production
-//     the start room is at origin (0,0,0) so its CubeEntities are already in
-//     dungeon-absolute coordinates, and after the first OpenDoor merges new
-//     monsters at absolute coordinates the persisted CubeEntities stay in
-//     absolute thereafter. So further OpenDoor calls keep merging correctly.
-//   - The newly revealed room's monsters use MonsterInfo.Position, which was
-//     constructed earlier in OpenDoor via localToAbsoluteOrLocal — i.e.
-//     dungeon-absolute when a Module exists, or room-local fallback otherwise.
+// Coordinate-space contract: this PR establishes that post-OpenDoor encounter
+// RoomData.CubeEntities holds dungeon-absolute cube coordinates. Consumers on
+// the read path MUST NOT re-translate (no LocalToAbsolute, no
+// applyOriginToEntities). Pre-OpenDoor we know the start room is at origin
+// (0,0,0) so its existing CubeEntities are already absolute by construction;
+// once OpenDoor merges new monsters and obstacles at absolute coordinates the
+// persisted CubeEntities stay in absolute thereafter, so further OpenDoor
+// calls keep merging correctly.
 //
-// existingRoomData may be nil or a non-pointer spatial.RoomData (interface{}
-// stored in repo); both cases are handled.
+// Inputs:
+//   - existingRoomData: the prior encounter RoomData (may be nil, *spatial.RoomData,
+//     or non-pointer spatial.RoomData stored as interface{} in the repo).
+//   - encounterID, revealedRoom: used to fall back to a deterministic RoomData
+//     ID/Width/Height when the encounter had no prior RoomData.
+//   - revealedRoomID, module: used to translate the revealed room's obstacle
+//     positions (room-local) into dungeon-absolute. module may be nil for the
+//     single-room start case (origin (0,0,0)) — in that case room-local equals
+//     absolute and localToAbsoluteOrLocal falls back to identity.
+//   - newMonsters: monsters spawned by OpenDoor; their Position field has
+//     already been translated to dungeon-absolute earlier in OpenDoor via
+//     localToAbsoluteOrLocal, so we copy through directly without further
+//     translation.
 func buildCombinedRoomDataAfterOpenDoor(
 	existingRoomData interface{},
 	encounterID string,
 	revealedRoom *dungeon.Room,
+	revealedRoomID string,
+	module *dungeon.Module,
 	newMonsters []MonsterInfo,
 ) *spatial.RoomData {
 	combined := &spatial.RoomData{
@@ -5772,6 +5802,26 @@ func buildCombinedRoomDataAfterOpenDoor(
 		if revealedRoom.Shape != nil {
 			combined.Width = revealedRoom.Shape.Width
 			combined.Height = revealedRoom.Shape.Height
+		}
+	}
+
+	// Add obstacles from the revealed room. convertToRoomData already does this
+	// for the start-room case at StartCombat; we mirror that here for revealed
+	// rooms so movement-collision (executeMove / MoveCharacter) sees blocking
+	// features in newly opened rooms. Obstacle.Position is room-local; we
+	// translate to dungeon-absolute via the same localToAbsoluteOrLocal helper
+	// used for new monsters.
+	if revealedRoom != nil && revealedRoom.Features != nil {
+		for _, obstacle := range revealedRoom.Features.Obstacles {
+			abs := localToAbsoluteOrLocal(module, revealedRoomID, obstacle.Position)
+			combined.CubeEntities[obstacle.ID] = spatial.EntityCubePlacement{
+				EntityID:          obstacle.ID,
+				EntityType:        entityTypeObstacle,
+				CubePosition:      spatial.CubeCoordinate{X: abs.X, Y: abs.Y, Z: abs.Z},
+				Size:              1,
+				BlocksMovement:    obstacle.BlocksMovement,
+				BlocksLineOfSight: obstacle.BlocksLineOfSight,
+			}
 		}
 	}
 

--- a/internal/orchestrators/encounter/orchestrator.go
+++ b/internal/orchestrators/encounter/orchestrator.go
@@ -3240,7 +3240,30 @@ func (o *Orchestrator) OpenDoor(
 		return nil, fmt.Errorf("failed to update dungeon: %w", err)
 	}
 
-	// 11. Update encounter state with new initiative and boss monster IDs
+	// 10c. Build a combined RoomData covering entities from ALL revealed rooms.
+	//
+	// Issue #464: previously OpenDoor persisted Monsters and InitiativeData but
+	// not RoomData. The next EndTurn -> executeMonsterTurns -> buildPerception
+	// would read the stale single-room CubeEntities and fail to find the new
+	// monster (let alone any cross-room targets), so the new monster perceived
+	// zero enemies and skipped its turn — appearing AFK.
+	//
+	// We build a unified RoomData whose CubeEntities live in dungeon-absolute
+	// cube coordinates so a monster from room N can perceive a character from
+	// room M. The existing CubeEntities are carried forward as-is: in the
+	// common case the start room is at origin (0,0,0) so start-local equals
+	// absolute, and after the first OpenDoor the persisted CubeEntities are
+	// already in absolute coords so further OpenDoor calls keep merging
+	// correctly.
+	combinedRoomData := buildCombinedRoomDataAfterOpenDoor(
+		encOutput.Data.RoomData,
+		dng.EncounterID,
+		revealedRoom,
+		monsters,
+	)
+
+	// 11. Update encounter state with new initiative, boss monster IDs, and the
+	// combined RoomData so subsequent perception sees all revealed-room entities.
 	// Merge new boss IDs with any existing ones
 	allBossIDs := make([]string, 0, len(encOutput.Data.BossMonsterIDs)+len(newBossMonsterIDs))
 	allBossIDs = append(allBossIDs, encOutput.Data.BossMonsterIDs...)
@@ -3251,10 +3274,16 @@ func (o *Orchestrator) OpenDoor(
 		InitiativeRolls: allRolls, // Persist merged rolls so EndTurn can re-sort at round start
 		Monsters:        encOutput.Data.Monsters,
 		BossMonsterIDs:  allBossIDs,
+		RoomData:        combinedRoomData,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update encounter: %w", err)
 	}
+
+	// Keep the in-memory encounter data in sync with what we just persisted so
+	// downstream code in this same call (snapshot, events) sees the new
+	// monsters in CubeEntities.
+	encOutput.Data.RoomData = combinedRoomData
 
 	// 12. Build room data for response with entities and walls
 	responseRoomData := &RoomData{
@@ -5681,4 +5710,85 @@ func (o *Orchestrator) addMonstersToEntityMap(
 			ToolkitData: monsterData,
 		}
 	}
+}
+
+// buildCombinedRoomDataAfterOpenDoor builds a *spatial.RoomData that carries
+// CubeEntities for every revealed room in the encounter so that perception
+// (executeMonsterTurns -> buildPerception) can find targets across rooms.
+//
+// Strategy:
+//   - The existing encounter RoomData is carried forward as-is. In production
+//     the start room is at origin (0,0,0) so its CubeEntities are already in
+//     dungeon-absolute coordinates, and after the first OpenDoor merges new
+//     monsters at absolute coordinates the persisted CubeEntities stay in
+//     absolute thereafter. So further OpenDoor calls keep merging correctly.
+//   - The newly revealed room's monsters use MonsterInfo.Position, which was
+//     constructed earlier in OpenDoor via localToAbsoluteOrLocal — i.e.
+//     dungeon-absolute when a Module exists, or room-local fallback otherwise.
+//
+// existingRoomData may be nil or a non-pointer spatial.RoomData (interface{}
+// stored in repo); both cases are handled.
+func buildCombinedRoomDataAfterOpenDoor(
+	existingRoomData interface{},
+	encounterID string,
+	revealedRoom *dungeon.Room,
+	newMonsters []MonsterInfo,
+) *spatial.RoomData {
+	combined := &spatial.RoomData{
+		Type:         "dungeon",
+		GridType:     spatial.GridTypeHex,
+		CubeEntities: make(map[string]spatial.EntityCubePlacement),
+	}
+
+	// Carry forward existing fields (ID, Width, Height) and CubeEntities from
+	// the previous RoomData. ID/Width/Height are descriptive of the original
+	// room and are preserved for backwards compatibility with consumers that
+	// inspect them; the encounter's authoritative geometry now spans multiple
+	// rooms.
+	switch existing := existingRoomData.(type) {
+	case *spatial.RoomData:
+		if existing != nil {
+			combined.ID = existing.ID
+			combined.Width = existing.Width
+			combined.Height = existing.Height
+			combined.HexFlatTop = existing.HexFlatTop
+			for id, placement := range existing.CubeEntities {
+				combined.CubeEntities[id] = placement
+			}
+		}
+	case spatial.RoomData:
+		combined.ID = existing.ID
+		combined.Width = existing.Width
+		combined.Height = existing.Height
+		combined.HexFlatTop = existing.HexFlatTop
+		for id, placement := range existing.CubeEntities {
+			combined.CubeEntities[id] = placement
+		}
+	}
+
+	// Fall back to a deterministic ID when the encounter had no prior RoomData.
+	if combined.ID == "" && revealedRoom != nil {
+		combined.ID = encounterID + "-" + revealedRoom.ID
+		if revealedRoom.Shape != nil {
+			combined.Width = revealedRoom.Shape.Width
+			combined.Height = revealedRoom.Shape.Height
+		}
+	}
+
+	// Add the newly spawned monsters using their already-translated positions.
+	for _, m := range newMonsters {
+		if m.Position == nil {
+			continue
+		}
+		combined.CubeEntities[m.ID] = spatial.EntityCubePlacement{
+			EntityID:          m.ID,
+			EntityType:        entityTypeMonster,
+			CubePosition:      spatial.CubeCoordinate{X: m.Position.X, Y: m.Position.Y, Z: m.Position.Z},
+			Size:              1,
+			BlocksMovement:    true,
+			BlocksLineOfSight: false,
+		}
+	}
+
+	return combined
 }


### PR DESCRIPTION
## Summary

Fixes #464 — after `OpenDoor`, monsters from the newly revealed room appeared in initiative but never took a turn (AFK).

**Root cause:** `OpenDoor` persisted `Monsters` and `InitiativeData` but not `RoomData`. On the next `EndTurn` -> `executeMonsterTurns` -> `buildPerception`, the lookup `roomData.CubeEntities[monsterID]` missed the new monster, so perception returned an empty enemy list and the monster skipped.

**Fix:** `OpenDoor` now builds a combined `*spatial.RoomData` covering entities from ALL revealed rooms. New-room monster `CubeEntities` are written in dungeon-absolute coordinates so a monster from room N can perceive a character from room M. The existing `CubeEntities` are carried through as-is — start room is at origin so start-local equals absolute, and once we merge new monsters at absolute coords subsequent `OpenDoor` calls keep merging correctly. The `RoomData` is included in the encounter `Update` and the in-memory `encOutput.Data.RoomData` is kept in sync so downstream snapshot/event code in the same call sees the new monsters too.

## Test plan

- [x] New integration-style orchestrator test `TestOpenDoorPerceptionTestSuite/TestOpenDoor_PersistsRoomDataSoNewMonstersPerceiveCharacters` reproduces the bug:
  - Seeds a two-room dungeon (room-2 origin offset to (20,0) absolute) with a character at the door in room 1
  - Opens the door to room 2 with a deterministic stub roller
  - Reloads the persisted encounter and asserts the new skeleton is in `CubeEntities` at dungeon-absolute (25,5) — local (5,5) plus origin (20,0)
  - Calls `buildPerception` for the new monster and asserts the character is found as an enemy
- [x] Confirmed the test FAILS on main (without the fix): `persisted RoomData must contain the new monster monster-room-2-mp-1`
- [x] Confirmed the test PASSES with the fix
- [x] Full encounter package tests pass: `go test ./internal/orchestrators/encounter/...`
- [x] Full repo tests pass with race: `go test -race ./internal/...` (matches CI's test step)

## #465 assessment (Room 2 missing outer/perimeter walls after OpenDoor)

**Not auto-resolved.** This fix only persists `CubeEntities` for cross-room perception. Walls live on `dungeon.Room.Walls`, not in `spatial.RoomData`, and every wall-consumer in this orchestrator (`MoveCharacter`, `executeMonsterTurns`, `ResolveAttack`) still loads walls only for `dungeon.CurrentRoomID`. #465 needs a separate change — either aggregate walls from all revealed rooms, or have `GetEncounterState` return per-room wall sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)