### PR TITLE
feat(encounter/v2): implement CreateEncounter RPC (#499)

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,0 +1,61 @@
+---
+name: encounter (v1alpha2)
+description: v1alpha2 encounter service — lightweight toolkit adapter, no orchestrator
+updated: 2026-05-07
+confidence: high — verified by reading handler.go, create.go, project.go, translate.go
+---
+
+# encounter (v1alpha2)
+
+The v1alpha2 encounter service is the second-generation encounter handler. Unlike the v1alpha1 handler which delegates through a full orchestrator stack, v2 talks directly to the rpg-toolkit encounter SDK and a v2 repository. The handler is a thin wire adapter — no business logic, no orchestrator.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct, constructor, MoveEntity, StreamEncounter |
+| `internal/handlers/dnd5e/v2/encounter/create.go` | CreateEncounter RPC |
+| `internal/handlers/dnd5e/v2/encounter/project.go` | ProjectFor helper — toolkit Data → proto Encounter |
+| `internal/handlers/dnd5e/v2/encounter/translate.go` | Event translator — toolkit events → proto EncounterEvent |
+| `internal/repositories/encounters/v2/repository.go` | Repository interface (Get, Save) |
+| `internal/repositories/encounters/v2/in_memory.go` | In-memory implementation (JSON round-trip) |
+| `internal/repositories/encounters/v2/redis.go` | Redis implementation |
+
+## v2 RPCs
+
+| RPC | Status | Wave |
+|---|---|---|
+| `CreateEncounter` | Implemented (#499) | 2.6 |
+| `GetEncounter` | Unimplemented | 2.6 (#500) |
+| `StreamEncounter` | Implemented (#496) | 2.5 |
+| `MoveEntity` | Implemented (#496) | 2.5 |
+
+## CreateEncounter flow
+
+1. Validate auth — `auth.GetPlayerID(ctx)` empty → `Unauthenticated`.
+2. Validate request — `campaign_id` empty → `InvalidArgument`.
+3. Construct `tkenc.New(uuid, broker)`, add creator as first player via `enc.AddPlayer`.
+4. Persist via `h.encRepo.Save(ctx, enc.ToData())`.
+5. Build proto response via `ProjectFor(data, viewer, broker, now)`.
+
+## ProjectFor helper
+
+`project.go` exposes a single exported function:
+
+```go
+func ProjectFor(
+    data *tkenc.Data,
+    viewer core.PlayerID,
+    broker *tkenc.Broker,
+    now time.Time,
+) (*encounterv2pb.Encounter, error)
+```
+
+It is the single source of truth for toolkit Snapshot → proto Encounter translation. Called by `CreateEncounter` today; `GetEncounter` (#500) and snapshot replay (#497) will reuse it without duplicating the projection logic.
+
+## Architecture notes
+
+- Handler imports no orchestrator — direct toolkit dependency is intentional for v2.
+- `encounter.Broker` is process-scoped (one broker per server process, shared across all v2 RPCs).
+- Repository follows the standard Input/Output interface pattern but `Get` returns `*encounter.Data` directly (toolkit's native type is the domain entity here).
+- Entity ID in CreateEncounter defaults to player ID for the initial seat; future PRs will wire in character selection.

--- a/internal/handlers/dnd5e/v2/encounter/create.go
+++ b/internal/handlers/dnd5e/v2/encounter/create.go
@@ -25,6 +25,16 @@ func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.Create
 	if req.GetCampaignId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "campaign_id is required")
 	}
+	// Wave 2.6 only supports FREE_ROAM. UNSPECIFIED is treated as FREE_ROAM
+	// for forward compatibility with older clients. TURN_BASED lands in Wave 2.8.
+	switch req.GetInitialMode() {
+	case encounterv2pb.EncounterMode_ENCOUNTER_MODE_UNSPECIFIED,
+		encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM:
+	default:
+		return nil, status.Errorf(codes.InvalidArgument,
+			"initial_mode %s is not supported (only FREE_ROAM is implemented)",
+			req.GetInitialMode())
+	}
 
 	encID := core.EncounterID(uuid.NewString())
 	enc := tkenc.New(encID, h.broker)

--- a/internal/handlers/dnd5e/v2/encounter/create.go
+++ b/internal/handlers/dnd5e/v2/encounter/create.go
@@ -1,0 +1,56 @@
+package encounter
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// CreateEncounter handles the CreateEncounter RPC. It validates auth and
+// request fields, constructs a fresh encounter with the caller as the sole
+// player, persists it, and returns the proto Encounter projected for the
+// caller's view.
+func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.CreateEncounterRequest) (*encounterv2pb.CreateEncounterResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+	if req.GetCampaignId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "campaign_id is required")
+	}
+
+	encID := core.EncounterID(uuid.NewString())
+	enc := tkenc.New(encID, h.broker)
+	// The creator is automatically added as the encounter's first player.
+	// Entity ID mirrors the player ID for the initial seat; future PRs can
+	// wire in a character-selection step that replaces this with the
+	// player's chosen character ID.
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: core.PlayerID(playerID),
+		EntityID: core.EntityID(playerID),
+		Position: core.Hex{Q: 0, R: 0, S: 0},
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "add creator to encounter: %v", err)
+	}
+
+	data := enc.ToData()
+	if err := h.encRepo.Save(ctx, data); err != nil {
+		return nil, status.Errorf(codes.Internal, "save encounter: %v", err)
+	}
+
+	pbEncounter, err := ProjectFor(data, core.PlayerID(playerID), h.broker, h.now())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "project encounter: %v", err)
+	}
+
+	return &encounterv2pb.CreateEncounterResponse{
+		Encounter: pbEncounter,
+	}, nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -73,6 +73,26 @@ func (s *HandlerSuite) TestCreateEncounter_EmptyCampaignID_InvalidArgument() {
 	s.Require().Equal(codes.InvalidArgument, st.Code())
 }
 
+func (s *HandlerSuite) TestCreateEncounter_TurnBasedMode_InvalidArgument() {
+	_, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
+		CampaignId:  "campaign-1",
+		InitialMode: encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestCreateEncounter_UnspecifiedMode_TreatedAsFreeRoam() {
+	resp, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
+		CampaignId: "campaign-1",
+		// InitialMode omitted -> ENCOUNTER_MODE_UNSPECIFIED
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+	s.Require().NotEmpty(resp.GetEncounter().GetId())
+}
+
 func (s *HandlerSuite) TestCreateEncounter_Success_ReturnsEncounterWithID() {
 	resp, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
 		CampaignId:  "campaign-1",

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -54,12 +54,49 @@ func (s *HandlerSuite) TearDownTest() {
 	s.cancel()
 }
 
-func (s *HandlerSuite) TestCreateEncounter_ReturnsUnimplemented() {
-	_, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{})
+func (s *HandlerSuite) TestCreateEncounter_NoAuth_Unauthenticated() {
+	ctx := context.Background() // no auth
+	_, err := s.handler.CreateEncounter(ctx, &encounterv2pb.CreateEncounterRequest{
+		CampaignId: "campaign-1",
+	})
 	s.Require().Error(err)
-	st, ok := status.FromError(err)
-	s.Require().True(ok)
-	s.Require().Equal(codes.Unimplemented, st.Code())
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unauthenticated, st.Code())
+}
+
+func (s *HandlerSuite) TestCreateEncounter_EmptyCampaignID_InvalidArgument() {
+	_, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
+		CampaignId: "",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestCreateEncounter_Success_ReturnsEncounterWithID() {
+	resp, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
+		CampaignId:  "campaign-1",
+		InitialMode: encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.GetEncounter())
+	s.Require().NotEmpty(resp.GetEncounter().GetId())
+}
+
+func (s *HandlerSuite) TestCreateEncounter_Success_PersistsToRepo() {
+	resp, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
+		CampaignId:  "campaign-1",
+		InitialMode: encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+
+	encID := resp.GetEncounter().GetId()
+	data, err := s.repo.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	s.Require().NotNil(data)
+	s.Require().Equal(encID, string(data.ID))
 }
 
 func (s *HandlerSuite) TestMoveEntity_HappyPath_LoadsCallsMoveSaves() {

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -13,8 +13,8 @@ import (
 )
 
 // ProjectFor builds a proto *encounterv2pb.Encounter for the given viewer from
-// the encounter's persisted data. It is called by CreateEncounter,
-// GetEncounter, and StreamEncounter (SnapshotDelivered.encounter) so the
+// the encounter's persisted data. CreateEncounter calls it today; GetEncounter
+// (#500) and StreamEncounter snapshot replay (#497) will reuse it so the
 // projection logic lives in exactly one place.
 //
 // The broker is required to rehydrate a live Encounter via LoadFromData

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -1,0 +1,74 @@
+// Package encounter is the v2 encounter handler.
+// project.go translates a toolkit encounter.Data into the v1alpha2
+// proto Encounter message for a specific viewer.
+package encounter
+
+import (
+	"sort"
+	"time"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ProjectFor builds a proto *encounterv2pb.Encounter for the given viewer from
+// the encounter's persisted data. It is called by CreateEncounter,
+// GetEncounter, and StreamEncounter (SnapshotDelivered.encounter) so the
+// projection logic lives in exactly one place.
+//
+// The broker is required to rehydrate a live Encounter via LoadFromData
+// (needed for SnapshotFor).
+//
+// now is passed explicitly so callers in tests can inject a fixed clock.
+func ProjectFor(
+	data *tkenc.Data,
+	viewer core.PlayerID,
+	broker *tkenc.Broker,
+	now time.Time,
+) (*encounterv2pb.Encounter, error) {
+	enc, err := tkenc.LoadFromData(data, broker)
+	if err != nil {
+		return nil, err
+	}
+
+	snap := enc.SnapshotFor(viewer)
+
+	// Build the Space from the viewer's revealed hexes. Hexes are sorted by
+	// (Q,R,S) so the wire output is deterministic across Go map iterations.
+	keys := make([]core.Hex, 0, len(snap.RevealedHexes))
+	for h := range snap.RevealedHexes {
+		keys = append(keys, h)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Q != keys[j].Q {
+			return keys[i].Q < keys[j].Q
+		}
+		if keys[i].R != keys[j].R {
+			return keys[i].R < keys[j].R
+		}
+		return keys[i].S < keys[j].S
+	})
+	hexes := make([]*encounterv2pb.Hex, 0, len(keys))
+	for _, h := range keys {
+		hexes = append(hexes, &encounterv2pb.Hex{Position: HexToPosition(h)})
+	}
+
+	// The viewer's own entity is visible at their position.
+	var entities []*encounterv2pb.Entity
+	if snap.PlayerID != "" {
+		entities = append(entities, &encounterv2pb.Entity{
+			Id:       string(snap.PlayerID),
+			Position: HexToPosition(snap.Position),
+		})
+	}
+
+	return &encounterv2pb.Encounter{
+		Id:   string(data.ID),
+		Mode: encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
+		Space: &encounterv2pb.Space{
+			Hexes:    hexes,
+			Entities: entities,
+		},
+	}, nil
+}

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -50,6 +50,21 @@ func (s *EncounterV2IntegrationSuite) authCtx(playerID string) context.Context {
 	return metadata.AppendToOutgoingContext(s.ctx, "authorization", "Dev "+playerID)
 }
 
+func (s *EncounterV2IntegrationSuite) TestCreateEncounter_Basic() {
+	ctxA := s.authCtx("alice")
+	resp, err := s.srv.EncounterClientV2.CreateEncounter(ctxA, &encounterv2pb.CreateEncounterRequest{
+		CampaignId:  "campaign-1",
+		InitialMode: encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+	s.Require().NotEmpty(resp.GetEncounter().GetId())
+
+	data, err := s.srv.EncRepoV2.Get(s.ctx, resp.GetEncounter().GetId())
+	s.Require().NoError(err)
+	s.Require().NotNil(data)
+}
+
 func (s *EncounterV2IntegrationSuite) TestMovementSliceTwoPlayers() {
 	// Seed: encounter with players A and B in mutual LoS.
 	// SightRange must be > 0; default 0 means neither player sees anything.


### PR DESCRIPTION
## Summary

- Implement `CreateEncounter` v2 RPC end-to-end (handler, persistence, projected response)
- Extract `ProjectFor(data, viewer, broker, now)` helper in `project.go` so #500 (`GetEncounter`) and #497 (`StreamEncounter` snapshot replay) can reuse the toolkit-Snapshot → proto-Encounter projection without duplicating logic
- Add v2 component doc at `docs/architecture/components/encounter.md`

Closes #499. Part of Wave 2.6 on board #11.

## Behavior

- `auth.GetPlayerID(ctx)` empty → `Unauthenticated`
- `req.GetCampaignId()` empty → `InvalidArgument`
- Caller becomes the only player on the new encounter (creator membership)
- Encounter ID is a server-generated UUID
- Response carries the projected snapshot for the caller via `ProjectFor`

## Test plan

- [x] Unit tests for handler: missing auth, empty campaign_id, success-returns-ID, success-persists-to-repo
- [x] Integration test `TestCreateEncounter_Basic` (bufconn) — authed call returns non-empty Encounter ID and `EncRepoV2.Get` confirms persistence
- [x] `make ci-check` — no new lint issues in v2/ packages (pre-existing failures in `internal/integration/encounter/helpers.go`, `internal/integration/harness/harness.go` unchanged)

## Reviewer notes

Three suggestions surfaced in code review and deferred (none are blockers):

1. `internal/integration/encounter_v2_test.go` — could add `s.Require().Contains(data.Players, core.PlayerID("alice"))` to `TestCreateEncounter_Basic` to catch a future regression where `AddPlayer` stops being called.
2. `internal/handlers/dnd5e/v2/encounter/project.go:43-51` — the `(Q,R,S)` sort comparator is duplicated with `translate.go:96-104`. Worth extracting to a `sortHexes` helper if a third consumer appears.
3. `internal/handlers/dnd5e/v2/encounter/project.go:58-64` — viewer-only entity projection is a slice-1 limitation; happy to add a comment or wait until #497 broadens it.

## Out of scope

- `GetEncounter` (#500), `StreamEncounter` snapshot replay (#497)
- Persistence beyond in-memory
- Party rosters, dungeon refs, web LobbyView migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)