### PR TITLE
feat(encounter/v2): TakeAction + EndTurn handlers + NPC dispatch loop + combat translator (#505)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260507051118-0443dec90664
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.2.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.3.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.55.5
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.2.0 h1:bKFFL0pjBsMTSXWEkFPAhKZahd43jKyCouhDeXo3Jjg=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.2.0/go.mod h1:9l7Dhs+qi1HF4ussqJhkEoZyOTQMFGTBXVM4wStQYy4=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.3.0 h1:RpYY7Dl78TAZ7EH+/O9hMk0o7zyWKaXXNU15frYWQqA=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.3.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -48,8 +48,9 @@ func (s *HandlerSuite) seedCombatEncounter() {
 	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
 }
 
-// makeAttackTargetMonster constructs the standard "alice attacks goblin-1"
-// request body. Tests override fields as needed.
+// makeAttackRequest constructs the standard "alice attacks goblin-1" attack
+// request body, parameterized so tests can swap actor/target ids. The
+// action_ref is hardwired to the wave-2.8 supported {dnd5e:action:attack}.
 func makeAttackRequest(actorEntityID, targetEntityID string) *encounterv2pb.TakeActionRequest {
 	return &encounterv2pb.TakeActionRequest{
 		EncounterId:   combatEncID,

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -1,0 +1,484 @@
+package encounter_test
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// Test fixture identifiers shared across the combat handler tests.
+const (
+	combatEncID    = "enc-combat"
+	playerAliceID  = "alice"
+	entityAliceID  = "char-alice"
+	playerBobID    = "bob"
+	entityBobID    = "char-bob"
+	monsterGoblin1 = "goblin-1"
+)
+
+// seedCombatEncounter builds a deterministic two-player + one-monster fixture
+// in TURN_BASED mode and persists it through the suite's repo. Returns the
+// loaded data so callers can inspect Initiative ordering for tests that need
+// to know whose turn is active first.
+func (s *HandlerSuite) seedCombatEncounter() {
+	enc := tkenc.New(combatEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: playerAliceID, EntityID: entityAliceID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4, DamageDice: "1d8+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: playerBobID, EntityID: entityBobID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 10, MaxHP: 10, AC: 13, AttackBonus: 3, DamageDice: "1d6+1", DamageType: "piercing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: monsterGoblin1, Position: core.Hex{Q: 2, R: -1, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+}
+
+// makeAttackTargetMonster constructs the standard "alice attacks goblin-1"
+// request body. Tests override fields as needed.
+func makeAttackRequest(actorEntityID, targetEntityID string) *encounterv2pb.TakeActionRequest {
+	return &encounterv2pb.TakeActionRequest{
+		EncounterId:   combatEncID,
+		ActorEntityId: actorEntityID,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: targetEntityID},
+		},
+	}
+}
+
+// activeEntityID returns the entity id of the currently active actor in the
+// seeded encounter — handy for tests that need to dispatch TakeAction /
+// EndTurn against whichever side initiative landed on.
+func (s *HandlerSuite) activeEntityID() core.EntityID {
+	data, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(data.Initiative, "initiative must be rolled before reading active actor")
+	return data.Initiative[data.ActiveIdx]
+}
+
+// activePlayerCtx returns an auth context for whichever player owns the
+// active entity. Returns nil if the active entity is the monster.
+func (s *HandlerSuite) activePlayerCtx() context.Context {
+	id := s.activeEntityID()
+	switch string(id) {
+	case entityAliceID:
+		return contextWithPlayer(s.ctx, playerAliceID)
+	case entityBobID:
+		return contextWithPlayer(s.ctx, playerBobID)
+	}
+	return nil
+}
+
+// contextWithPlayer wraps the suite's context with a different auth player.
+// The suite's s.ctx already carries player-A; this lets tests authenticate
+// as a different player without rebuilding the entire context chain.
+func contextWithPlayer(parent context.Context, player string) context.Context {
+	return auth.WithPlayerID(parent, player)
+}
+
+// advanceToActivePlayer ends NPC turns until a player is active. With the
+// 3-combatant fixture (alice, bob, goblin) at most one EndTurn-the-NPC step
+// is needed. Reads the current encounter state to decide; calls EndTurn via
+// the handler so the NPC dispatch loop fires (which does the right thing).
+//
+// In practice the seed fixture's deterministic initiative order (sorted by
+// rolled d20 desc, ties by id asc) plus the test's fixed roller means the
+// first active actor is one of the three deterministically. If the goblin
+// is first, this method dispatches EndTurn from one of the player contexts
+// — but EndTurn's auth check requires the calling player owns the active
+// entity, so when the goblin is active we can't EndTurn it from a player.
+// Instead, this method finds the player adjacent in initiative order who
+// would be active after the goblin, simulates that path by directly invoking
+// the toolkit's EndTurn (which the orchestrator's loop would also do
+// server-side), and persists.
+func (s *HandlerSuite) advanceToActivePlayer() {
+	for {
+		data, err := s.repo.Get(s.ctx, combatEncID)
+		s.Require().NoError(err)
+		active := data.Initiative[data.ActiveIdx]
+		if _, isPlayer := s.findPlayerByEntity(data, active); isPlayer {
+			return
+		}
+		// Active is goblin — load, advance via toolkit (NPCAct + EndTurn) and
+		// save. We bypass the handler here because the handler's EndTurn auth
+		// check requires the caller's controlled entity = active actor; the
+		// goblin has no controlling player.
+		enc, err := tkenc.LoadFromData(data, s.broker)
+		s.Require().NoError(err)
+		s.Require().NoError(enc.NPCAct(s.ctx, active))
+		_, _, err = enc.EndTurn(active)
+		s.Require().NoError(err)
+		s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+	}
+}
+
+// findPlayerByEntity scans data.Players for the entry whose EntityID matches
+// entityID. Returns (PlayerID, true) on match, ("", false) otherwise.
+func (s *HandlerSuite) findPlayerByEntity(data *tkenc.Data, entityID core.EntityID) (core.PlayerID, bool) {
+	for pid, pd := range data.Players {
+		if pd.EntityID == entityID {
+			return pid, true
+		}
+	}
+	return "", false
+}
+
+// TakeAction tests --------------------------------------------------------
+
+func (s *HandlerSuite) TestTakeAction_NoAuth_Unauthenticated() {
+	ctx := context.Background()
+	_, err := s.handler.TakeAction(ctx, makeAttackRequest(entityAliceID, monsterGoblin1))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unauthenticated, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_EmptyEncounterID_InvalidArgument() {
+	req := makeAttackRequest(entityAliceID, monsterGoblin1)
+	req.EncounterId = ""
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_EmptyActorEntityID_InvalidArgument() {
+	req := makeAttackRequest("", monsterGoblin1)
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_NilActionRef_InvalidArgument() {
+	req := makeAttackRequest(entityAliceID, monsterGoblin1)
+	req.ActionRef = nil
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_NilTarget_InvalidArgument() {
+	req := makeAttackRequest(entityAliceID, monsterGoblin1)
+	req.Target = nil
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_TargetMissingKind_InvalidArgument() {
+	req := makeAttackRequest(entityAliceID, monsterGoblin1)
+	req.Target = &encounterv2pb.ActionTarget{} // no oneof set
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_MissingEncounter_NotFound() {
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	req := makeAttackRequest(entityAliceID, monsterGoblin1)
+	req.EncounterId = "does-not-exist"
+	_, err := s.handler.TakeAction(ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_PlayerNotInEncounter_PermissionDenied() {
+	s.seedCombatEncounter()
+	ctx := contextWithPlayer(s.ctx, "interloper")
+	_, err := s.handler.TakeAction(ctx, makeAttackRequest(entityAliceID, monsterGoblin1))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_ActorIDMismatch_PermissionDenied() {
+	s.seedCombatEncounter()
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	// alice's controlled entity is char-alice; she can't direct char-bob.
+	_, err := s.handler.TakeAction(ctx, makeAttackRequest(entityBobID, monsterGoblin1))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_NotTurnBased_FailedPrecondition() {
+	// Seed a free-roam encounter (no SetMode). The toolkit's combat verb
+	// returns ErrNotTurnBased which the handler maps to FailedPrecondition.
+	enc := tkenc.New(combatEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: playerAliceID, EntityID: entityAliceID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4, DamageDice: "1d8+2",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: monsterGoblin1, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6, MonsterRef: "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: "1d6+2",
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	_, err := s.handler.TakeAction(ctx, makeAttackRequest(entityAliceID, monsterGoblin1))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_NotYourTurn_FailedPrecondition() {
+	s.seedCombatEncounter()
+	// Whichever player is NOT active tries to attack. Initiative is rolled
+	// deterministically for the ID order so we read from data and pick the
+	// non-active player's context.
+	active := s.activeEntityID()
+	var idleCtx context.Context
+	var idleEntity string
+	switch string(active) {
+	case entityAliceID:
+		idleCtx = contextWithPlayer(s.ctx, playerBobID)
+		idleEntity = entityBobID
+	case entityBobID:
+		idleCtx = contextWithPlayer(s.ctx, playerAliceID)
+		idleEntity = entityAliceID
+	default:
+		// Goblin is active first — both players are off-turn. Use alice.
+		idleCtx = contextWithPlayer(s.ctx, playerAliceID)
+		idleEntity = entityAliceID
+	}
+	_, err := s.handler.TakeAction(idleCtx, makeAttackRequest(idleEntity, monsterGoblin1))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_UnknownTarget_FailedPrecondition() {
+	s.seedCombatEncounter()
+	// EndTurn until a player is active.
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	actorEntity := s.activeEntityID()
+	_, err := s.handler.TakeAction(ctx, makeAttackRequest(string(actorEntity), "ghost-monster"))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_UnsupportedAction_Unimplemented() {
+	s.seedCombatEncounter()
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	actorEntity := s.activeEntityID()
+	req := makeAttackRequest(string(actorEntity), monsterGoblin1)
+	req.ActionRef = &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "fireball"}
+	_, err := s.handler.TakeAction(ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unimplemented, st.Code())
+}
+
+func (s *HandlerSuite) TestTakeAction_AttackHappyPath_PersistsMonsterHP() {
+	s.seedCombatEncounter()
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	actorEntity := s.activeEntityID()
+
+	// Snapshot goblin HP before.
+	preData, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	preHP := preData.Monsters[monsterGoblin1].HP
+
+	resp, err := s.handler.TakeAction(ctx, makeAttackRequest(string(actorEntity), monsterGoblin1))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// Reload — toolkit may or may not have hit (random d20). The contract is
+	// that the encounter is saved post-attack. HP <= preHP regardless of
+	// hit/miss; on hit it's strictly less.
+	postData, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	s.Require().LessOrEqual(postData.Monsters[monsterGoblin1].HP, preHP,
+		"goblin HP must not increase after attack")
+}
+
+// EndTurn tests -----------------------------------------------------------
+
+func (s *HandlerSuite) TestEndTurn_NoAuth_Unauthenticated() {
+	ctx := context.Background()
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: entityAliceID,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unauthenticated, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_EmptyEncounterID_InvalidArgument() {
+	_, err := s.handler.EndTurn(s.ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: "", EntityId: entityAliceID,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_EmptyEntityID_InvalidArgument() {
+	_, err := s.handler.EndTurn(s.ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: "",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_MissingEncounter_NotFound() {
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: "does-not-exist", EntityId: entityAliceID,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_PlayerNotInEncounter_PermissionDenied() {
+	s.seedCombatEncounter()
+	ctx := contextWithPlayer(s.ctx, "interloper")
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: entityAliceID,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_EntityIDMismatch_PermissionDenied() {
+	s.seedCombatEncounter()
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: entityBobID,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_NotTurnBased_FailedPrecondition() {
+	// Seed FreeRoam — EndTurn requires TURN_BASED.
+	enc := tkenc.New(combatEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: playerAliceID, EntityID: entityAliceID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: entityAliceID,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_NotYourTurn_FailedPrecondition() {
+	s.seedCombatEncounter()
+	active := s.activeEntityID()
+	// Pick the non-active player and try to end their turn.
+	var idleCtx context.Context
+	var idleEntity string
+	switch string(active) {
+	case entityAliceID:
+		idleCtx = contextWithPlayer(s.ctx, playerBobID)
+		idleEntity = entityBobID
+	default:
+		idleCtx = contextWithPlayer(s.ctx, playerAliceID)
+		idleEntity = entityAliceID
+	}
+	_, err := s.handler.EndTurn(idleCtx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: idleEntity,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestEndTurn_HappyPath_AdvancesInitiative() {
+	s.seedCombatEncounter()
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	actorEntity := s.activeEntityID()
+
+	preData, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	preIdx := preData.ActiveIdx
+
+	_, err = s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: string(actorEntity),
+	})
+	s.Require().NoError(err)
+
+	postData, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	// Initiative advanced. Either ActiveIdx incremented or it wrapped to 0
+	// (and Round incremented), AND the active actor is no longer actorEntity
+	// (or it cycled all the way back through NPC turns and an NPC dispatch
+	// loop brought us back to the same player — but with our 3-combatant
+	// fixture that shouldn't happen in one EndTurn call).
+	if preIdx+1 < len(preData.Initiative) {
+		s.Require().NotEqual(preIdx, postData.ActiveIdx, "ActiveIdx must advance")
+	}
+}
+
+// TestEndTurn_NPCDispatchLoop_RunsNPCTurnAutomatically verifies the
+// orchestrator-side NPC dispatch loop: when EndTurn cycles to an NPC, the
+// handler calls NPCAct and EndTurn-the-NPC server-side until the next
+// active actor is a player. Verified by: after the first player ends turn,
+// the saved data shows initiative has cycled past the goblin and the next
+// active actor is a player (not the goblin), AND the goblin's HP was
+// affected if the player attacked it OR a player's HP was affected by the
+// goblin's NPCAct attack.
+func (s *HandlerSuite) TestEndTurn_NPCDispatchLoop_CyclesPastNPC() {
+	s.seedCombatEncounter()
+
+	// Walk through initiative until a player is active. Then end that
+	// player's turn — if the next combatant in initiative is the goblin,
+	// the NPC dispatch loop should fire NPCAct and advance past the goblin.
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	actorEntity := s.activeEntityID()
+
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: string(actorEntity),
+	})
+	s.Require().NoError(err)
+
+	postData, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	postActive := postData.Initiative[postData.ActiveIdx]
+
+	// If the goblin was next in initiative, the dispatch loop ran NPCAct +
+	// EndTurn-the-goblin, so the post-state active actor is NOT the goblin.
+	// Either way (goblin was next-and-cycled or goblin was elsewhere), the
+	// post-state active actor must be a player.
+	_, postIsPlayer := s.findPlayerByEntity(postData, postActive)
+	s.Require().True(postIsPlayer, "after EndTurn, active actor must be a player (not goblin)")
+}

--- a/internal/handlers/dnd5e/v2/encounter/create.go
+++ b/internal/handlers/dnd5e/v2/encounter/create.go
@@ -25,14 +25,17 @@ func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.Create
 	if req.GetCampaignId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "campaign_id is required")
 	}
-	// Wave 2.6 only supports FREE_ROAM. UNSPECIFIED is treated as FREE_ROAM
-	// for forward compatibility with older clients. TURN_BASED lands in Wave 2.8.
+	// Wave 2.6 supported FREE_ROAM only. Wave 2.8 adds TURN_BASED via the
+	// toolkit's Encounter.SetMode verb, which rolls initiative on flip.
+	// UNSPECIFIED is treated as FREE_ROAM for forward compatibility with
+	// older clients.
 	switch req.GetInitialMode() {
 	case encounterv2pb.EncounterMode_ENCOUNTER_MODE_UNSPECIFIED,
-		encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM:
+		encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
+		encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED:
 	default:
 		return nil, status.Errorf(codes.InvalidArgument,
-			"initial_mode %s is not supported (only FREE_ROAM is implemented)",
+			"initial_mode %s is not a recognized mode",
 			req.GetInitialMode())
 	}
 
@@ -48,6 +51,17 @@ func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.Create
 		Position: core.Hex{Q: 0, R: 0, S: 0},
 	}); err != nil {
 		return nil, status.Errorf(codes.Internal, "add creator to encounter: %v", err)
+	}
+
+	// Flip into TURN_BASED if requested. Mode flip publishes ModeChangedEvent +
+	// initial TurnStartedEvent, but no subscribers exist at construction time so
+	// these are dropped (the broker is fanout-only; events fire iff a viewer is
+	// subscribed). Subsequent connect-time ProjectFor reads Mode/Initiative from
+	// data so client state is correct on first stream.
+	if req.GetInitialMode() == encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED {
+		if err := enc.SetMode(core.ModeTurnBased); err != nil {
+			return nil, status.Errorf(codes.Internal, "set turn-based mode: %v", err)
+		}
 	}
 
 	data := enc.ToData()

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -14,11 +14,25 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// maxNPCChainDepth caps the NPC dispatch loop to avoid runaway cycles when
-// initiative is unexpectedly all-NPCs (shouldn't happen with at least one
-// player, but defensive). After hitting the cap, the handler stops the loop
-// and returns; the next manual EndTurn from any player picks up.
-const maxNPCChainDepth = 16
+// npcChainSafetyMargin is added to the initiative roster size to derive the
+// per-call NPC dispatch cap. The cap (initiative_len + margin) lets the loop
+// cycle past every combatant once and absorb a few extra rounds of pure-NPC
+// initiative without deadlocking, while still bounding the worst case.
+//
+// Why "len(Initiative) + margin" instead of a fixed value: with a fixed cap
+// of N, an all-NPC encounter (initiative larger than N — degenerate but
+// possible if a future scenario seeds 20 monsters and 0 players) would exit
+// the loop with an NPC still active. Since EndTurn requires a player-owned
+// entity_id, the RPC would deadlock — players couldn't progress past the
+// NPC chain.
+//
+// With the size-derived cap, the loop is guaranteed to either reach a player
+// or exhaust the entire roster (in which case the encounter genuinely has no
+// players and the deadlock is the encounter's own design, not the handler's).
+// We still surface a defensive error if the cap is hit while isNPC is true
+// (see the post-loop check below) so operators can spot misconfigured
+// encounters rather than seeing them silently freeze.
+const npcChainSafetyMargin = 4
 
 // EndTurn ends the active actor's turn, advances initiative, and — when the
 // new active actor is an NPC — dispatches the toolkit's NPCAct verb on
@@ -78,9 +92,10 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 
 	// NPC dispatch loop. After the toolkit's EndTurn advances initiative, if
 	// the new active actor is an NPC the handler runs its turn server-side
-	// and ends it, then re-checks. The cap protects against the pathological
-	// all-NPC initiative case.
-	for depth := 0; isNPC && depth < maxNPCChainDepth; depth++ {
+	// and ends it, then re-checks. The cap is initiative-size + margin so an
+	// all-NPC roster cycles all the way through rather than freezing the RPC.
+	npcChainCap := len(data.Initiative) + npcChainSafetyMargin
+	for depth := 0; isNPC && depth < npcChainCap; depth++ {
 		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
 			// NPCAct errors are surfaced as Internal — they indicate either a
 			// rehydration / bus / publish failure (system-shaped) or an
@@ -98,6 +113,22 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 		if endErr != nil {
 			return nil, endTurnStatusError(endErr)
 		}
+	}
+
+	// Defensive: if the cap was reached while isNPC is still true, the
+	// encounter has more consecutive NPCs than the cap allows. Save what we
+	// have and surface FailedPrecondition so the caller (and any operator
+	// watching logs) sees the misconfiguration rather than a silent freeze.
+	// This shouldn't happen with valid encounter setups; the cap-by-roster
+	// math above guarantees the loop reaches a player whenever one exists.
+	if isNPC {
+		if saveErr := h.encRepo.Save(ctx, enc.ToData()); saveErr != nil {
+			return nil, status.Errorf(codes.Internal,
+				"npc dispatch loop exhausted and save failed: %v", saveErr)
+		}
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"npc dispatch loop exhausted with NPC %q still active; encounter may have no players in initiative",
+			string(newActive))
 	}
 
 	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -1,0 +1,123 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// maxNPCChainDepth caps the NPC dispatch loop to avoid runaway cycles when
+// initiative is unexpectedly all-NPCs (shouldn't happen with at least one
+// player, but defensive). After hitting the cap, the handler stops the loop
+// and returns; the next manual EndTurn from any player picks up.
+const maxNPCChainDepth = 16
+
+// EndTurn ends the active actor's turn, advances initiative, and — when the
+// new active actor is an NPC — dispatches the toolkit's NPCAct verb on
+// behalf of the server. The NPC dispatch loop continues cycling through any
+// chain of consecutive NPC turns until the active actor is a player or the
+// chain depth cap is reached.
+//
+// This is the orchestrator-side half of pat-v2-npc-turn-dispatch: the
+// toolkit's EndTurn returns (newActiveID, isNPC, err) so the handler knows
+// whether to call NPCAct without re-querying state. After NPCAct returns,
+// the handler must call EndTurn again to advance the NPC's turn — NPCAct
+// itself is single-purpose (resolve the NPC's action) and does not touch
+// turn state.
+//
+// Mode-gating, turn-violation, no-combatants errors are surfaced by the
+// toolkit and mapped per pat-v2-status-code-mapping.
+func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest) (*encounterv2pb.EndTurnResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+	if req.GetEncounterId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+	if req.GetEntityId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "entity_id is required")
+	}
+
+	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "encounter not found")
+		}
+		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	// Caller must be in the encounter and the entity_id must be the caller's
+	// controlled entity (you can't end someone else's turn). The toolkit
+	// also enforces "is the active actor" via ErrNotYourTurn.
+	pd, ok := data.Players[core.PlayerID(playerID)]
+	if !ok {
+		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
+	}
+	if string(pd.EntityID) != req.GetEntityId() {
+		return nil, status.Error(codes.PermissionDenied, "entity_id does not match player's controlled entity")
+	}
+
+	enc, err := tkenc.LoadFromData(data, h.broker)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
+	}
+
+	newActive, isNPC, err := enc.EndTurn(core.EntityID(req.GetEntityId()))
+	if err != nil {
+		return nil, endTurnStatusError(err)
+	}
+
+	// NPC dispatch loop. After the toolkit's EndTurn advances initiative, if
+	// the new active actor is an NPC the handler runs its turn server-side
+	// and ends it, then re-checks. The cap protects against the pathological
+	// all-NPC initiative case.
+	for depth := 0; isNPC && depth < maxNPCChainDepth; depth++ {
+		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
+			// NPCAct errors are surfaced as Internal — they indicate either a
+			// rehydration / bus / publish failure (system-shaped) or an
+			// unexpected state mismatch. Save what state we have first so the
+			// player isn't stuck on the NPC's turn forever; the next manual
+			// EndTurn picks up.
+			if saveErr := h.encRepo.Save(ctx, enc.ToData()); saveErr != nil {
+				return nil, status.Errorf(codes.Internal,
+					"npc act failed (%v) and save failed (%v)", actErr, saveErr)
+			}
+			return nil, status.Errorf(codes.Internal, "npc act %q: %v", string(newActive), actErr)
+		}
+		var endErr error
+		newActive, isNPC, endErr = enc.EndTurn(newActive)
+		if endErr != nil {
+			return nil, endTurnStatusError(endErr)
+		}
+	}
+
+	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
+		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	return &encounterv2pb.EndTurnResponse{}, nil
+}
+
+// endTurnStatusError maps toolkit EndTurn sentinel errors onto gRPC status
+// codes. All EndTurn errors are state-dependent → FailedPrecondition,
+// except wrapping/internal failures which surface as Internal.
+func endTurnStatusError(err error) error {
+	switch {
+	case errors.Is(err, tkenc.ErrNotTurnBased):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrNotYourTurn):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrNoCombatants):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	}
+	return status.Errorf(codes.Internal, "end turn: %v", err)
+}

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -185,6 +185,10 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 			switch {
 			case errors.Is(translateErr, ErrViewerSawNothing):
 				continue
+			case errors.Is(translateErr, ErrEventSuppressed):
+				// Translator deliberately drops this event — no wire shape,
+				// expected behavior. Continue without log or send.
+				continue
 			case errors.Is(translateErr, ErrUnknownEventType):
 				// Translator has no mapping for this event type — log so
 				// the gap shows up in production rather than silently

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -73,14 +73,23 @@ func (s *HandlerSuite) TestCreateEncounter_EmptyCampaignID_InvalidArgument() {
 	s.Require().Equal(codes.InvalidArgument, st.Code())
 }
 
-func (s *HandlerSuite) TestCreateEncounter_TurnBasedMode_InvalidArgument() {
-	_, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
+func (s *HandlerSuite) TestCreateEncounter_TurnBasedMode_RollsInitiative() {
+	// Wave 2.8 enables TURN_BASED on create. The handler delegates to the
+	// toolkit's SetMode verb which rolls initiative across the encounter's
+	// players + monsters. With only the creator seated, initiative contains
+	// exactly one entry and the encounter saves with Mode = ModeTurnBased.
+	resp, err := s.handler.CreateEncounter(s.ctx, &encounterv2pb.CreateEncounterRequest{
 		CampaignId:  "campaign-1",
 		InitialMode: encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED,
 	})
-	s.Require().Error(err)
-	st, _ := status.FromError(err)
-	s.Require().Equal(codes.InvalidArgument, st.Code())
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.GetEncounter())
+
+	data, err := s.repo.Get(s.ctx, resp.GetEncounter().GetId())
+	s.Require().NoError(err)
+	s.Require().Equal(core.ModeTurnBased, data.Mode)
+	s.Require().Len(data.Initiative, 1, "creator should be the sole combatant in initiative")
+	s.Require().Equal(1, data.Round)
 }
 
 func (s *HandlerSuite) TestCreateEncounter_UnspecifiedMode_TreatedAsFreeRoam() {

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -1,0 +1,124 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// TakeAction dispatches a player-initiated action against the encounter's
+// turn-based combat verbs. Wave 2.8 only wires the "attack" action ref;
+// other refs return Unimplemented.
+//
+// The handler is a thin shim over the toolkit's Encounter.TakeAction verb:
+// load → load-from-data → call verb → save. Mode-gating, turn-violation,
+// non-combatant, and unknown-target errors are all surfaced by the toolkit
+// as sentinel errors (encounter.ErrNotTurnBased, ErrNotYourTurn,
+// ErrUnsupportedAction, ErrNonCombatant, ErrUnknownTarget); the handler
+// maps each onto the corresponding gRPC status code.
+//
+// Outcome events (AttackResolvedEvent + DamageDealtEvent on hit) are
+// published per-viewer through the broker by the toolkit verb itself; the
+// handler does not need to translate or echo them in the response. Empty
+// TakeActionResponse is the design — the events deliver state changes.
+func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionRequest) (*encounterv2pb.TakeActionResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+	if req.GetEncounterId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+	if req.GetActorEntityId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "actor_entity_id is required")
+	}
+	if req.GetActionRef() == nil {
+		return nil, status.Error(codes.InvalidArgument, "action_ref is required")
+	}
+	if req.GetTarget() == nil || req.GetTarget().GetKind() == nil {
+		return nil, status.Error(codes.InvalidArgument, "target is required")
+	}
+
+	// Wave 2.8 only supports entity-id targeting. Other oneof variants are
+	// reserved for future waves (position for AoEs, area for spells, self
+	// for buffs). InvalidArgument because the request shape is wrong, not
+	// the world state.
+	entityID := req.GetTarget().GetEntityId()
+	if entityID == "" {
+		return nil, status.Error(codes.InvalidArgument, "target.entity_id is required (only entity-id targeting is supported in this wave)")
+	}
+
+	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "encounter not found")
+		}
+		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	// Caller must be in the encounter and the actor entity must be the
+	// caller's controlled entity. Read directly from data BEFORE LoadFromData
+	// so we don't pay rehydration cost on the auth-fail path.
+	pd, ok := data.Players[core.PlayerID(playerID)]
+	if !ok {
+		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
+	}
+	if string(pd.EntityID) != req.GetActorEntityId() {
+		return nil, status.Error(codes.PermissionDenied, "actor_entity_id does not match player's controlled entity")
+	}
+
+	enc, err := tkenc.LoadFromData(data, h.broker)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
+	}
+
+	actionRef := tkenc.ActionRef{
+		Module: req.GetActionRef().GetModule(),
+		Type:   req.GetActionRef().GetType(),
+		ID:     req.GetActionRef().GetId(),
+	}
+	target := tkenc.ActionTarget{EntityID: core.EntityID(entityID)}
+
+	if err := enc.TakeAction(core.PlayerID(playerID), actionRef, target); err != nil {
+		return nil, takeActionStatusError(err)
+	}
+
+	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
+		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	return &encounterv2pb.TakeActionResponse{}, nil
+}
+
+// takeActionStatusError maps toolkit TakeAction sentinel errors onto gRPC
+// status codes per pat-v2-status-code-mapping (FailedPrecondition for
+// state-dependent failures, Unimplemented for unsupported actions,
+// InvalidArgument for unknown targets that are syntactically valid but
+// don't exist in the encounter — though the toolkit overloads
+// ErrUnknownTarget to also mean state-dependent missing-monster, so we
+// map it to FailedPrecondition).
+func takeActionStatusError(err error) error {
+	switch {
+	case errors.Is(err, tkenc.ErrNotTurnBased):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrNotYourTurn):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrNonCombatant):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrUnsupportedAction):
+		return status.Error(codes.Unimplemented, err.Error())
+	case errors.Is(err, tkenc.ErrUnknownTarget):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrNoCombatants):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	}
+	return status.Errorf(codes.Internal, "take action: %v", err)
+}

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -25,6 +25,17 @@ var ErrViewerSawNothing = errors.New("viewer saw nothing in this event")
 // the given toolkit event type. The stream loop should log + continue.
 var ErrUnknownEventType = errors.New("translator has no mapping for this event type")
 
+// ErrEventSuppressed is returned when the translator deliberately drops a
+// toolkit event that has no proto wire shape. Used for cause-stage combat
+// events (AttackResolvedEvent) where the proto only carries the effect
+// (EntityDamaged). The stream loop must errors.Is-check and continue
+// silently — neither logging (it's expected) nor sending.
+//
+// This differs from ErrViewerSawNothing (per-viewer empty slice) and
+// ErrUnknownEventType (translator gap to log) — it's a deliberate design
+// choice baked in per pat-v2-combat-event-translator.
+var ErrEventSuppressed = errors.New("event deliberately suppressed by translator")
+
 // HexToPosition maps a toolkit cube hex (Q,R,S) to a proto Position (x,y,z).
 // The proto invariant x+y+z=0 is preserved by construction.
 func HexToPosition(h core.Hex) *encounterv2pb.Position {
@@ -47,6 +58,22 @@ func TranslateEvent(evt events.EncounterEvent, viewer core.PlayerID, now time.Ti
 		return translateEntityAppearedEvent(e, viewer, now)
 	case *events.EntityDisappearedEvent:
 		return translateEntityDisappearedEvent(e, viewer, now)
+	case *events.AttackResolvedEvent:
+		// Cause-stage event with no proto wire shape (proto designers chose
+		// EntityDamaged as the canonical wire shape; AttackResolved is
+		// narration/animation hooks the web doesn't render in this wave).
+		// Suppress so the stream loop neither logs nor sends.
+		return nil, ErrEventSuppressed
+	case *events.DamageDealtEvent:
+		return translateDamageDealtEvent(e, viewer, now)
+	case *events.ConditionAppliedEvent:
+		return translateConditionAppliedEvent(e, viewer, now)
+	case *events.ModeChangedEvent:
+		return translateModeChangedEvent(e, viewer, now)
+	case *events.TurnStartedEvent:
+		return translateTurnStartedEvent(e, viewer, now)
+	case *events.TurnEndedEvent:
+		return translateTurnEndedEvent(e, viewer, now)
 	default:
 		return nil, fmt.Errorf("%w: %T", ErrUnknownEventType, evt)
 	}
@@ -164,6 +191,198 @@ func translateEntityDisappearedEvent(e *events.EntityDisappearedEvent, viewer co
 			},
 		},
 	}, nil
+}
+
+// translateDamageDealtEvent maps the toolkit's DamageDealtEvent (effect of
+// an attack) to the proto EntityDamaged envelope. Per
+// pat-v2-combat-event-translator, this is the canonical wire shape for HP
+// outcomes — the cause-stage AttackResolvedEvent is suppressed.
+//
+// Per-viewer projection: viewers absent from PerPlayer don't see the event;
+// viewers with Visible:false return ErrViewerSawNothing for stream-loop
+// silent skip. The toolkit's publish-side already gated audience by LoS to
+// attacker OR target so a Visible:true entry means the viewer should see
+// the wire-shape event.
+func translateDamageDealtEvent(e *events.DamageDealtEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	slice, ok := e.PerPlayer[viewer]
+	if !ok || !slice.Visible {
+		return nil, ErrViewerSawNothing
+	}
+	out := &encounterv2pb.EntityDamaged{
+		EntityId: string(e.TargetID),
+		Amount:   int32(e.Amount),
+		HpAfter: &encounterv2pb.HitPoints{
+			Current: int32(e.HPAfter),
+			Max:     int32(e.MaxHP),
+		},
+	}
+	if e.DamageType != "" {
+		out.DamageType = damageRefFor(e.DamageType)
+	}
+	if e.SourceID != "" {
+		s := string(e.SourceID)
+		out.SourceEntityId = &s
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_EntityDamaged{
+			EntityDamaged: out,
+		},
+	}, nil
+}
+
+// translateConditionAppliedEvent maps the toolkit's ConditionAppliedEvent
+// (effect of an action that applies a status — e.g., "poisoned" from a
+// poisoned-attack) to the proto StatusApplied envelope.
+//
+// The toolkit publishes ConditionRef as the toolkit's three-part-ref string
+// (e.g. "dnd5e:conditions:poisoned"). For Wave 2.8, the rpg-api translator
+// emits the StatusEffect.Source as a Ref with the same id portion; the web
+// resolves display_name / icon_hint from its own lookup table. Future waves
+// can plumb richer status metadata when toolkit ships it.
+func translateConditionAppliedEvent(e *events.ConditionAppliedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	slice, ok := e.PerPlayer[viewer]
+	if !ok || !slice.Visible {
+		return nil, ErrViewerSawNothing
+	}
+	status := &encounterv2pb.StatusEffect{
+		Source: conditionRefFor(e.ConditionRef),
+	}
+	if e.DurationRounds > 0 {
+		d := int32(e.DurationRounds)
+		status.DurationRounds = &d
+	}
+	out := &encounterv2pb.StatusApplied{
+		EntityId: string(e.TargetID),
+		Status:   status,
+	}
+	if e.SourceID != "" {
+		s := string(e.SourceID)
+		out.SourceEntityId = &s
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_StatusApplied{
+			StatusApplied: out,
+		},
+	}, nil
+}
+
+// translateModeChangedEvent maps the toolkit's ModeChangedEvent to the
+// proto ModeChanged envelope. Audience is implicit (every player sees mode
+// flips), so we only check viewer-presence; Visible flag is always true on
+// the toolkit side.
+func translateModeChangedEvent(e *events.ModeChangedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	if _, ok := e.PerPlayer[viewer]; !ok {
+		return nil, ErrViewerSawNothing
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_ModeChanged{
+			ModeChanged: &encounterv2pb.ModeChanged{
+				From:   encounterModeToProto(e.From),
+				To:     encounterModeToProto(e.To),
+				Reason: e.Reason,
+			},
+		},
+	}, nil
+}
+
+// translateTurnStartedEvent maps the toolkit's TurnStartedEvent to the proto
+// TurnStarted envelope. Round is 1-indexed in both shapes.
+func translateTurnStartedEvent(e *events.TurnStartedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	if _, ok := e.PerPlayer[viewer]; !ok {
+		return nil, ErrViewerSawNothing
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_TurnStarted{
+			TurnStarted: &encounterv2pb.TurnStarted{
+				EntityId: string(e.ActorID),
+				Round:    int32(e.Round),
+			},
+		},
+	}, nil
+}
+
+// translateTurnEndedEvent maps the toolkit's TurnEndedEvent to the proto
+// TurnEnded envelope. Audience is implicit (every player sees turn
+// transitions); viewer must be in PerPlayer.
+func translateTurnEndedEvent(e *events.TurnEndedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	if _, ok := e.PerPlayer[viewer]; !ok {
+		return nil, ErrViewerSawNothing
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_TurnEnded{
+			TurnEnded: &encounterv2pb.TurnEnded{
+				EntityId: string(e.ActorID),
+			},
+		},
+	}, nil
+}
+
+// damageRefFor builds a proto Ref for a toolkit damage-type string. The
+// toolkit emits bare strings (e.g. "slashing", "fire", "untyped"); the proto
+// wire shape uses a Ref triple. For Wave 2.8 we hardwire module=dnd5e and
+// type=damage; future modules can route off the toolkit string when they
+// ship.
+func damageRefFor(toolkitDamageType string) *encounterv2pb.Ref {
+	return &encounterv2pb.Ref{
+		Module: "dnd5e",
+		Type:   "damage",
+		Id:     toolkitDamageType,
+	}
+}
+
+// conditionRefFor builds a proto Ref for a toolkit condition-ref string.
+// The toolkit ships a fully-qualified ref (e.g. "dnd5e:conditions:poisoned");
+// we parse it back into module/type/id. Bare strings are treated as ids
+// under module=dnd5e, type=condition.
+func conditionRefFor(toolkitConditionRef string) *encounterv2pb.Ref {
+	parts := splitRef(toolkitConditionRef)
+	if len(parts) == 3 {
+		return &encounterv2pb.Ref{Module: parts[0], Type: parts[1], Id: parts[2]}
+	}
+	return &encounterv2pb.Ref{Module: "dnd5e", Type: "condition", Id: toolkitConditionRef}
+}
+
+// splitRef splits a "module:type:id" string into its three parts. Returns
+// an empty slice if the input doesn't have exactly two colons.
+func splitRef(s string) []string {
+	parts := []string{}
+	start := 0
+	colons := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ':' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+			colons++
+		}
+	}
+	if colons != 2 {
+		return nil
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+// encounterModeToProto maps the toolkit's core.EncounterMode enum to the
+// proto EncounterMode enum. The toolkit's ModeUnspecified maps to
+// ENCOUNTER_MODE_UNSPECIFIED; FreeRoam → FREE_ROAM; TurnBased → TURN_BASED.
+func encounterModeToProto(m core.EncounterMode) encounterv2pb.EncounterMode {
+	switch m {
+	case core.ModeFreeRoam:
+		return encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM
+	case core.ModeTurnBased:
+		return encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED
+	}
+	return encounterv2pb.EncounterMode_ENCOUNTER_MODE_UNSPECIFIED
 }
 
 // TranslateSnapshot wraps a projected proto Encounter in a synthetic

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -353,7 +353,8 @@ func conditionRefFor(toolkitConditionRef string) *encounterv2pb.Ref {
 }
 
 // splitRef splits a "module:type:id" string into its three parts. Returns
-// an empty slice if the input doesn't have exactly two colons.
+// nil when the input doesn't have exactly two colons. Callers should treat
+// the nil return as "not a fully-qualified ref" and fall back to defaults.
 func splitRef(s string) []string {
 	parts := []string{}
 	start := 0

--- a/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
@@ -1,0 +1,257 @@
+package encounter_test
+
+import (
+	"errors"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+// Combat event translator tests — covers the Wave 2.8 additions:
+// AttackResolvedEvent (suppressed), DamageDealtEvent, ConditionAppliedEvent,
+// ModeChangedEvent, TurnStartedEvent, TurnEndedEvent.
+
+func (s *TranslateSuite) TestTranslateEvent_AttackResolvedEvent_Suppressed() {
+	// AttackResolvedEvent is the cause-stage event; the proto wire shape uses
+	// EntityDamaged (effect) as the canonical attack-result event. The
+	// translator deliberately drops AttackResolved to avoid double-emitting.
+	evt := events.NewAttackResolvedEvent(
+		"enc-1", uint64(10),
+		"char-A", "goblin-1",
+		true, false, 18, 4, 15,
+		map[core.PlayerID]events.AttackResolvedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrEventSuppressed),
+		"AttackResolvedEvent must return ErrEventSuppressed, got: %v", err)
+	s.Require().Nil(out)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_HappyPath() {
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(11),
+		"goblin-1", "char-A",
+		5, "slashing",
+		2, 7,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+
+	dmg := out.GetEntityDamaged()
+	s.Require().NotNil(dmg, "expected EntityDamaged envelope")
+	s.Require().Equal("goblin-1", dmg.GetEntityId())
+	s.Require().Equal(int32(5), dmg.GetAmount())
+	s.Require().Equal("char-A", dmg.GetSourceEntityId())
+	s.Require().NotNil(dmg.GetHpAfter())
+	s.Require().Equal(int32(2), dmg.GetHpAfter().GetCurrent())
+	s.Require().Equal(int32(7), dmg.GetHpAfter().GetMax())
+	s.Require().NotNil(dmg.GetDamageType())
+	s.Require().Equal("dnd5e", dmg.GetDamageType().GetModule())
+	s.Require().Equal("damage", dmg.GetDamageType().GetType())
+	s.Require().Equal("slashing", dmg.GetDamageType().GetId())
+	s.Require().Equal(int64(11), out.Sequence)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_EmptyDamageTypeSkipsRef() {
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(12),
+		"char-A", "goblin-1",
+		3, "",
+		9, 12,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	dmg := out.GetEntityDamaged()
+	s.Require().NotNil(dmg)
+	s.Require().Nil(dmg.GetDamageType(), "empty toolkit damage type → nil proto Ref")
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_NotVisible_ReturnsErrViewerSawNothing() {
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(13),
+		"goblin-1", "char-A",
+		5, "slashing",
+		2, 7,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-A": {Visible: false},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(14),
+		"goblin-1", "char-A",
+		5, "slashing",
+		2, 7,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ConditionAppliedEvent_HappyPath_FullyQualifiedRef() {
+	evt := events.NewConditionAppliedEvent(
+		"enc-1", uint64(20),
+		"char-A", "goblin-1",
+		"dnd5e:conditions:poisoned", 3,
+		map[core.PlayerID]events.ConditionAppliedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	app := out.GetStatusApplied()
+	s.Require().NotNil(app)
+	s.Require().Equal("char-A", app.GetEntityId())
+	s.Require().Equal("goblin-1", app.GetSourceEntityId())
+	s.Require().NotNil(app.GetStatus())
+	s.Require().NotNil(app.GetStatus().GetSource())
+	s.Require().Equal("dnd5e", app.GetStatus().GetSource().GetModule())
+	s.Require().Equal("conditions", app.GetStatus().GetSource().GetType())
+	s.Require().Equal("poisoned", app.GetStatus().GetSource().GetId())
+	s.Require().Equal(int32(3), app.GetStatus().GetDurationRounds())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ConditionAppliedEvent_BareIDFallsBackToDefaults() {
+	evt := events.NewConditionAppliedEvent(
+		"enc-1", uint64(21),
+		"char-A", "goblin-1",
+		"prone", 0,
+		map[core.PlayerID]events.ConditionAppliedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	app := out.GetStatusApplied()
+	src := app.GetStatus().GetSource()
+	s.Require().Equal("dnd5e", src.GetModule())
+	s.Require().Equal("condition", src.GetType())
+	s.Require().Equal("prone", src.GetId())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ConditionAppliedEvent_NotVisible_ReturnsErrViewerSawNothing() {
+	evt := events.NewConditionAppliedEvent(
+		"enc-1", uint64(22),
+		"char-A", "goblin-1",
+		"dnd5e:conditions:poisoned", 3,
+		map[core.PlayerID]events.ConditionAppliedSlice{
+			"player-A": {Visible: false},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ModeChangedEvent_FreeRoamToTurnBased() {
+	evt := events.NewModeChangedEvent(
+		"enc-1", uint64(30),
+		core.ModeFreeRoam, core.ModeTurnBased,
+		"ambush",
+		map[core.PlayerID]events.ModeChangedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	mc := out.GetModeChanged()
+	s.Require().NotNil(mc)
+	s.Require().Equal(encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM, mc.GetFrom())
+	s.Require().Equal(encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED, mc.GetTo())
+	s.Require().Equal("ambush", mc.GetReason())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ModeChangedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewModeChangedEvent(
+		"enc-1", uint64(31),
+		core.ModeFreeRoam, core.ModeTurnBased,
+		"",
+		map[core.PlayerID]events.ModeChangedSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_TurnStartedEvent_HappyPath() {
+	evt := events.NewTurnStartedEvent(
+		"enc-1", uint64(40),
+		"char-A", 2,
+		map[core.PlayerID]events.TurnStartedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	ts := out.GetTurnStarted()
+	s.Require().NotNil(ts)
+	s.Require().Equal("char-A", ts.GetEntityId())
+	s.Require().Equal(int32(2), ts.GetRound())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_TurnStartedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewTurnStartedEvent(
+		"enc-1", uint64(41),
+		"char-A", 1,
+		map[core.PlayerID]events.TurnStartedSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_TurnEndedEvent_HappyPath() {
+	evt := events.NewTurnEndedEvent(
+		"enc-1", uint64(50),
+		"char-A",
+		map[core.PlayerID]events.TurnEndedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	te := out.GetTurnEnded()
+	s.Require().NotNil(te)
+	s.Require().Equal("char-A", te.GetEntityId())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_TurnEndedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewTurnEndedEvent(
+		"enc-1", uint64(51),
+		"char-A",
+		map[core.PlayerID]events.TurnEndedSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -531,8 +531,12 @@ func (s *EncounterV2IntegrationSuite) TestStreamEncounter_LiveEventsDoNotDuplica
 //   - Two players + one monster, all in mutual LoS, mode set to TURN_BASED on
 //     seed (initiative is rolled by the toolkit).
 //   - Both players subscribe via StreamEncounter and drain replay events.
-//   - The active player attacks goblin-1; both streams must observe an
-//     EntityDamaged event (per-viewer projection routes them based on LoS).
+//   - The active player attacks goblin-1; the toolkit resolves the attack
+//     with a real d20, so EntityDamaged is published only on hit. The test
+//     asserts that IF EntityDamaged arrives, it is shaped correctly
+//     (target=goblin-1, source=attacker); a miss-only run is still a valid
+//     pass. AttackResolvedEvent is suppressed at the translator and must
+//     not appear on either stream.
 //   - The active player ends turn; the orchestrator's NPC dispatch loop runs
 //     NPCAct + EndTurn for the goblin server-side until the next active actor
 //     is a player. Both streams observe TurnEnded → (NPC events) → TurnStarted.
@@ -596,8 +600,16 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 	go aSink.drain(streamA)
 	go bSink.drain(streamB)
 
-	// Wait briefly for replay to land on both sinks.
-	time.Sleep(300 * time.Millisecond)
+	// Wait until both sinks have observed the full replay set: SnapshotDelivered
+	// + at least one EntityAppeared (the viewer's own entity) + GeometryRevealed
+	// (the viewer's revealed-hexes set). All replay events ship with Sequence==0
+	// (pre-history); live events start at Sequence>=1. The replay-complete
+	// signal is robust against slow CI without timing assumptions — we only
+	// watermark once both viewers have received their replay envelopes.
+	s.Require().Eventually(func() bool {
+		return aSink.hasReplayComplete() && bSink.hasReplayComplete()
+	}, 2*time.Second, 25*time.Millisecond,
+		"both streams must complete replay (snapshot + entity-appeared + geometry-revealed) before the test fires the active RPC")
 	aSink.snapshot() // capture replay watermark; subsequent reads start AFTER this
 	bSink.snapshot()
 
@@ -747,6 +759,30 @@ func (s *eventSink) hasTurnEndedFor(entityID string) bool {
 		}
 	}
 	return false
+}
+
+// hasReplayComplete reports whether the sink has observed all expected
+// replay events: SnapshotDelivered + at least one EntityAppeared + at least
+// one GeometryRevealed. Replay events are sent synchronously by the handler
+// before it enters the live forward loop; once all three kinds are present
+// the replay phase is guaranteed complete (per the BuildReplayEvents output
+// shape — see translate.go). Used by tests as the watermark signal.
+func (s *eventSink) hasReplayComplete() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var sawSnap, sawAppeared, sawGeo bool
+	for _, ev := range s.events {
+		if ev.GetSnapshotDelivered() != nil {
+			sawSnap = true
+		}
+		if ev.GetEntityAppeared() != nil {
+			sawAppeared = true
+		}
+		if ev.GetGeometryRevealed() != nil {
+			sawGeo = true
+		}
+	}
+	return sawSnap && sawAppeared && sawGeo
 }
 
 // findEntityDamaged returns the first EntityDamaged event in the slice, or

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -5,6 +5,7 @@ package integration_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -522,6 +523,253 @@ func (s *EncounterV2IntegrationSuite) TestStreamEncounter_LiveEventsDoNotDuplica
 	// fire another EntityAppeared for bob from a move that stays within LoS.
 	s.Require().Zero(extraBobAppeared,
 		"live stream must not re-emit EntityAppeared for bob who was already visible from replay")
+}
+
+// TestCombatSlice_TakeActionAndEndTurn_NPCDispatch is the wave-2.8 gate test.
+// It exercises the full attack → endturn → npc-act → endturn loop on bufconn:
+//
+//   - Two players + one monster, all in mutual LoS, mode set to TURN_BASED on
+//     seed (initiative is rolled by the toolkit).
+//   - Both players subscribe via StreamEncounter and drain replay events.
+//   - The active player attacks goblin-1; both streams must observe an
+//     EntityDamaged event (per-viewer projection routes them based on LoS).
+//   - The active player ends turn; the orchestrator's NPC dispatch loop runs
+//     NPCAct + EndTurn for the goblin server-side until the next active actor
+//     is a player. Both streams observe TurnEnded → (NPC events) → TurnStarted.
+//
+// This is the integration-test face of pat-v2-npc-turn-dispatch and
+// pat-v2-combat-event-translator.
+func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDispatch() {
+	enc := tkenc.New("enc-combat", s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4, DamageDice: "1d8+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: -1, S: 0}, SightRange: 10,
+		HP: 10, MaxHP: 10, AC: 13, AttackBonus: 3, DamageDice: "1d6+1", DamageType: "piercing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 2, R: -1, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	// Walk initiative until a player is active so both TakeAction and
+	// EndTurn run in their happy path. Done outside the streams so the
+	// initial-state replay is what each viewer sees on connect.
+	s.advanceUntilPlayerActiveByDirectToolkit(enc)
+
+	// Reload to discover whose turn it is now.
+	data, err := s.srv.EncRepoV2.Get(s.ctx, "enc-combat")
+	s.Require().NoError(err)
+	activeEntity := string(data.Initiative[data.ActiveIdx])
+	var activePlayer string
+	for pid, pd := range data.Players {
+		if string(pd.EntityID) == activeEntity {
+			activePlayer = string(pid)
+			break
+		}
+	}
+	s.Require().NotEmpty(activePlayer, "an active player must be found before TakeAction")
+
+	ctxAlice := s.authCtx("alice")
+	ctxBob := s.authCtx("bob")
+	ctxActive := s.authCtx(activePlayer)
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxAlice, &encounterv2pb.StreamEncounterRequest{EncounterId: "enc-combat"})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxBob, &encounterv2pb.StreamEncounterRequest{EncounterId: "enc-combat"})
+	s.Require().NoError(err)
+
+	// Both streams use a single long-running background drainer started
+	// here. Each drainer collects all events into its own slice with a mutex.
+	// Tests then read from the slice with a polling helper after firing the
+	// active RPC. This avoids racy multi-call collectStreamEvents patterns.
+	aSink := newEventSink()
+	bSink := newEventSink()
+	go aSink.drain(streamA)
+	go bSink.drain(streamB)
+
+	// Wait briefly for replay to land on both sinks.
+	time.Sleep(300 * time.Millisecond)
+	aSink.snapshot() // capture replay watermark; subsequent reads start AFTER this
+	bSink.snapshot()
+
+	// Active player attacks goblin-1.
+	_, err = s.srv.EncounterClientV2.TakeAction(ctxActive, &encounterv2pb.TakeActionRequest{
+		EncounterId:   "enc-combat",
+		ActorEntityId: activeEntity,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: "goblin-1"},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Active player ends turn — fires the NPC dispatch loop server-side.
+	_, err = s.srv.EncounterClientV2.EndTurn(ctxActive, &encounterv2pb.EndTurnRequest{
+		EncounterId: "enc-combat", EntityId: activeEntity,
+	})
+	s.Require().NoError(err)
+
+	// Wait for the broker to fan out the events triggered by both RPCs.
+	// TakeAction emits AttackResolvedEvent (suppressed) + DamageDealtEvent (on hit).
+	// EndTurn emits TurnEnded(activeEntity) + (NPC chain if applicable) +
+	// TurnStarted(nextActor).
+	s.Require().Eventually(func() bool {
+		return aSink.hasTurnEndedFor(activeEntity) && bSink.hasTurnEndedFor(activeEntity)
+	}, 2*time.Second, 50*time.Millisecond,
+		"both streams must see TurnEnded for the active entity")
+
+	aPost := aSink.eventsAfterSnapshot()
+	bPost := bSink.eventsAfterSnapshot()
+
+	// AttackResolved is suppressed at the translator. Verify no events with
+	// a nil oneof slipped through (every event must carry a known envelope).
+	s.Require().True(eventsHaveNoUnmappedEnvelope(aPost),
+		"alice's stream must not surface unmapped envelopes")
+	s.Require().True(eventsHaveNoUnmappedEnvelope(bPost),
+		"bob's stream must not surface unmapped envelopes")
+
+	// On hit, EntityDamaged should target goblin-1 with the active entity as source.
+	if dmg := findEntityDamaged(aPost); dmg != nil {
+		s.Require().Equal("goblin-1", dmg.GetEntityId(), "alice's damage event targets goblin-1")
+		s.Require().Equal(activeEntity, dmg.GetSourceEntityId(),
+			"alice's damage event source is the attacking entity")
+	}
+	if dmg := findEntityDamaged(bPost); dmg != nil {
+		s.Require().Equal("goblin-1", dmg.GetEntityId(), "bob's damage event targets goblin-1")
+	}
+
+	// Reload final state — active actor must be a player after the loop.
+	finalData, err := s.srv.EncRepoV2.Get(s.ctx, "enc-combat")
+	s.Require().NoError(err)
+	finalActive := finalData.Initiative[finalData.ActiveIdx]
+	finalIsPlayer := false
+	for _, pd := range finalData.Players {
+		if pd.EntityID == finalActive {
+			finalIsPlayer = true
+			break
+		}
+	}
+	s.Require().True(finalIsPlayer,
+		"after EndTurn + NPC dispatch loop, active actor must be a player, got %q", finalActive)
+}
+
+// advanceUntilPlayerActiveByDirectToolkit drives toolkit verbs directly to
+// cycle past any leading NPC turns in initiative. Used in test setup so the
+// integration test starts with a player active and TakeAction runs in its
+// happy path without needing a SetMode RPC.
+func (s *EncounterV2IntegrationSuite) advanceUntilPlayerActiveByDirectToolkit(enc *tkenc.Encounter) {
+	for {
+		data := enc.ToData()
+		if len(data.Initiative) == 0 {
+			s.Require().FailNow("seeded encounter has empty initiative; SetMode may have failed")
+		}
+		active := data.Initiative[data.ActiveIdx]
+		isPlayer := false
+		for _, pd := range data.Players {
+			if pd.EntityID == active {
+				isPlayer = true
+				break
+			}
+		}
+		if isPlayer {
+			break
+		}
+		// Active is the goblin — run NPCAct + EndTurn to cycle.
+		s.Require().NoError(enc.NPCAct(s.ctx, active))
+		_, _, err := enc.EndTurn(active)
+		s.Require().NoError(err)
+	}
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+}
+
+// eventSink consumes a stream's events into a thread-safe slice. snapshot()
+// captures a watermark; eventsAfterSnapshot() returns everything after the
+// last snapshot. Used by the combat integration test to separate replay
+// events from the events fired by an active RPC.
+type eventSink struct {
+	mu        sync.Mutex
+	events    []*encounterv2pb.EncounterEvent
+	watermark int
+}
+
+func newEventSink() *eventSink {
+	return &eventSink{events: make([]*encounterv2pb.EncounterEvent, 0, 32)}
+}
+
+// drain runs in a background goroutine, appending every event from stream
+// into the sink until stream.Recv errors (typically EOF / context cancel).
+func (s *eventSink) drain(stream encounterv2pb.EncounterService_StreamEncounterClient) {
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			return
+		}
+		s.mu.Lock()
+		s.events = append(s.events, ev)
+		s.mu.Unlock()
+	}
+}
+
+// snapshot records the current event count as the watermark. Subsequent
+// eventsAfterSnapshot calls return only events that arrived after this
+// point.
+func (s *eventSink) snapshot() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.watermark = len(s.events)
+}
+
+// eventsAfterSnapshot returns the events that arrived after the most recent
+// snapshot() call. Safe to call concurrently with drain().
+func (s *eventSink) eventsAfterSnapshot() []*encounterv2pb.EncounterEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*encounterv2pb.EncounterEvent, len(s.events)-s.watermark)
+	copy(out, s.events[s.watermark:])
+	return out
+}
+
+// hasTurnEndedFor reports whether the sink has observed a TurnEnded
+// envelope with the given entity id, AFTER the most recent snapshot.
+func (s *eventSink) hasTurnEndedFor(entityID string) bool {
+	for _, ev := range s.eventsAfterSnapshot() {
+		if te := ev.GetTurnEnded(); te != nil && te.GetEntityId() == entityID {
+			return true
+		}
+	}
+	return false
+}
+
+// findEntityDamaged returns the first EntityDamaged event in the slice, or
+// nil if none is present.
+func findEntityDamaged(events []*encounterv2pb.EncounterEvent) *encounterv2pb.EntityDamaged {
+	for _, ev := range events {
+		if d := ev.GetEntityDamaged(); d != nil {
+			return d
+		}
+	}
+	return nil
+}
+
+// eventsHaveNoUnmappedEnvelope asserts every event in the slice has a
+// non-nil oneof envelope. Translator suppression should drop events at the
+// stream loop (continue without sending), not surface a nil-oneof event.
+func eventsHaveNoUnmappedEnvelope(events []*encounterv2pb.EncounterEvent) bool {
+	for _, ev := range events {
+		if ev.GetEvent() == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func TestEncounterV2IntegrationSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

The rpg-api half of Wave 2.8 (Combat slice). Pairs with the toolkit slice merged in `rpg-toolkit#638` (encounter v0.3.0). Closes #505.

- Bump `rpg-toolkit/encounter` to v0.3.0. Surfaces the toolkit's new combat verbs (`SetMode`, `TakeAction`, `EndTurn`, `NPCAct`), `MonsterData`, mode + initiative on `encounter.Data`, and the six new combat event types (`AttackResolvedEvent`, `DamageDealtEvent`, `ConditionAppliedEvent`, `ModeChangedEvent`, `TurnStartedEvent`, `TurnEndedEvent`).
- New v2 handlers `TakeAction` and `EndTurn` (`internal/handlers/dnd5e/v2/encounter/take_action.go`, `end_turn.go`). Both follow `pat-v2-handler-direct-no-orchestrator`: load → `LoadFromData` → call toolkit verb → save. Toolkit-emitted sentinels (`ErrNotTurnBased`, `ErrNotYourTurn`, `ErrUnsupportedAction`, `ErrUnknownTarget`, `ErrNonCombatant`, `ErrNoCombatants`) are mapped per `pat-v2-status-code-mapping`.
- `EndTurn` drives the orchestrator-side **NPC dispatch loop** (`pat-v2-npc-turn-dispatch`). The toolkit's `EndTurn` returns `(newActive, isNPC, err)`; when the new active is an NPC the handler runs `NPCAct` + a follow-up `EndTurn` server-side, looping until the active actor is a player. Loop is capped at 16 to defend against pathological all-NPC initiatives.
- Translator additions in `translate.go` for the six new event types. `DamageDealt → EntityDamaged`, `ConditionApplied → StatusApplied`, `ModeChanged/TurnStarted/TurnEnded` → matching proto envelopes. `AttackResolvedEvent` has no proto wire shape (proto designers chose `EntityDamaged` as the canonical effect-event), so the translator suppresses it via a new `ErrEventSuppressed` and the stream loop drops without log.
- `CreateEncounter` now accepts `INITIAL_MODE_TURN_BASED`, delegating initiative roll to the toolkit's `SetMode`.
- Bufconn integration test (`TestCombatSlice_TakeActionAndEndTurn_NPCDispatch`) exercises the full attack → endturn → npc-act → endturn cycle with two players + one monster. Uses a per-stream `eventSink` with snapshot watermarks so live events are deterministically separated from initial-state replay.

## Behavior

- `TakeAction(playerID, actor_entity_id, action_ref={dnd5e:action:attack}, target.entity_id=monster)` — gated to `TURN_BASED`. Returns `FailedPrecondition` for state-dependent failures (mode, turn, non-combatant, unknown-target); `Unimplemented` for unsupported action ids; `PermissionDenied` for actor mismatch / non-member; `InvalidArgument` for malformed request.
- `EndTurn(playerID, entity_id)` — gated to `TURN_BASED`. After advancing initiative, runs the NPC dispatch loop until next active actor is a player.
- Visibility per `pat-v2-translator-typed-errors`: per-viewer `Visible:false` returns `ErrViewerSawNothing` (silent skip); `AttackResolvedEvent` returns `ErrEventSuppressed` (silent suppress).

## Deferred reviewer notes

- The toolkit's stand-in attack resolver (run by `NPCAct` and `TakeAction` for player attacks) is captured at `rpg-toolkit#635` — the dnd5e action layer doesn't yet route through `combat.ResolveAttack`. Not blocking; the wire shape is correct. When `#635` lands, only the toolkit changes; this PR's translator stays as-is.
- `TestCreateEncounter_TurnBasedMode_RollsInitiative` replaces the old `TestCreateEncounter_TurnBasedMode_InvalidArgument` (TURN_BASED is now accepted on create).

## Test plan

- [x] `go test ./internal/handlers/dnd5e/v2/encounter/...` — unit tests pass.
- [x] `go test ./internal/integration/... -run TestEncounterV2IntegrationSuite` — bufconn integration including the new combat slice test passes.
- [x] `golangci-lint run ./internal/handlers/dnd5e/v2/encounter/...` — 0 issues in new code (repo has 66 pre-existing lint issues unrelated to this PR; same count on `main`).
- [x] `go mod tidy` clean; `gofmt -s -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)