### PR TITLE
fix(encounter): project player entities with type/hp/character data

### DIFF
--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -7,10 +7,11 @@ import (
 	"sort"
 	"time"
 
-	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 )
 
 // ProjectFor builds a proto *encounterv2pb.Encounter for the given viewer from
@@ -80,20 +81,14 @@ func ProjectFor(
 		pd := data.Players[pid]
 		if pid == viewer {
 			// Viewer always sees their own entity.
-			entities = append(entities, &encounterv2pb.Entity{
-				Id:       string(pd.EntityID),
-				Position: HexToPosition(snap.Position),
-			})
+			entities = append(entities, playerEntity(pd, snap.Position))
 			continue
 		}
 		if pd.View == nil {
 			continue
 		}
 		if visibleNow != nil && visibleNow.Has(pd.View.Position) {
-			entities = append(entities, &encounterv2pb.Entity{
-				Id:       string(pd.EntityID),
-				Position: HexToPosition(pd.View.Position),
-			})
+			entities = append(entities, playerEntity(pd, pd.View.Position))
 		}
 	}
 
@@ -164,6 +159,32 @@ func buildTurnState(data *tkenc.Data) *encounterv2pb.TurnState {
 		InitiativeOrder: order,
 		ActiveEntityId:  active,
 		Round:           int32(data.Round),
+	}
+}
+
+// playerEntity builds the wire-shape proto Entity for a player seat. The
+// viewer's-own and visible-other-player branches differ only in which position
+// the caller supplies (snap.Position vs pd.View.Position), so the rest of the
+// emit lives here to keep them symmetric and to mirror the monster emit shape.
+//
+// CharacterData currently sets only PlayerId. ClassRef/RaceRef are deferred
+// until toolkit PlayerData carries class/race info; see issue #511 for the
+// rationale (we don't want to couple ProjectFor to the character orchestrator
+// for a thin enrichment).
+func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
+	return &encounterv2pb.Entity{
+		Id:       string(pd.EntityID),
+		Position: HexToPosition(pos),
+		Type:     encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER,
+		Hp: &encounterv2pb.HitPoints{
+			Current: int32(pd.HP),
+			Max:     int32(pd.MaxHP),
+		},
+		Data: &encounterv2pb.Entity_Character{
+			Character: &encounterv2pb.CharacterData{
+				PlayerId: string(pd.ID),
+			},
+		},
 	}
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
-	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
 )
 
 // ProjectSuite covers ProjectFor's per-viewer projection of toolkit
@@ -249,6 +250,72 @@ func (s *ProjectSuite) TestProjectFor_MonsterRef_MalformedFallsBackToDefaults() 
 		s.Require().Equal("no-colons-here", ref.GetId())
 	}
 	s.Require().True(found, "weird-1 must be projected (in alice's LOS)")
+}
+
+func (s *ProjectSuite) TestProjectFor_PlayerEntitiesCarryTypeHpAndCharacterData() {
+	// Symmetric to monster emission: both the viewer's own entity and visible
+	// other-player entities must carry Type=CHARACTER, HP, and CharacterData
+	// with PlayerId populated. Previously these emit paths produced bare
+	// {id, position} entities which rendered as UNSPECIFIED with no HP on the
+	// client (issue #511).
+	data := tkenc.NewData("enc-players")
+	data.Mode = core.ModeTurnBased
+	data.Round = 1
+	data.ActiveIdx = 0
+	data.Initiative = []core.EntityID{"char-alice", "char-bob"}
+
+	alice := newPlayerData("player-alice", "char-alice", originHex, 3)
+	alice.HP = 12
+	alice.MaxHP = 15
+
+	bob := newPlayerData("player-bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0}, 3)
+	bob.HP = 8
+	bob.MaxHP = 10
+
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{
+		"player-alice": alice,
+		"player-bob":   bob,
+	}
+
+	pb, err := v2encounter.ProjectFor(data, "player-alice", s.broker, s.now)
+	s.Require().NoError(err)
+
+	byID := make(map[string]*encounterv2pb.Entity)
+	for _, e := range pb.GetSpace().GetEntities() {
+		byID[e.GetId()] = e
+	}
+
+	// Viewer's own entity (alice).
+	a := byID["char-alice"]
+	s.Require().NotNil(a, "viewer's own entity must be emitted")
+	s.Require().Equal(
+		encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER, a.GetType(),
+		"viewer's own entity must carry ENTITY_TYPE_CHARACTER",
+	)
+	s.Require().NotNil(a.GetHp(), "viewer's own entity must carry HP")
+	s.Require().Equal(int32(12), a.GetHp().GetCurrent())
+	s.Require().Equal(int32(15), a.GetHp().GetMax())
+	ac := a.GetCharacter()
+	s.Require().NotNil(ac, "viewer's own entity must carry CharacterData oneof")
+	s.Require().Equal("player-alice", ac.GetPlayerId(),
+		"CharacterData.PlayerId must equal the toolkit PlayerData.ID")
+	// ClassRef / RaceRef intentionally deferred — see issue #511 deferred section.
+	s.Require().Nil(ac.GetClassRef(), "ClassRef deferred until PlayerData carries it")
+	s.Require().Nil(ac.GetRaceRef(), "RaceRef deferred until PlayerData carries it")
+
+	// Visible other-player (bob, in alice's sight).
+	b := byID["char-bob"]
+	s.Require().NotNil(b, "visible other-player must be emitted")
+	s.Require().Equal(
+		encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER, b.GetType(),
+		"visible other-player must carry ENTITY_TYPE_CHARACTER",
+	)
+	s.Require().NotNil(b.GetHp(), "visible other-player must carry HP")
+	s.Require().Equal(int32(8), b.GetHp().GetCurrent())
+	s.Require().Equal(int32(10), b.GetHp().GetMax())
+	bc := b.GetCharacter()
+	s.Require().NotNil(bc, "visible other-player must carry CharacterData oneof")
+	s.Require().Equal("player-bob", bc.GetPlayerId())
 }
 
 func (s *ProjectSuite) TestProjectFor_MonsterRef_TooManyColonsTreatedAsMalformed() {


### PR DESCRIPTION
## Summary
Symmetric follow-up to #510 (which fixed monster emission). The two player-emit branches in `ProjectFor` (viewer's-own + visible-other-player) were still producing bare `{id, position}` entities — no `Type`, no `Hp`, no `CharacterData` oneof. The client therefore rendered both as `UNSPECIFIED` with HP `—`, even though the toolkit `PlayerData` had `hp: 12, max_hp: 12` populated. Verified end-to-end via Chrome DevTools MCP after #510 + rpg-dnd5e-web#401 merged.

Both branches now share a `playerEntity(pd, pos)` helper that emits:
- `Type = ENTITY_TYPE_CHARACTER`
- `Hp` from `PlayerData.HP` / `MaxHP`
- `Data.Character.PlayerId = string(pd.ID)`

The helper keeps the two emit sites symmetric and mirrors the monster emit shape — they only differ in which position they pass (`snap.Position` for the viewer's own entity, `pd.View.Position` for visible others).

## Deferred
`CharacterData.class_ref` and `CharacterData.race_ref` are intentionally left empty. Toolkit `PlayerData` carries combat stats only (`HP/MaxHP/AC/AttackBonus/DamageDice/DamageType`), not class or race. Two options were considered:

1. **Set `PlayerId` only** (this PR). No new dependencies, no layer crossings.
2. Look up the character from the character repository inside `ProjectFor` to enrich class/race. Rejected: that would couple the projector to the character orchestrator and break the layer purity #510 carefully preserved.

If/when class/race is needed on the encounter wire (panel migration in rpg-project#28 may require it), the cleaner fix is to surface the refs on toolkit `PlayerData` itself. Tracking that separately rather than poisoning the projector layer.

## Tests
- New `TestProjectFor_PlayerEntitiesCarryTypeHpAndCharacterData` asserts both branches (viewer's-own + visible-other-player) emit `Type=ENTITY_TYPE_CHARACTER`, the correct `Hp`, and `Data.GetCharacter().PlayerId`. Also asserts `ClassRef` and `RaceRef` are nil with comments calling out the deferral.
- All 8 ProjectSuite tests pass.

## Test plan
- [x] `go test ./internal/handlers/dnd5e/v2/encounter/... -run TestProjectSuite` — all pass
- [ ] Chrome DevTools MCP playtest after merge: confirm both player markers render as `CHARACTER` with HP `12/12` (was `UNSPECIFIED` `—`)

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)