### PR TITLE
feat(encounter/v2): implement GetEncounter RPC (#500)

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter (v1alpha2)
 description: v1alpha2 encounter service — lightweight toolkit adapter, no orchestrator
-updated: 2026-05-07
-confidence: high — verified by reading handler.go, create.go, project.go, translate.go
+updated: 2026-05-08
+confidence: high — verified by reading handler.go, create.go, get.go, project.go, translate.go
 ---
 
 # encounter (v1alpha2)
@@ -15,6 +15,7 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 |---|---|
 | `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct, constructor, MoveEntity, StreamEncounter |
 | `internal/handlers/dnd5e/v2/encounter/create.go` | CreateEncounter RPC |
+| `internal/handlers/dnd5e/v2/encounter/get.go` | GetEncounter RPC |
 | `internal/handlers/dnd5e/v2/encounter/project.go` | ProjectFor helper — toolkit Data → proto Encounter |
 | `internal/handlers/dnd5e/v2/encounter/translate.go` | Event translator — toolkit events → proto EncounterEvent |
 | `internal/repositories/encounters/v2/repository.go` | Repository interface (Get, Save) |
@@ -26,7 +27,7 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 | RPC | Status | Wave |
 |---|---|---|
 | `CreateEncounter` | Implemented (#499) | 2.6 |
-| `GetEncounter` | Unimplemented | 2.6 (#500) |
+| `GetEncounter` | Implemented (#500) | 2.6 |
 | `StreamEncounter` | Implemented (#496) | 2.5 |
 | `MoveEntity` | Implemented (#496) | 2.5 |
 
@@ -36,6 +37,14 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 2. Validate request — `campaign_id` empty → `InvalidArgument`.
 3. Construct `tkenc.New(uuid, broker)`, add creator as first player via `enc.AddPlayer`.
 4. Persist via `h.encRepo.Save(ctx, enc.ToData())`.
+5. Build proto response via `ProjectFor(data, viewer, broker, now)`.
+
+## GetEncounter flow
+
+1. Validate auth — `auth.GetPlayerID(ctx)` empty → `Unauthenticated`.
+2. Validate request — `encounter_id` empty → `InvalidArgument`.
+3. Load encounter via `h.encRepo.Get`; `ErrNotFound` → `NotFound`.
+4. Authority check — `data.Players[core.PlayerID(playerID)]` lookup; not present → `PermissionDenied`. Mirrors `MoveEntity` exactly.
 5. Build proto response via `ProjectFor(data, viewer, broker, now)`.
 
 ## ProjectFor helper
@@ -51,7 +60,11 @@ func ProjectFor(
 ) (*encounterv2pb.Encounter, error)
 ```
 
-It is the single source of truth for toolkit Snapshot → proto Encounter translation. Called by `CreateEncounter` today; `GetEncounter` (#500) and snapshot replay (#497) will reuse it without duplicating the projection logic.
+It is the single source of truth for toolkit Snapshot → proto Encounter translation. Called by `CreateEncounter` and `GetEncounter`; snapshot replay (#497) will reuse it without duplicating the projection logic.
+
+### Entity visibility in ProjectFor (#500 broadening)
+
+As of #500, `ProjectFor` includes all entities currently visible to the viewer — not just the viewer's own entity. Visibility is computed using `perception.VisibleHexesAt(viewer.Position, viewer.SightRange)` against each other player's current position in `data.Players`. Entities are sorted by player ID for deterministic wire output. This gives clients a real point-in-time snapshot of what the viewer can see.
 
 ## Architecture notes
 

--- a/internal/auth/mock/mock_discord.go
+++ b/internal/auth/mock/mock_discord.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	auth "github.com/KirkDiggler/rpg-api/internal/auth"
 	gomock "go.uber.org/mock/gomock"
+
+	auth "github.com/KirkDiggler/rpg-api/internal/auth"
 )
 
 // MockTokenValidator is a mock of TokenValidator interface.

--- a/internal/handlers/dnd5e/v2/encounter/get.go
+++ b/internal/handlers/dnd5e/v2/encounter/get.go
@@ -1,0 +1,50 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// GetEncounter handles the GetEncounter RPC. It validates auth and request
+// fields, loads the encounter, enforces membership, and returns the proto
+// Encounter projected through the caller's PerceptionView.
+func (h *Handler) GetEncounter(ctx context.Context, req *encounterv2pb.GetEncounterRequest) (*encounterv2pb.GetEncounterResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+	if req.GetEncounterId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+
+	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "encounter not found")
+		}
+		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	// Authority check: caller must be a member of this encounter.
+	// Mirrors the MoveEntity pattern exactly: data.Players[core.PlayerID(playerID)].
+	if _, ok := data.Players[core.PlayerID(playerID)]; !ok {
+		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
+	}
+
+	pbEncounter, err := ProjectFor(data, core.PlayerID(playerID), h.broker, h.now())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "project encounter: %v", err)
+	}
+
+	return &encounterv2pb.GetEncounterResponse{
+		Encounter: pbEncounter,
+	}, nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -254,6 +254,65 @@ func (s *HandlerSuite) TestStreamEncounter_ForwardsBrokerEvents() {
 	s.Require().NotNil(got.GetEntityMoved())
 }
 
+func (s *HandlerSuite) TestGetEncounter_NoAuth_Unauthenticated() {
+	ctx := context.Background() // no auth
+	_, err := s.handler.GetEncounter(ctx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "enc-1",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unauthenticated, st.Code())
+}
+
+func (s *HandlerSuite) TestGetEncounter_EmptyEncounterID_InvalidArgument() {
+	_, err := s.handler.GetEncounter(s.ctx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestGetEncounter_UnknownID_NotFound() {
+	_, err := s.handler.GetEncounter(s.ctx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "does-not-exist",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestGetEncounter_NonMember_PermissionDenied() {
+	// Encounter seeded with player-B only; auth context is player-A.
+	enc := tkenc.New("enc-nonmember", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-B", EntityID: "char-B", Position: core.Hex{Q: 0, R: 0, S: 0},
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.handler.GetEncounter(s.ctx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "enc-nonmember",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
+}
+
+func (s *HandlerSuite) TestGetEncounter_Success_ReturnsEncounterWithID() {
+	enc := tkenc.New("enc-get-1", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0},
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	resp, err := s.handler.GetEncounter(s.ctx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "enc-get-1",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+	s.Require().Equal("enc-get-1", resp.GetEncounter().GetId())
+}
+
 func TestHandlerSuite(t *testing.T) {
 	suite.Run(t, new(HandlerSuite))
 }

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -65,18 +65,18 @@ func ProjectFor(
 
 	// Collect entities visible to the viewer. Start with the viewer's own
 	// entity (always visible), then add other players whose current position
-	// falls within the viewer's sight range. Sorted by entity ID so wire
-	// output is deterministic across Go map iterations.
-	entityKeys := make([]core.PlayerID, 0, len(data.Players))
+	// falls within the viewer's sight range. Iterate data.Players in player-ID
+	// order so wire output is deterministic across Go map iterations.
+	playerIDs := make([]core.PlayerID, 0, len(data.Players))
 	for pid := range data.Players {
-		entityKeys = append(entityKeys, pid)
+		playerIDs = append(playerIDs, pid)
 	}
-	sort.Slice(entityKeys, func(i, j int) bool {
-		return string(entityKeys[i]) < string(entityKeys[j])
+	sort.Slice(playerIDs, func(i, j int) bool {
+		return string(playerIDs[i]) < string(playerIDs[j])
 	})
 
 	var entities []*encounterv2pb.Entity
-	for _, pid := range entityKeys {
+	for _, pid := range playerIDs {
 		pd := data.Players[pid]
 		if pid == viewer {
 			// Viewer always sees their own entity.

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -10,6 +10,7 @@ import (
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 )
 
 // ProjectFor builds a proto *encounterv2pb.Encounter for the given viewer from
@@ -54,13 +55,46 @@ func ProjectFor(
 		hexes = append(hexes, &encounterv2pb.Hex{Position: HexToPosition(h)})
 	}
 
-	// The viewer's own entity is visible at their position.
+	// Build the set of hexes currently visible to the viewer so we can
+	// include other players who are visible right now (not just ever-revealed).
+	// This requires the viewer's sight range from the persisted view.
+	var visibleNow core.HexSet
+	if vp, ok := data.Players[viewer]; ok && vp.View != nil {
+		visibleNow = perception.VisibleHexesAt(snap.Position, vp.View.SightRange)
+	}
+
+	// Collect entities visible to the viewer. Start with the viewer's own
+	// entity (always visible), then add other players whose current position
+	// falls within the viewer's sight range. Sorted by entity ID so wire
+	// output is deterministic across Go map iterations.
+	entityKeys := make([]core.PlayerID, 0, len(data.Players))
+	for pid := range data.Players {
+		entityKeys = append(entityKeys, pid)
+	}
+	sort.Slice(entityKeys, func(i, j int) bool {
+		return string(entityKeys[i]) < string(entityKeys[j])
+	})
+
 	var entities []*encounterv2pb.Entity
-	if snap.PlayerID != "" {
-		entities = append(entities, &encounterv2pb.Entity{
-			Id:       string(snap.PlayerID),
-			Position: HexToPosition(snap.Position),
-		})
+	for _, pid := range entityKeys {
+		pd := data.Players[pid]
+		if pid == viewer {
+			// Viewer always sees their own entity.
+			entities = append(entities, &encounterv2pb.Entity{
+				Id:       string(pd.EntityID),
+				Position: HexToPosition(snap.Position),
+			})
+			continue
+		}
+		if pd.View == nil {
+			continue
+		}
+		if visibleNow != nil && visibleNow.Has(pd.View.Position) {
+			entities = append(entities, &encounterv2pb.Entity{
+				Id:       string(pd.EntityID),
+				Position: HexToPosition(pd.View.Position),
+			})
+		}
 	}
 
 	return &encounterv2pb.Encounter{

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
@@ -240,6 +242,96 @@ func (s *EncounterV2IntegrationSuite) TestMovementSlicePerViewerProjection_Asymm
 	s.Require().Equal(int32(0), bDisappeared.LastKnownPosition.X)
 	s.Require().Equal(int32(-1), bDisappeared.LastKnownPosition.Y)
 	s.Require().Equal(int32(1), bDisappeared.LastKnownPosition.Z)
+}
+
+// TestGetEncounter_ProjectsView verifies that GetEncounter returns the encounter
+// with the caller's own entity visible, and that other players within mutual LoS
+// also appear in the projected snapshot.
+func (s *EncounterV2IntegrationSuite) TestGetEncounter_ProjectsView() {
+	enc := tkenc.New("enc-get-1", s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position:   core.Hex{Q: 1, R: -1, S: 0},
+		SightRange: 10,
+	}))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	ctxA := s.authCtx("alice")
+	resp, err := s.srv.EncounterClientV2.GetEncounter(ctxA, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "enc-get-1",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+	s.Require().Equal("enc-get-1", resp.GetEncounter().GetId())
+
+	// Both alice and bob should appear in alice's projected snapshot because
+	// they are within mutual SightRange:10.
+	entities := resp.GetEncounter().GetSpace().GetEntities()
+	s.Require().Len(entities, 2, "alice's snapshot should include both alice and bob")
+
+	entityIDs := make(map[string]bool, len(entities))
+	for _, e := range entities {
+		entityIDs[e.GetId()] = true
+	}
+	s.Require().True(entityIDs["char-alice"], "alice's own entity should be in the snapshot")
+	s.Require().True(entityIDs["char-bob"], "bob should be visible to alice (mutual LoS, SightRange 10)")
+}
+
+// TestGetEncounter_AsymmetricLoS_ExcludesHidden verifies that players outside
+// the viewer's current sight range are excluded from the projected snapshot.
+func (s *EncounterV2IntegrationSuite) TestGetEncounter_AsymmetricLoS_ExcludesHidden() {
+	enc := tkenc.New("enc-get-asym", s.srv.BrokerV2)
+	// alice at origin with SightRange:1 — can only see adjacent hexes.
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 1,
+	}))
+	// bob is far away (distance 5) — invisible to alice.
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position:   core.Hex{Q: 5, R: -2, S: -3},
+		SightRange: 10,
+	}))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	ctxA := s.authCtx("alice")
+	resp, err := s.srv.EncounterClientV2.GetEncounter(ctxA, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "enc-get-asym",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+
+	// Only alice's own entity — bob is outside alice's SightRange:1.
+	entities := resp.GetEncounter().GetSpace().GetEntities()
+	s.Require().Len(entities, 1, "alice should only see herself, not bob (out of sight range)")
+	s.Require().Equal("char-alice", entities[0].GetId())
+}
+
+// TestGetEncounter_NonMember_PermissionDenied verifies that a player not in the
+// encounter receives PermissionDenied.
+func (s *EncounterV2IntegrationSuite) TestGetEncounter_NonMember_PermissionDenied() {
+	enc := tkenc.New("enc-get-perm", s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0},
+	}))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	// charlie is not in this encounter.
+	ctxC := s.authCtx("charlie")
+	_, err := s.srv.EncounterClientV2.GetEncounter(ctxC, &encounterv2pb.GetEncounterRequest{
+		EncounterId: "enc-get-perm",
+	})
+	s.Require().Error(err)
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
 }
 
 // recvUntilEntityMoved pulls events from the stream until an EntityMoved arrives

--- a/internal/orchestrators/character/mock/mock_service.go
+++ b/internal/orchestrators/character/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 	gomock "go.uber.org/mock/gomock"
+
+	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/dice/mock/mock_service.go
+++ b/internal/orchestrators/dice/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 	gomock "go.uber.org/mock/gomock"
+
+	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/encounter/mock/mock_service.go
+++ b/internal/orchestrators/encounter/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounter "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 	gomock "go.uber.org/mock/gomock"
+
+	encounter "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/processors/event/mock/mock_processor.go
+++ b/internal/processors/event/mock/mock_processor.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	event "github.com/KirkDiggler/rpg-api/internal/processors/event"
 	gomock "go.uber.org/mock/gomock"
+
+	event "github.com/KirkDiggler/rpg-api/internal/processors/event"
 )
 
 // MockProcessor is a mock of Processor interface.

--- a/internal/publishers/encounter/mock/mock_publisher.go
+++ b/internal/publishers/encounter/mock/mock_publisher.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounter "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
 	gomock "go.uber.org/mock/gomock"
+
+	encounter "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
 )
 
 // MockPublisher is a mock of Publisher interface.

--- a/internal/repositories/character/mock/mock_repository.go
+++ b/internal/repositories/character/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	gomock "go.uber.org/mock/gomock"
+
+	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/character_draft/mock/mock_repository.go
+++ b/internal/repositories/character_draft/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 	gomock "go.uber.org/mock/gomock"
+
+	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dice_session/mock/mock_repository.go
+++ b/internal/repositories/dice_session/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 	gomock "go.uber.org/mock/gomock"
+
+	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dungeons/mock/mock_repository.go
+++ b/internal/repositories/dungeons/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dungeons "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
 	gomock "go.uber.org/mock/gomock"
+
+	dungeons "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/encounterlog/mock/mock_repository.go
+++ b/internal/repositories/encounterlog/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounterlog "github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog"
 	gomock "go.uber.org/mock/gomock"
+
+	encounterlog "github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/encounters/mock/mock_repository.go
+++ b/internal/repositories/encounters/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounters "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 	gomock "go.uber.org/mock/gomock"
+
+	encounters "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/services/sandboxroom/mock/mock_service.go
+++ b/internal/services/sandboxroom/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
 	gomock "go.uber.org/mock/gomock"
+
+	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
 )
 
 // MockService is a mock of Service interface.


### PR DESCRIPTION
## Summary

- Implement `GetEncounter` v2 RPC: load encounter, authority-check caller, project through their PerceptionView, return proto Encounter
- Broaden `ProjectFor` to emit all visible non-viewer entities (not just the viewer's own seat) — closes the slice-1 gap noted in #499
- Reuse #499's `ProjectFor` helper; no inline projection in the handler

Closes #500. Lifecycle pair with #499 (merged in #501). Part of Wave 2.6 on board #11.

## Behavior

- `auth.GetPlayerID(ctx)` empty → `Unauthenticated`
- `req.GetEncounterId()` empty → `InvalidArgument`
- Encounter not in repo → `NotFound`
- Caller not in `data.Players` → `PermissionDenied` (mirrors `MoveEntity`'s authority pattern)
- Success → proto `Encounter` with revealed hexes + visible entities (viewer + any other player whose position is in the viewer's `perception.VisibleHexesAt(snap.Position, sightRange)`)

## ProjectFor broadening

`ProjectFor` previously emitted only the viewer's own entity. With this PR it iterates `data.Players` (sorted by player ID for determinism) and includes each non-viewer player whose `View.Position` is within the viewer's current sight range. CreateEncounter is a no-op for the broadening (single-player encounter), verified by passing #499 unit tests.

## Test plan

- [x] Unit: `TestGetEncounter_NoAuth_Unauthenticated`, `TestGetEncounter_EmptyEncounterID_InvalidArgument`, `TestGetEncounter_UnknownID_NotFound`, `TestGetEncounter_NonMember_PermissionDenied`, `TestGetEncounter_Success_ReturnsEncounterWithID`
- [x] Integration: `TestGetEncounter_ProjectsView` (mutual LoS — bob appears in alice's projection), `TestGetEncounter_AsymmetricLoS_ExcludesHidden` (alice SightRange:1, bob distance 5 — excluded), `TestGetEncounter_NonMember_PermissionDenied`
- [x] Full `TestEncounterV2IntegrationSuite` passes — no regression to streaming/movement tests that consume `ProjectFor`'s snapshot
- [x] `golangci-lint run ./internal/handlers/dnd5e/v2/encounter/...` → 0 issues
- [x] `make ci-check` — pre-existing failures in `internal/integration/harness/harness.go` and `internal/integration/encounter/helpers.go` unchanged

## Drive-by cleanup

13 mock files have one-line goimports diffs (separating third-party imports from local with a blank line). Pre-commit produced these — they fix main's pre-existing "Import issues" CI failure. No logic / signature changes.

## Reviewer notes (deferred from code review)

- `project.go:62` — `visibleNow` is silently empty if `data.Players[viewer]` is missing or `View == nil`; the handler enforces membership upstream so we degrade gracefully here. Could add a one-line contract comment.
- `project.go:92` — `visibleNow != nil` guard is defensive-but-redundant (`HexSet.Has` on nil map returns false safely); harmless either way.
- Performance: O(P) per RPC + one `VisibleHexesAt` call. Fine for Wave-2.6 scale (1–8 players); revisit if NPCs land in large numbers.

## Out of scope

- `StreamEncounter` snapshot replay (#497)
- Reconnect semantics, real LoS (toolkit perception is still stub Manhattan-radius)
- Web LobbyView migration (Wave 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)