### PR TITLE
feat(encounter/v2): implement Interact RPC for door interactions (#504)

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter (v1alpha2)
 description: v1alpha2 encounter service — lightweight toolkit adapter, no orchestrator
-updated: 2026-05-08
-confidence: high — verified by reading handler.go, create.go, get.go, project.go, translate.go, translate_test.go, encounter_v2_test.go
+updated: 2026-05-09
+confidence: high — verified by reading handler.go, create.go, get.go, interact.go, project.go, translate.go, translate_test.go, encounter_v2_test.go
 ---
 
 # encounter (v1alpha2)
@@ -16,6 +16,7 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 | `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct, constructor, MoveEntity, StreamEncounter |
 | `internal/handlers/dnd5e/v2/encounter/create.go` | CreateEncounter RPC |
 | `internal/handlers/dnd5e/v2/encounter/get.go` | GetEncounter RPC |
+| `internal/handlers/dnd5e/v2/encounter/interact.go` | Interact RPC (Wave 2.7 — door interactions) |
 | `internal/handlers/dnd5e/v2/encounter/project.go` | ProjectFor helper — toolkit Data → proto Encounter |
 | `internal/handlers/dnd5e/v2/encounter/translate.go` | Event translator — toolkit events → proto EncounterEvent |
 | `internal/repositories/encounters/v2/repository.go` | Repository interface (Get, Save) |
@@ -30,6 +31,7 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 | `GetEncounter` | Implemented (#500) | 2.6 |
 | `StreamEncounter` | Implemented (#496, replay #497) | 2.5 / 2.7 |
 | `MoveEntity` | Implemented (#496) | 2.5 |
+| `Interact` | Implemented for doors (#504) | 2.7 |
 
 ## CreateEncounter flow
 
@@ -46,6 +48,23 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 3. Load encounter via `h.encRepo.Get`; `ErrNotFound` → `NotFound`.
 4. Authority check — `data.Players[core.PlayerID(playerID)]` lookup; not present → `PermissionDenied`. Mirrors `MoveEntity` exactly.
 5. Build proto response via `ProjectFor(data, viewer, broker, now)`.
+
+## Interact flow (Wave 2.7)
+
+1. Validate auth — `auth.GetPlayerID(ctx)` empty → `Unauthenticated`.
+2. Validate request — `encounter_id` or `target_entity_id` empty → `InvalidArgument`.
+3. Load encounter via `h.encRepo.Get`; `ErrNotFound` → `NotFound`.
+4. Dispatch by target — Wave 2.7 only wires doors. `data.Doors[targetID]` lookup; not present → `NotFound` ("target entity is not a door, or door does not exist").
+5. `encounter.LoadFromData(data, h.broker)` → rehydrate; error → `Internal`.
+6. `enc.OpenDoor(playerID, doorID)` — toolkit publishes `DoorOpenedEvent` plus a parallel `HexRevealedEvent` for any viewer whose vision grew. Toolkit errors (player not in encounter, door already open) → `FailedPrecondition` per `pat-v2-status-code-mapping`.
+7. `h.encRepo.Save(ctx, enc.ToData())` → `Internal` on error.
+8. Return `&InteractResponse{}` (empty — door world changes flow as events). `InputRequired` is reserved for Wave 2.10 locked-door skill checks.
+
+`interaction_kind` is plumbed through the proto for future routing (`examine`, `loot`, `disarm`) but unused in Wave 2.7. Future waves extend the dispatch with chests, levers, NPCs, traps.
+
+### Cause/effect event split
+
+The translator emits BOTH `DoorOpened` and `GeometryRevealed` as separate proto envelopes. The `DoorOpened.revealed_hexes`, `revealed_walls`, `removed_walls` fields are deliberately empty — the parallel `HexRevealedEvent` (translated to `GeometryRevealed`) carries the geometry delta. This mirrors the toolkit's cause/effect decomposition (see `rpg-toolkit/encounter/events/hex_revealed.go` for the rationale). Web composes the visual response from the two envelopes.
 
 ## ProjectFor helper
 

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -318,6 +318,132 @@ func (s *HandlerSuite) TestGetEncounter_Success_ReturnsEncounterWithID() {
 	s.Require().Equal("enc-get-1", resp.GetEncounter().GetId())
 }
 
+// --- Interact (Wave 2.7) -----------------------------------------------------
+
+func (s *HandlerSuite) TestInteract_NoPlayerID_Unauthenticated() {
+	ctx := context.Background() // no auth
+	_, err := s.handler.Interact(ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-1",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unauthenticated, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_EmptyEncounterID_InvalidArgument() {
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_EmptyTargetEntityID_InvalidArgument() {
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-1",
+		TargetEntityId: "",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_MissingEncounter_NotFound() {
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "missing",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_MissingDoorTarget_NotFound() {
+	enc := tkenc.New("enc-no-door", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	// Wave 2.7 only supports door interactions; a target not in data.Doors
+	// must be NotFound (not InvalidArgument — the request was syntactically
+	// fine, the world just doesn't have an interactable target by that id).
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-no-door",
+		TargetEntityId: "not-a-door",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_DoorAlreadyOpen_FailedPrecondition() {
+	enc := tkenc.New("enc-open-door", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	// Pre-seed the door as already open.
+	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, true)
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-open-door",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	// Toolkit OpenDoor refuses an already-open door — state-dependent
+	// failure, FailedPrecondition per pat-v2-status-code-mapping.
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_PlayerNotInEncounter_FailedPrecondition() {
+	// Encounter has a door but no player-A. Toolkit OpenDoor refuses the
+	// player-not-in-encounter case as a state-dependent error.
+	enc := tkenc.New("enc-no-player", s.broker)
+	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, false)
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-no-player",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestInteract_OpenDoor_HappyPath() {
+	enc := tkenc.New("enc-interact-1", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	// Door at adjacent hex so player-A's SightRange:4 can perceive it
+	// (toolkit ProjectDoorOpen requires the viewer to see the door's hex
+	// before publishing a per-viewer slice).
+	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, false)
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	resp, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-interact-1",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp, "response is empty by proto design but must be non-nil")
+	s.Require().Nil(resp.GetInputRequired(), "Wave 2.7 doors don't prompt; InputRequired is for Wave 2.10 locked doors")
+
+	// Verify the door is now open in the persisted data.
+	loaded, err := s.repo.Get(s.ctx, "enc-interact-1")
+	s.Require().NoError(err)
+	s.Require().NotNil(loaded)
+	door, ok := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(ok, "door-east must remain in persisted Doors map")
+	s.Require().True(door.Open, "door-east must be persisted as Open after Interact")
+}
+
 func TestHandlerSuite(t *testing.T) {
 	suite.Run(t, new(HandlerSuite))
 }

--- a/internal/handlers/dnd5e/v2/encounter/interact.go
+++ b/internal/handlers/dnd5e/v2/encounter/interact.go
@@ -1,0 +1,84 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// Interact handles the Interact RPC. Wave 2.7 wires only door interactions:
+// when target_entity_id matches a known door, the toolkit's
+// Encounter.OpenDoor() verb is dispatched. The toolkit publishes the cause
+// event (DoorOpenedEvent) and the parallel effect event (HexRevealedEvent)
+// to the broker for delivery on StreamEncounter.
+//
+// Future waves extend the dispatch to chests, levers, NPCs, and traps; the
+// optional interaction_kind field is plumbed through the proto for that
+// future routing but is unused today.
+//
+// Behavior contract:
+//   - missing auth → Unauthenticated
+//   - empty encounter_id / target_entity_id → InvalidArgument
+//   - encounter not in repo → NotFound
+//   - target is not a known door in this encounter → NotFound
+//   - toolkit OpenDoor refuses (player not in encounter, door already open,
+//     etc.) → FailedPrecondition (per pat-v2-status-code-mapping)
+//   - save failure → Internal
+//
+// The empty InteractResponse is by proto design — door world changes flow as
+// events on StreamEncounter, not as response payload. Future locked-door
+// flow (Wave 2.10) will populate InputRequired for skill-check prompts.
+func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractRequest) (*encounterv2pb.InteractResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+	if req.GetEncounterId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+	if req.GetTargetEntityId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "target_entity_id is required")
+	}
+
+	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "encounter not found")
+		}
+		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	// Wave 2.7 dispatch: only door interactions are wired. Future waves add
+	// chests, levers, NPCs, traps via additional lookups + dispatch arms.
+	targetID := core.EntityID(req.GetTargetEntityId())
+	if _, ok := data.Doors[targetID]; !ok {
+		return nil, status.Error(codes.NotFound, "target entity is not a door, or door does not exist")
+	}
+
+	enc, err := encounter.LoadFromData(data, h.broker)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
+	}
+
+	if err := enc.OpenDoor(core.PlayerID(playerID), targetID); err != nil {
+		// Toolkit OpenDoor errors are state-dependent (player not in
+		// encounter, door already open) — these are gRPC FailedPrecondition
+		// per pat-v2-status-code-mapping. The request is syntactically
+		// valid but the world state forbids the action.
+		return nil, status.Errorf(codes.FailedPrecondition, "open door: %v", err)
+	}
+
+	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
+		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	return &encounterv2pb.InteractResponse{}, nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -47,6 +47,8 @@ func TranslateEvent(evt events.EncounterEvent, viewer core.PlayerID, now time.Ti
 		return translateEntityAppearedEvent(e, viewer, now)
 	case *events.EntityDisappearedEvent:
 		return translateEntityDisappearedEvent(e, viewer, now)
+	case *events.DoorOpenedEvent:
+		return translateDoorOpenedEvent(e, viewer, now)
 	default:
 		return nil, fmt.Errorf("%w: %T", ErrUnknownEventType, evt)
 	}
@@ -161,6 +163,38 @@ func translateEntityDisappearedEvent(e *events.EntityDisappearedEvent, viewer co
 				EntityId:          string(e.Entity),
 				Reason:            "left LOS",
 				LastKnownPosition: HexToPosition(lastKnown),
+			},
+		},
+	}, nil
+}
+
+// translateDoorOpenedEvent maps the toolkit's DoorOpenedEvent to the
+// v1alpha2 DoorOpened proto envelope. Wave 2.7 deliberately splits the
+// cause/effect events: this envelope carries only the door identity (the
+// "what happened"); the parallel HexRevealedEvent published alongside
+// OpenDoor delivers the geometry deltas through GeometryRevealed (the
+// "what changed"). See rpg-toolkit/encounter/events/hex_revealed.go for
+// the rationale and Wave 2.7 plan for the API-side decision to mirror
+// that split — do NOT combine them here.
+//
+// revealed_walls / removed_walls are left empty: walls are not modeled in
+// the v0.2.0 toolkit. The proto carries them for forward compatibility
+// when the toolkit grows wall geometry.
+func translateDoorOpenedEvent(e *events.DoorOpenedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	slice, ok := e.PerPlayer[viewer]
+	if !ok || !slice.Visible {
+		return nil, ErrViewerSawNothing
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_DoorOpened{
+			DoorOpened: &encounterv2pb.DoorOpened{
+				DoorEntityId: string(e.DoorID),
+				// revealed_hexes / revealed_walls / removed_walls are
+				// intentionally empty: the parallel HexRevealedEvent
+				// (translated to GeometryRevealed) carries the geometry
+				// delta. Cause/effect events stay separate on the wire.
 			},
 		},
 	}, nil

--- a/internal/handlers/dnd5e/v2/encounter/translate_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate_test.go
@@ -176,12 +176,66 @@ func (s *TranslateSuite) TestTranslateEvent_EntityDisappearedEvent_ViewerNotInPe
 }
 
 func (s *TranslateSuite) TestTranslateEvent_UnknownEventTypeReturnsErrUnknownEventType() {
-	// DoorOpenedEvent implements events.EncounterEvent but TranslateEvent has no
-	// mapping for it — exercises the default branch (ErrUnknownEventType).
-	evt := events.NewDoorOpenedEvent("enc-1", uint64(3), "door-1", "char-A", nil)
-	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	// The events.EncounterEvent interface is sealed (unexported marker method);
+	// external packages cannot implement it, so we cannot synthesize a "novel"
+	// concrete type for the default branch. Wave 2.7 mapped DoorOpenedEvent
+	// (the previous unknown-type fixture), so all current concretes route to
+	// real translators. Passing a nil events.EncounterEvent exercises the
+	// default branch — a future toolkit event lacking a translator case will
+	// reproduce this same shape until its case is added.
+	_, err := v2encounter.TranslateEvent(nil, "player-A", s.now)
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, v2encounter.ErrUnknownEventType))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DoorOpenedEvent_HappyPath() {
+	evt := events.NewDoorOpenedEvent(
+		"enc-1", uint64(11), "door-east", "char-alice",
+		map[core.PlayerID]events.DoorOpenedPlayerSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+
+	door := out.GetDoorOpened()
+	s.Require().NotNil(door)
+	s.Require().Equal("door-east", door.GetDoorEntityId())
+	// Cause/effect split: DoorOpened envelope carries only door identity;
+	// HexRevealedEvent translation (GeometryRevealed) carries the geometry
+	// delta as a parallel event. revealed_hexes / revealed_walls /
+	// removed_walls must be empty here.
+	s.Require().Empty(door.GetRevealedHexes(), "revealed_hexes belongs on the parallel GeometryRevealed event")
+	s.Require().Empty(door.GetRevealedWalls(), "revealed_walls deferred — not modeled in v0.2.0")
+	s.Require().Empty(door.GetRemovedWalls(), "removed_walls deferred — not modeled in v0.2.0")
+	s.Require().Equal(int64(11), out.Sequence)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DoorOpenedEvent_NotVisible_ReturnsErrViewerSawNothing() {
+	evt := events.NewDoorOpenedEvent(
+		"enc-1", uint64(11), "door-east", "char-alice",
+		map[core.PlayerID]events.DoorOpenedPlayerSlice{
+			// Defensive: even if the toolkit changed to populate Visible:false
+			// for non-visible viewers, the translator must skip them.
+			"player-A": {Visible: false},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DoorOpenedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewDoorOpenedEvent(
+		"enc-1", uint64(11), "door-east", "char-alice",
+		map[core.PlayerID]events.DoorOpenedPlayerSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-X", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
 }
 
 // TestTranslateSnapshot_EmptyEncounter verifies that TranslateSnapshot with a

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -524,6 +524,120 @@ func (s *EncounterV2IntegrationSuite) TestStreamEncounter_LiveEventsDoNotDuplica
 		"live stream must not re-emit EntityAppeared for bob who was already visible from replay")
 }
 
+// TestInteract_OpenDoor_TwoPlayers exercises the Wave 2.7 OpenDoor flow
+// end-to-end through the v2 service. Two players in mutual LoS see a closed
+// door; alice opens it via Interact; both streams receive the cause event
+// (DoorOpened) and the parallel effect event (GeometryRevealed) for any
+// newly-revealed hexes around the door.
+//
+// Mirrors the toolkit's TestSlice_OpenDoor fixture (rpg-toolkit/encounter
+// integration_test.go:71) so the projection layer is exercised against the
+// same shape that the toolkit-level test proved.
+func (s *EncounterV2IntegrationSuite) TestInteract_OpenDoor_TwoPlayers() {
+	enc := tkenc.New("enc-door-1", s.srv.BrokerV2)
+	// SightRange:10 ensures both alice and bob can perceive a door at
+	// distance 4 (per ProjectDoorOpen's visibility check).
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: -1, S: 0}, SightRange: 10,
+	}))
+	enc.AddDoor("door-east", core.Hex{Q: 4, R: 0, S: -4}, false)
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	ctxA := s.authCtx("alice")
+	ctxB := s.authCtx("bob")
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxA, &encounterv2pb.StreamEncounterRequest{EncounterId: "enc-door-1"})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxB, &encounterv2pb.StreamEncounterRequest{EncounterId: "enc-door-1"})
+	s.Require().NoError(err)
+
+	// Drain the snapshot + replay events on each stream before firing Interact.
+	// Replay shape per pat-v2-snapshot-replay-builder-pair: SnapshotDelivered +
+	// EntityAppeared per visible entity + GeometryRevealed for revealed hexes.
+	// Two visible entities (alice + bob) = 4 events total per stream.
+	for i := 0; i < 4; i++ {
+		_, recvErr := streamA.Recv()
+		s.Require().NoError(recvErr, "alice replay event %d", i+1)
+		_, recvErr = streamB.Recv()
+		s.Require().NoError(recvErr, "bob replay event %d", i+1)
+	}
+
+	// Alice opens the door.
+	resp, err := s.srv.EncounterClientV2.Interact(ctxA, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-door-1",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Nil(resp.GetInputRequired(), "Wave 2.7 doors do not prompt for input")
+
+	// Both alice and bob must see the DoorOpened event (toolkit emits a
+	// per-viewer slice for every player that can see the door's hex). The
+	// HexRevealedEvent rides as a parallel envelope (GeometryRevealed) — we
+	// don't require its arrival here because some viewers may already have
+	// seen the door's neighbors and have an empty reveal slice. Cause is
+	// load-bearing; effect is opportunistic per viewer.
+	postA := s.collectStreamEvents(streamA, 3, 500*time.Millisecond)
+	postB := s.collectStreamEvents(streamB, 3, 500*time.Millisecond)
+
+	var aDoor *encounterv2pb.DoorOpened
+	for _, ev := range postA {
+		if d := ev.GetDoorOpened(); d != nil {
+			aDoor = d
+			break
+		}
+	}
+	s.Require().NotNil(aDoor, "alice should receive DoorOpened (she opened it)")
+	s.Require().Equal("door-east", aDoor.GetDoorEntityId())
+	// Cause/effect split: revealed_hexes/walls ride on the parallel
+	// GeometryRevealed event, NOT on this envelope.
+	s.Require().Empty(aDoor.GetRevealedHexes(), "revealed_hexes belongs on the parallel GeometryRevealed event, not DoorOpened")
+
+	var bDoor *encounterv2pb.DoorOpened
+	for _, ev := range postB {
+		if d := ev.GetDoorOpened(); d != nil {
+			bDoor = d
+			break
+		}
+	}
+	s.Require().NotNil(bDoor, "bob should receive DoorOpened (door is in his LoS)")
+	s.Require().Equal("door-east", bDoor.GetDoorEntityId())
+	s.Require().Empty(bDoor.GetRevealedHexes(), "revealed_hexes belongs on the parallel GeometryRevealed event, not DoorOpened")
+
+	// Confirm the door is persisted as open after Interact.
+	persisted, err := s.srv.EncRepoV2.Get(s.ctx, "enc-door-1")
+	s.Require().NoError(err)
+	s.Require().True(persisted.Doors[core.EntityID("door-east")].Open, "door must be persisted Open after Interact")
+}
+
+// TestInteract_DoorAlreadyOpen_FailedPrecondition mirrors the unit test at
+// the integration level: a second Interact on an already-open door must be
+// rejected by the toolkit with FailedPrecondition.
+func (s *EncounterV2IntegrationSuite) TestInteract_DoorAlreadyOpen_FailedPrecondition() {
+	enc := tkenc.New("enc-door-twice", s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, true) // pre-open
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	ctxA := s.authCtx("alice")
+	_, err := s.srv.EncounterClientV2.Interact(ctxA, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-door-twice",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
 func TestEncounterV2IntegrationSuite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -609,10 +609,14 @@ func (s *EncounterV2IntegrationSuite) TestInteract_OpenDoor_TwoPlayers() {
 	s.Require().Equal("door-east", bDoor.GetDoorEntityId())
 	s.Require().Empty(bDoor.GetRevealedHexes(), "revealed_hexes belongs on the parallel GeometryRevealed event, not DoorOpened")
 
-	// Confirm the door is persisted as open after Interact.
+	// Confirm the door is persisted as open after Interact. Use the ok-check
+	// pattern so a missing entry is distinguishable from a closed door (and
+	// so this won't panic if the map value type ever becomes a pointer).
 	persisted, err := s.srv.EncRepoV2.Get(s.ctx, "enc-door-1")
 	s.Require().NoError(err)
-	s.Require().True(persisted.Doors[core.EntityID("door-east")].Open, "door must be persisted Open after Interact")
+	door, ok := persisted.Doors[core.EntityID("door-east")]
+	s.Require().True(ok, "door-east should be in persisted.Doors")
+	s.Require().True(door.Open, "door must be persisted Open after Interact")
 }
 
 // TestInteract_DoorAlreadyOpen_FailedPrecondition mirrors the unit test at


### PR DESCRIPTION
## Summary

- Implement `Interact` v2 RPC end-to-end for door interactions (Wave 2.7 on board #11)
- Extend translator with `*events.DoorOpenedEvent` case → `EncounterEvent_DoorOpened` envelope
- Preserve the cause/effect event split: `DoorOpened` carries only door identity; geometry deltas ride on the parallel `HexRevealedEvent` (translated to `GeometryRevealed`) — do NOT combine them
- Update `docs/architecture/components/encounter.md` with the new RPC + flow

Closes #504. Pairs with rpg-dnd5e-web#392 (parallel web consumer).

## Behavior

- `auth.GetPlayerID(ctx)` empty → `Unauthenticated`
- `encounter_id` or `target_entity_id` empty → `InvalidArgument`
- Encounter not in repo → `NotFound`
- Target not a known door in `data.Doors` → `NotFound` ("target entity is not a door, or door does not exist")
- Toolkit `OpenDoor` refuses (player not in encounter, door already open) → `FailedPrecondition` per `pat-v2-status-code-mapping`
- Save failure → `Internal`
- Success → empty `InteractResponse{}` (door world changes flow as events on `StreamEncounter`; `InputRequired` reserved for Wave 2.10 locked-door skill checks)

`interaction_kind` is plumbed through but unused in Wave 2.7 — future waves extend the dispatch with chests, levers, NPCs, traps.

## Cause/effect event split

The translator emits BOTH `DoorOpened` and `GeometryRevealed` as separate proto envelopes. `DoorOpened.revealed_hexes`, `revealed_walls`, `removed_walls` are deliberately empty — the parallel `HexRevealedEvent` (translated to `GeometryRevealed`) carries the geometry delta. This mirrors the toolkit's cause/effect decomposition (`rpg-toolkit/encounter/events/hex_revealed.go`) and the Wave 2.7 plan.

## Test plan

- [x] Unit handler: `TestInteract_NoPlayerID_Unauthenticated`, `TestInteract_EmptyEncounterID_InvalidArgument`, `TestInteract_EmptyTargetEntityID_InvalidArgument`, `TestInteract_MissingEncounter_NotFound`, `TestInteract_MissingDoorTarget_NotFound`, `TestInteract_DoorAlreadyOpen_FailedPrecondition`, `TestInteract_PlayerNotInEncounter_FailedPrecondition`, `TestInteract_OpenDoor_HappyPath`
- [x] Translator: `TestTranslateEvent_DoorOpenedEvent_HappyPath`, `TestTranslateEvent_DoorOpenedEvent_NotVisible_ReturnsErrViewerSawNothing`, `TestTranslateEvent_DoorOpenedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing`
- [x] Integration (bufconn): `TestInteract_OpenDoor_TwoPlayers` (mirrors toolkit's `TestSlice_OpenDoor` fixture — alice + bob mutual LoS; alice opens; both streams receive `DoorOpened`; door persisted as open) + `TestInteract_DoorAlreadyOpen_FailedPrecondition`
- [x] Full `TestEncounterV2IntegrationSuite` passes (no regression)
- [x] `golangci-lint run ./internal/handlers/dnd5e/v2/encounter/...` → 0 issues
- [x] Unit + translator tests pass on `make test`

## Drive-by

- The pre-existing `TestTranslateEvent_UnknownEventTypeReturnsErrUnknownEventType` fixture used `DoorOpenedEvent` as its "unknown" stand-in. Wave 2.7 maps `DoorOpenedEvent`, so the test now passes a `nil` `events.EncounterEvent` to exercise the default branch (the interface is sealed; external packages can't synthesize a novel concrete type).

## Reviewer notes

- Toolkit's `ProjectDoorOpen` only adds a `PerPlayer` entry when the viewer can see the door's hex — so `Visible: false` is unreachable in current toolkit code, but the translator checks it defensively per the issue brief.
- Integration test drains exactly 4 replay events per stream (snapshot + 2 EntityAppeared + 1 GeometryRevealed) before firing Interact. If a future PR changes the replay shape, this needs updating.
- `revealed_walls` / `removed_walls` are empty: the v0.2.0 toolkit doesn't model walls. Forward-compatible — the proto fields are populated when the toolkit grows wall geometry.

## Out of scope

- `DoorClosed` event / closing doors (not required for Wave 2.7 goal)
- Locked doors with skill-check prompts (Wave 2.10)
- `Interact` for chests, levers, NPCs, traps (Wave 2.10 — same RPC, different dispatch arms)
- Web consumer (rpg-dnd5e-web#392, parallel)
- Snapshot replay of door state on reconnect (covered by Wave 2.6 #497 if door state lands in `SnapshotFor`; if not, file a followup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)