### PR TITLE
feat(encounter/v2): SubmitCheck + locked-door Interact (Wave 2.9)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260507051118-0443dec90664
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.3.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.55.5
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.3.0 h1:RpYY7Dl78TAZ7EH+/O9hMk0o7zyWKaXXNU15frYWQqA=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.3.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.4.0 h1:0sonOGSTP5HVwR5O+z0Mh3cmWIvvksclDsmBAlt0Pl8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.4.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/character_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/character_resolver.go
@@ -1,0 +1,50 @@
+package encounter
+
+import (
+	"strings"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// CharacterResolver bridges the toolkit's encounter.CharacterResolver to
+// rpg-api's character store so SubmitCheck can total a roll with the player's
+// ability modifier (and tool-proficiency bonus, if any).
+//
+// Wave 2.9 ships a stub implementation (StubCharacterResolver) that reports
+// every modifier as zero. This unblocks the SubmitCheck wire flow without
+// coupling the encounter handler to the character orchestrator yet — sourcing
+// real ability modifiers requires a player→character lookup that does not
+// exist on the encounter today (PlayerData.EntityID currently mirrors PlayerID
+// rather than referencing a character).
+//
+// Tracking issue for real lookups: see rpg-api follow-up filed alongside #514.
+//
+// The interface alias here exists so the rest of the handler package can
+// reference a single name regardless of which implementation is wired.
+type CharacterResolver = tkenc.CharacterResolver
+
+// StubCharacterResolver returns (0, true) for every modifier and proficiency
+// query. It satisfies tkenc.CharacterResolver so SubmitCheck can resolve
+// rolls (total = roll + 0 + 0) until the real character store bridge ships.
+//
+// "ok=true" is intentional: the toolkit treats ok=false as "unknown player,
+// modifier is zero anyway" — but the orchestrator wants the reported total
+// to be deterministic during wire-shape verification, so we say "yes I know
+// this player, the modifier is zero" until real data flows.
+type StubCharacterResolver struct{}
+
+// AbilityModifier always returns 0, true. Ability is normalized to upper-case
+// for forward compatibility with both door-construction conventions ("DEX"
+// and "dex"); the stub doesn't act on the value but keeps the contract
+// compatible with any future real implementation that does.
+func (StubCharacterResolver) AbilityModifier(_ core.PlayerID, ability string) (int, bool) {
+	_ = strings.ToUpper(ability)
+	return 0, true
+}
+
+// ToolProficiencyBonus always returns 0, true. Tool refs are passed through
+// untouched.
+func (StubCharacterResolver) ToolProficiencyBonus(_ core.PlayerID, _ string) (int, bool) {
+	return 0, true
+}

--- a/internal/handlers/dnd5e/v2/encounter/create.go
+++ b/internal/handlers/dnd5e/v2/encounter/create.go
@@ -40,7 +40,11 @@ func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.Create
 	}
 
 	encID := core.EncounterID(uuid.NewString())
-	enc := tkenc.New(encID, h.broker)
+	// WithCharacterResolver wires the modifier-lookup hook needed for any
+	// future SubmitCheck against this encounter. CreateEncounter doesn't
+	// itself issue prompts, but persisting a resolver-less New encounter
+	// would leave subsequent SubmitCheck calls with ErrNoCharacterResolver.
+	enc := tkenc.New(encID, h.broker, tkenc.WithCharacterResolver(h.resolver))
 	// The creator is automatically added as the encounter's first player.
 	// Entity ID mirrors the player ID for the initial seat; future PRs can
 	// wire in a character-selection step that replaces this with the

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -80,7 +80,7 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 		return nil, status.Error(codes.PermissionDenied, "entity_id does not match player's controlled entity")
 	}
 
-	enc, err := tkenc.LoadFromData(data, h.broker)
+	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -18,9 +18,10 @@ import (
 
 // HandlerConfig configures a v2 encounter Handler.
 type HandlerConfig struct {
-	Broker *encounter.Broker
-	Repo   encountersv2.Repository
-	Now    func() time.Time // optional; defaults to time.Now
+	Broker   *encounter.Broker
+	Repo     encountersv2.Repository
+	Resolver CharacterResolver // optional; defaults to StubCharacterResolver
+	Now      func() time.Time  // optional; defaults to time.Now
 }
 
 // Handler implements dnd5e.api.v1alpha2.encounter.EncounterServiceServer.
@@ -29,9 +30,10 @@ type HandlerConfig struct {
 // returns codes.Unimplemented via the embedded server.
 type Handler struct {
 	encounterv2pb.UnimplementedEncounterServiceServer
-	broker  *encounter.Broker
-	encRepo encountersv2.Repository
-	now     func() time.Time
+	broker   *encounter.Broker
+	encRepo  encountersv2.Repository
+	resolver CharacterResolver
+	now      func() time.Time
 }
 
 // New constructs a Handler. Returns error on missing required deps.
@@ -49,7 +51,15 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 	if now == nil {
 		now = time.Now
 	}
-	return &Handler{broker: cfg.Broker, encRepo: cfg.Repo, now: now}, nil
+	resolver := cfg.Resolver
+	if resolver == nil {
+		// Wave 2.9 default: zero-modifier stub. SubmitCheck can resolve rolls
+		// (total = roll + 0 + 0) without an explicit character lookup. Replace
+		// with a real bridge to the character store once player→character
+		// resolution lands on the encounter (follow-up to #514).
+		resolver = StubCharacterResolver{}
+	}
+	return &Handler{broker: cfg.Broker, encRepo: cfg.Repo, resolver: resolver, now: now}, nil
 }
 
 // MoveEntity loads the encounter, validates that the request's entity_id matches
@@ -88,7 +98,7 @@ func (h *Handler) MoveEntity(ctx context.Context, req *encounterv2pb.MoveEntityR
 		return nil, status.Error(codes.InvalidArgument, "proposed_path is required")
 	}
 
-	enc, err := encounter.LoadFromData(data, h.broker)
+	enc, err := encounter.LoadFromData(data, h.broker, encounter.WithCharacterResolver(h.resolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -458,9 +458,11 @@ func (s *HandlerSuite) TestInteract_OpenDoor_HappyPath() {
 // Wave 2.9: locked-door Interact + SubmitCheck
 // --------------------------------------------------------------------
 
-// seedLockedDoorEncounter persists an encounter with player-A near a locked
-// door. Callers can override the door's lock fields by mutating the data
-// before re-saving. Returns the encounter ID for convenience.
+// seedLockedDoorEncounter persists an encounter with player-A standing
+// adjacent to a locked door whose lock parameters are taken from the
+// (dc, ability, tool) arguments. Tests that need finer control over the
+// fixture should construct the Data themselves rather than extending this
+// helper — it intentionally takes no extra knobs to keep call sites readable.
 func (s *HandlerSuite) seedLockedDoorEncounter(encID, doorID string, dc int, ability, tool string) {
 	enc := tkenc.New(core.EncounterID(encID), s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
@@ -597,6 +599,42 @@ func (s *HandlerSuite) TestSubmitCheck_MissingEncounter_NotFound() {
 	s.Require().Error(err)
 	st, _ := status.FromError(err)
 	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_NonMember_PermissionDenied() {
+	// Encounter exists with a different player (not the caller).
+	enc := tkenc.New("enc-non-member", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other-player", EntityID: "other-char",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	// player-A (the auth context's player) is not a member.
+	_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-non-member", EntityId: "char-A", Roll: 10,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_EntityIDMismatch_PermissionDenied() {
+	// Caller is in the encounter but the request's entity_id does not match
+	// their controlled entity (player-A controls char-A).
+	enc := tkenc.New("enc-wrong-entity", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-wrong-entity", EntityId: "char-someone-else", Roll: 10,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.PermissionDenied, st.Code())
 }
 
 func (s *HandlerSuite) TestSubmitCheck_NoPendingPrompt_FailedPrecondition() {

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -3,6 +3,7 @@ package encounter_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -451,6 +452,265 @@ func (s *HandlerSuite) TestInteract_OpenDoor_HappyPath() {
 	door, ok := loaded.Doors[core.EntityID("door-east")]
 	s.Require().True(ok, "door-east must remain in persisted Doors map")
 	s.Require().True(door.Open, "door-east must be persisted as Open after Interact")
+}
+
+// --------------------------------------------------------------------
+// Wave 2.9: locked-door Interact + SubmitCheck
+// --------------------------------------------------------------------
+
+// seedLockedDoorEncounter persists an encounter with player-A near a locked
+// door. Callers can override the door's lock fields by mutating the data
+// before re-saving. Returns the encounter ID for convenience.
+func (s *HandlerSuite) seedLockedDoorEncounter(encID, doorID string, dc int, ability, tool string) {
+	enc := tkenc.New(core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   "player-A",
+		EntityID:   "char-A",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 4,
+	}))
+	enc.AddDoor(core.EntityID(doorID), core.Hex{Q: 1, R: 0, S: -1}, false)
+	data := enc.ToData()
+	door := data.Doors[core.EntityID(doorID)]
+	door.Locked = true
+	door.LockDC = dc
+	door.LockAbility = ability
+	door.LockTool = tool
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+}
+
+func (s *HandlerSuite) TestInteract_LockedDoor_ReturnsSkillCheckPrompt() {
+	s.seedLockedDoorEncounter("enc-locked-1", "door-east", 15, "DEX", "dnd5e:item:thieves-tools")
+
+	resp, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-locked-1",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	prompt := resp.GetInputRequired().GetSkillCheck()
+	s.Require().NotNil(prompt, "InputRequired{skill_check} must be populated for locked door")
+	s.Require().Equal(int32(15), prompt.GetDc())
+	s.Require().Equal("DEX", prompt.GetAbility())
+	s.Require().NotNil(prompt.GetTool())
+	s.Require().Equal("dnd5e", prompt.GetTool().GetModule())
+	s.Require().Equal("item", prompt.GetTool().GetType())
+	s.Require().Equal("thieves-tools", prompt.GetTool().GetId())
+
+	// Persisted prompt survives the call so SubmitCheck can resolve it.
+	loaded, err := s.repo.Get(s.ctx, "enc-locked-1")
+	s.Require().NoError(err)
+	s.Require().NotNil(loaded.PendingPrompts)
+	s.Require().Contains(loaded.PendingPrompts, core.PlayerID("player-A"))
+
+	// Door state remains locked + closed until SubmitCheck resolves the prompt.
+	door, ok := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(ok)
+	s.Require().True(door.Locked)
+	s.Require().False(door.Open)
+}
+
+func (s *HandlerSuite) TestInteract_LockedDoor_OmitsToolWhenEmpty() {
+	// LockTool is empty (no tool proficiency required) — proto Tool field
+	// must be nil rather than a zero-valued Ref.
+	s.seedLockedDoorEncounter("enc-locked-no-tool", "door-east", 12, "STR", "")
+
+	resp, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-locked-no-tool",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+	prompt := resp.GetInputRequired().GetSkillCheck()
+	s.Require().NotNil(prompt)
+	s.Require().Equal(int32(12), prompt.GetDc())
+	s.Require().Equal("STR", prompt.GetAbility())
+	s.Require().Nil(prompt.GetTool(), "tool ref must be nil when LockTool is empty")
+}
+
+func (s *HandlerSuite) TestInteract_LockedDoor_PendingPromptCollision_FailedPrecondition() {
+	s.seedLockedDoorEncounter("enc-locked-collide", "door-east", 15, "DEX", "")
+
+	// First call issues the prompt.
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-locked-collide",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+
+	// Second call (same player, prompt outstanding) must be rejected — the
+	// "at most one pending prompt per player" invariant is enforced server
+	// side, never gated in the web client.
+	_, err = s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-locked-collide",
+		TargetEntityId: "door-east",
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_NoAuth_Unauthenticated() {
+	ctx := context.Background()
+	_, err := s.handler.SubmitCheck(ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-1", EntityId: "char-A", Roll: 10,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.Unauthenticated, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_EmptyEncounterID_InvalidArgument() {
+	_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "", EntityId: "char-A", Roll: 10,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_EmptyEntityID_InvalidArgument() {
+	_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-1", EntityId: "", Roll: 10,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_RollOutOfRange_InvalidArgument() {
+	tests := []int32{0, 21, -1, 100}
+	for _, roll := range tests {
+		_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+			EncounterId: "enc-1", EntityId: "char-A", Roll: roll,
+		})
+		s.Require().Error(err, "roll=%d", roll)
+		st, _ := status.FromError(err)
+		s.Require().Equal(codes.InvalidArgument, st.Code(), "roll=%d", roll)
+	}
+}
+
+func (s *HandlerSuite) TestSubmitCheck_MissingEncounter_NotFound() {
+	_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "missing", EntityId: "char-A", Roll: 10,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.NotFound, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_NoPendingPrompt_FailedPrecondition() {
+	// Encounter exists with player-A but no prompt outstanding.
+	enc := tkenc.New("enc-no-prompt", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-no-prompt", EntityId: "char-A", Roll: 15,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code())
+}
+
+func (s *HandlerSuite) TestSubmitCheck_SuccessPath_OpensDoorAndEmitsEvents() {
+	s.seedLockedDoorEncounter("enc-resolve-1", "door-east", 10, "DEX", "")
+
+	// Issue the prompt first via Interact (puts a PendingPrompt on the encounter).
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-resolve-1",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+
+	// Subscribe before resolving so we capture the DoorOpened event.
+	sub, err := s.broker.Subscribe(core.EncounterID("enc-resolve-1"), core.PlayerID("player-A"))
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	// Roll 20 — well above DC 10 even with stub resolver returning zero mods.
+	resp, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-resolve-1", EntityId: "char-A", Roll: 20,
+	})
+	s.Require().NoError(err)
+	s.Require().True(resp.GetSuccess())
+	s.Require().Equal(int32(20), resp.GetTotal())
+
+	// Drain broker events with a short timeout. We expect at least one
+	// DoorOpenedEvent emitted by the toolkit's OpenDoor dispatch.
+	var sawDoorOpened bool
+	timer := time.After(200 * time.Millisecond)
+	for !sawDoorOpened {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				s.FailNow("subscription closed before DoorOpened arrived")
+			}
+			// We don't import the toolkit event types here; reflect on the
+			// concrete type name to keep this test free of new imports. The
+			// integration test below verifies the wire shape end-to-end.
+			if evt != nil {
+				if t := fmt.Sprintf("%T", evt); strings.Contains(t, "DoorOpened") {
+					sawDoorOpened = true
+				}
+			}
+		case <-timer:
+			s.FailNow("timed out waiting for DoorOpenedEvent on success path")
+		}
+	}
+
+	// Door is now open + unlocked, prompt cleared.
+	loaded, err := s.repo.Get(s.ctx, "enc-resolve-1")
+	s.Require().NoError(err)
+	door, ok := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(ok)
+	s.Require().True(door.Open)
+	s.Require().False(door.Locked, "successful unlock clears Locked")
+	s.Require().Empty(loaded.PendingPrompts, "prompt cleared after successful SubmitCheck")
+}
+
+func (s *HandlerSuite) TestSubmitCheck_FailurePath_NoEventsPromptCleared() {
+	s.seedLockedDoorEncounter("enc-resolve-fail", "door-east", 30, "DEX", "")
+
+	_, err := s.handler.Interact(s.ctx, &encounterv2pb.InteractRequest{
+		EncounterId:    "enc-resolve-fail",
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+
+	sub, err := s.broker.Subscribe(core.EncounterID("enc-resolve-fail"), core.PlayerID("player-A"))
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	// Roll 1 against DC 30 — guaranteed failure.
+	resp, err := s.handler.SubmitCheck(s.ctx, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: "enc-resolve-fail", EntityId: "char-A", Roll: 1,
+	})
+	s.Require().NoError(err)
+	s.Require().False(resp.GetSuccess())
+	s.Require().Equal(int32(1), resp.GetTotal())
+
+	// No DoorOpened/HexRevealed events should fire on failure. Wait briefly
+	// to give a misbehaving toolkit a chance to publish; absence is the assertion.
+	select {
+	case evt := <-sub.Events():
+		if evt != nil {
+			s.Failf("unexpected event on failure path", "%T", evt)
+		}
+	case <-time.After(100 * time.Millisecond):
+		// expected: no events
+	}
+
+	// Door remains closed + locked (failure doesn't unlock), prompt cleared.
+	loaded, err := s.repo.Get(s.ctx, "enc-resolve-fail")
+	s.Require().NoError(err)
+	door, ok := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(ok)
+	s.Require().False(door.Open)
+	s.Require().True(door.Locked, "failed unlock leaves door locked")
+	s.Require().Empty(loaded.PendingPrompts, "prompt cleared even on failure")
 }
 
 func TestHandlerSuite(t *testing.T) {

--- a/internal/handlers/dnd5e/v2/encounter/interact.go
+++ b/internal/handlers/dnd5e/v2/encounter/interact.go
@@ -3,7 +3,6 @@ package encounter
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -146,13 +145,15 @@ func buildSkillCheckPrompt(issued encounter.PromptIssued) *encounterv2pb.InputRe
 }
 
 // parseToolkitRef converts a toolkit ref string (e.g.
-// "dnd5e:item:thieves-tools") into a proto Ref. Falls back to a generic
-// {dnd5e, item, raw} encoding if the ref isn't in the canonical
-// "module:type:id" shape so unknown refs still round-trip something the
-// client can display.
+// "dnd5e:item:thieves-tools") into a proto Ref. Reuses the package's
+// existing splitRef helper (translate.go) so ref parsing semantics stay
+// consistent across projection / translation / prompt translation —
+// splitRef requires exactly two colons and returns nil otherwise. Falls
+// back to a generic {dnd5e, item, raw} encoding if the ref isn't in the
+// canonical "module:type:id" shape so unknown refs still round-trip
+// something the client can display.
 func parseToolkitRef(ref string) *encounterv2pb.Ref {
-	parts := strings.SplitN(ref, ":", 3)
-	if len(parts) == 3 {
+	if parts := splitRef(ref); parts != nil {
 		return &encounterv2pb.Ref{Module: parts[0], Type: parts[1], Id: parts[2]}
 	}
 	return &encounterv2pb.Ref{Module: refModuleDnd5e, Type: "item", Id: ref}

--- a/internal/handlers/dnd5e/v2/encounter/interact.go
+++ b/internal/handlers/dnd5e/v2/encounter/interact.go
@@ -3,6 +3,7 @@ package encounter
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -14,11 +15,13 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// Interact handles the Interact RPC. Wave 2.7 wires only door interactions:
-// when target_entity_id matches a known door, the toolkit's
-// Encounter.OpenDoor() verb is dispatched. The toolkit publishes the cause
-// event (DoorOpenedEvent) and the parallel effect event (HexRevealedEvent)
-// to the broker for delivery on StreamEncounter.
+// Interact handles the Interact RPC. Wave 2.7 wired the unlocked-door path
+// (toolkit OpenDoor verb dispatched directly). Wave 2.9 adds the locked-door
+// path: when the target door has Locked: true, the handler issues a
+// per-player skill-check prompt via the toolkit's AttemptUnlock verb and
+// returns the prompt to the caller as InputRequired{skill_check} on the
+// response. The caller then resolves the prompt by calling SubmitCheck with
+// a d20 roll.
 //
 // Future waves extend the dispatch to chests, levers, NPCs, and traps; the
 // optional interaction_kind field is plumbed through the proto for that
@@ -29,13 +32,15 @@ import (
 //   - empty encounter_id / target_entity_id → InvalidArgument
 //   - encounter not in repo → NotFound
 //   - target is not a known door in this encounter → NotFound
-//   - toolkit OpenDoor refuses (player not in encounter, door already open,
-//     etc.) → FailedPrecondition (per pat-v2-status-code-mapping)
+//   - door is locked → AttemptUnlock issues a prompt; response carries
+//     InputRequired{skill_check}; persistence captures PendingPrompts so
+//     the prompt survives reconnect. Stream sees no event (caller-private).
+//   - door is unlocked → OpenDoor publishes per-viewer DoorOpened +
+//     GeometryRevealed; response is empty by proto design.
+//   - toolkit OpenDoor / AttemptUnlock refuses (player not in encounter,
+//     door already open, prompt already pending, etc.) → FailedPrecondition
+//     per pat-v2-status-code-mapping.
 //   - save failure → Internal
-//
-// The empty InteractResponse is by proto design — door world changes flow as
-// events on StreamEncounter, not as response payload. Future locked-door
-// flow (Wave 2.10) will populate InputRequired for skill-check prompts.
 func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractRequest) (*encounterv2pb.InteractResponse, error) {
 	playerID := auth.GetPlayerID(ctx)
 	if playerID == "" {
@@ -56,18 +61,57 @@ func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractReque
 		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
 	}
 
-	// Wave 2.7 dispatch: only door interactions are wired. Future waves add
-	// chests, levers, NPCs, traps via additional lookups + dispatch arms.
+	// Wave 2.7/2.9 dispatch: only door interactions are wired. Future waves
+	// add chests, levers, NPCs, traps via additional lookups + dispatch arms.
 	targetID := core.EntityID(req.GetTargetEntityId())
-	if _, ok := data.Doors[targetID]; !ok {
+	door, ok := data.Doors[targetID]
+	if !ok {
 		return nil, status.Error(codes.NotFound, "target entity is not a door, or door does not exist")
 	}
 
-	enc, err := encounter.LoadFromData(data, h.broker)
+	enc, err := encounter.LoadFromData(data, h.broker, encounter.WithCharacterResolver(h.resolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}
 
+	// Locked-door branch (Wave 2.9): issue a per-player skill-check prompt
+	// via the toolkit's AttemptUnlock verb. The prompt is persisted to
+	// data.PendingPrompts so the caller can resolve it later via SubmitCheck;
+	// no broker event is emitted (prompts are caller-private).
+	if door.Locked {
+		issued, unlockErr := enc.AttemptUnlock(core.PlayerID(playerID), targetID)
+		if unlockErr != nil {
+			switch {
+			case errors.Is(unlockErr, encounter.ErrPromptAlreadyPending):
+				return nil, status.Error(codes.FailedPrecondition,
+					"resolve the pending prompt before issuing another action")
+			case errors.Is(unlockErr, encounter.ErrDoorNotLocked):
+				// Defensive: we just checked door.Locked. If toolkit reports
+				// unlocked the persisted snapshot is inconsistent with the
+				// loaded encounter — surface as Internal.
+				return nil, status.Errorf(codes.Internal,
+					"locked-door dispatch refused as not-locked: %v", unlockErr)
+			default:
+				// Player not in encounter, door not in encounter, etc. — these
+				// are state-dependent and map to FailedPrecondition per
+				// pat-v2-status-code-mapping. AttemptUnlock wraps these with
+				// fmt.Errorf rather than sentinels, so the default arm covers
+				// the long tail.
+				return nil, status.Errorf(codes.FailedPrecondition, "attempt unlock: %v", unlockErr)
+			}
+		}
+
+		if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"save encounter %q after attempt unlock: %v", req.GetEncounterId(), err)
+		}
+
+		return &encounterv2pb.InteractResponse{
+			InputRequired: buildSkillCheckPrompt(issued),
+		}, nil
+	}
+
+	// Unlocked-door branch (Wave 2.7): dispatch directly to OpenDoor.
 	if err := enc.OpenDoor(core.PlayerID(playerID), targetID); err != nil {
 		// Toolkit OpenDoor errors are state-dependent (player not in
 		// encounter, door already open) — these are gRPC FailedPrecondition
@@ -81,4 +125,35 @@ func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractReque
 	}
 
 	return &encounterv2pb.InteractResponse{}, nil
+}
+
+// buildSkillCheckPrompt translates the toolkit's PromptIssued verb-return
+// into the proto wire shape InputRequired{skill_check}. The tool ref is
+// optional (empty when no tool proficiency applies); we surface it as a
+// nullable Ref so the client can render thieves'-tools-or-not without a
+// separate flag.
+func buildSkillCheckPrompt(issued encounter.PromptIssued) *encounterv2pb.InputRequired {
+	prompt := &encounterv2pb.SkillCheckPrompt{
+		Dc:      int32(issued.DC), //nolint:gosec // DC is bounded by ruleset, never overflows int32
+		Ability: issued.Ability,
+	}
+	if issued.Tool != "" {
+		prompt.Tool = parseToolkitRef(issued.Tool)
+	}
+	return &encounterv2pb.InputRequired{
+		Kind: &encounterv2pb.InputRequired_SkillCheck{SkillCheck: prompt},
+	}
+}
+
+// parseToolkitRef converts a toolkit ref string (e.g.
+// "dnd5e:item:thieves-tools") into a proto Ref. Falls back to a generic
+// {dnd5e, item, raw} encoding if the ref isn't in the canonical
+// "module:type:id" shape so unknown refs still round-trip something the
+// client can display.
+func parseToolkitRef(ref string) *encounterv2pb.Ref {
+	parts := strings.SplitN(ref, ":", 3)
+	if len(parts) == 3 {
+		return &encounterv2pb.Ref{Module: parts[0], Type: parts[1], Id: parts[2]}
+	}
+	return &encounterv2pb.Ref{Module: refModuleDnd5e, Type: "item", Id: ref}
 }

--- a/internal/handlers/dnd5e/v2/encounter/submit_check.go
+++ b/internal/handlers/dnd5e/v2/encounter/submit_check.go
@@ -35,6 +35,9 @@ const (
 //   - roll outside [1, 20] → InvalidArgument (defense in depth before
 //     the toolkit also checks; surfaces a clearer error to the client)
 //   - encounter not in repo → NotFound
+//   - caller is not a member of the encounter → PermissionDenied
+//   - entity_id does not match caller's controlled entity →
+//     PermissionDenied (mirrors MoveEntity / EndTurn / TakeAction)
 //   - no pending prompt → FailedPrecondition
 //   - prompt is not a skill check → FailedPrecondition (other prompt
 //     kinds resolve via different verbs in future waves)
@@ -72,6 +75,23 @@ func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitChec
 		}
 		return nil, status.Errorf(codes.Internal,
 			"load encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	// Authorization: the caller must be a member of this encounter and the
+	// supplied entity_id must match their controlled entity. Mirrors the
+	// pattern used by MoveEntity / EndTurn / TakeAction so a caller cannot
+	// resolve a prompt that doesn't belong to them (defense in depth — the
+	// toolkit already keys PendingPrompts by playerID, so a non-member would
+	// hit ErrNoPendingPrompt anyway, but PermissionDenied is the clearer
+	// signal and prevents leaking encounter membership through the FailedPrecondition
+	// vs PermissionDenied distinction).
+	pd, ok := data.Players[core.PlayerID(playerID)]
+	if !ok {
+		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
+	}
+	if string(pd.EntityID) != req.GetEntityId() {
+		return nil, status.Error(codes.PermissionDenied,
+			"entity_id does not match player's controlled entity")
 	}
 
 	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))

--- a/internal/handlers/dnd5e/v2/encounter/submit_check.go
+++ b/internal/handlers/dnd5e/v2/encounter/submit_check.go
@@ -1,0 +1,129 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// d20 roll bounds — defense-in-depth alongside the toolkit's
+// ErrInvalidRoll, so we surface InvalidArgument before reaching the verb.
+const (
+	minD20Roll = 1
+	maxD20Roll = 20
+)
+
+// SubmitCheck handles the SubmitCheck RPC: it resolves the caller's currently
+// pending InputRequired prompt against a supplied d20 roll. The toolkit owns
+// modifier resolution (via the wired CharacterResolver) and any side-effect
+// dispatch on success — for Wave 2.9 the only wired action is "open" on a
+// locked door, which the toolkit dispatches to OpenDoor internally; that
+// publishes DoorOpened + GeometryRevealed through the broker the same way
+// Wave 2.7 did.
+//
+// Behavior contract:
+//   - missing auth → Unauthenticated
+//   - empty encounter_id / entity_id → InvalidArgument
+//   - roll outside [1, 20] → InvalidArgument (defense in depth before
+//     the toolkit also checks; surfaces a clearer error to the client)
+//   - encounter not in repo → NotFound
+//   - no pending prompt → FailedPrecondition
+//   - prompt is not a skill check → FailedPrecondition (other prompt
+//     kinds resolve via different verbs in future waves)
+//   - prompt's TriggeredAction is not wired in this toolkit version →
+//     Unimplemented
+//   - encounter has no character resolver → Internal (the orchestrator
+//     misconfigured itself; the resolver is wired by HandlerConfig)
+//   - save failure → Internal
+//
+// On success the response carries the resolved total (roll + ability
+// modifier + tool-proficiency bonus) and a boolean indicating whether
+// total >= prompt DC. World effects flow as broker events on the existing
+// StreamEncounter session — the response itself does not include them.
+func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitCheckRequest) (*encounterv2pb.SubmitCheckResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+	if req.GetEncounterId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+	if req.GetEntityId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "entity_id is required")
+	}
+	if req.GetRoll() < minD20Roll || req.GetRoll() > maxD20Roll {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"roll %d is outside the d20 range [%d, %d]",
+			req.GetRoll(), minD20Roll, maxD20Roll)
+	}
+
+	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, status.Error(codes.NotFound, "encounter not found")
+		}
+		return nil, status.Errorf(codes.Internal,
+			"load encounter %q: %v", req.GetEncounterId(), err)
+	}
+
+	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"load from data %q: %v", req.GetEncounterId(), err)
+	}
+
+	result, submitErr := enc.SubmitCheck(core.PlayerID(playerID), int(req.GetRoll()))
+	if submitErr != nil {
+		switch {
+		case errors.Is(submitErr, tkenc.ErrNoPendingPrompt):
+			return nil, status.Error(codes.FailedPrecondition,
+				"no pending prompt to resolve for caller")
+		case errors.Is(submitErr, tkenc.ErrPromptKindMismatch):
+			return nil, status.Error(codes.FailedPrecondition,
+				"pending prompt is not a skill check")
+		case errors.Is(submitErr, tkenc.ErrInvalidRoll):
+			// Defense in depth: handler-side bounds check above should have
+			// caught this. If it didn't, the toolkit's range disagrees with
+			// ours — still InvalidArgument from the client's perspective.
+			return nil, status.Errorf(codes.InvalidArgument,
+				"roll rejected by toolkit: %v", submitErr)
+		case errors.Is(submitErr, tkenc.ErrUnsupportedPromptAction):
+			return nil, status.Errorf(codes.Unimplemented,
+				"prompt action not supported in this server version: %v", submitErr)
+		case errors.Is(submitErr, tkenc.ErrNoCharacterResolver):
+			// The handler always wires a resolver (StubCharacterResolver as
+			// default). Reaching this means the orchestrator rebuilt the
+			// encounter without going through HandlerConfig — surface as
+			// Internal.
+			return nil, status.Errorf(codes.Internal,
+				"encounter has no character resolver wired: %v", submitErr)
+		default:
+			// Resolution-proceeded-but-dispatch-failed cases (downstream
+			// OpenDoor failures) wrap with fmt.Errorf rather than sentinels.
+			// The check itself succeeded (Success=true is reported in result)
+			// but the side effect failed; the prompt has been cleared by the
+			// toolkit. Surface as Internal so the client knows the world
+			// state may be inconsistent.
+			return nil, status.Errorf(codes.Internal,
+				"submit check dispatch: %v", submitErr)
+		}
+	}
+
+	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"save encounter %q after submit check: %v", req.GetEncounterId(), err)
+	}
+
+	return &encounterv2pb.SubmitCheckResponse{
+		Success: result.Success,
+		Total:   int32(result.Total), //nolint:gosec // total is roll(1-20)+small mods, fits int32
+	}, nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -75,7 +75,7 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 		return nil, status.Error(codes.PermissionDenied, "actor_entity_id does not match player's controlled entity")
 	}
 
-	enc, err := tkenc.LoadFromData(data, h.broker)
+	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -807,8 +807,10 @@ func (s *EncounterV2IntegrationSuite) TestInteract_LockedDoor_FailedRoll_NoEvent
 		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
 	s.Require().NoError(err)
 	for i := 0; i < 4; i++ {
-		_, _ = streamA.Recv()
-		_, _ = streamB.Recv()
+		_, recvErr := streamA.Recv()
+		s.Require().NoError(recvErr, "alice replay event %d", i+1)
+		_, recvErr = streamB.Recv()
+		s.Require().NoError(recvErr, "bob replay event %d", i+1)
 	}
 
 	_, err = s.srv.EncounterClientV2.Interact(ctxA, &encounterv2pb.InteractRequest{

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -643,6 +643,205 @@ func (s *EncounterV2IntegrationSuite) TestInteract_DoorAlreadyOpen_FailedPrecond
 	s.Require().Equal(codes.FailedPrecondition, st.Code())
 }
 
+// TestInteract_LockedDoor_PromptAndResolve_TwoPlayers is the Wave 2.9 gate
+// test. It exercises the full locked-door flow end-to-end:
+//
+//   - Two players in mutual LoS see a locked door.
+//   - alice calls Interact on the locked door — the response carries
+//     InputRequired{skill_check} (caller-private); bob's stream sees nothing
+//     for the prompt itself.
+//   - alice calls SubmitCheck with a passing roll — both alice and bob
+//     receive DoorOpened; the door is persisted as open + unlocked.
+//
+// The failure-path subtest exercises the same flow with a roll guaranteed to
+// fall short of the DC: the prompt clears, no events fire, and the door
+// stays closed + locked.
+func (s *EncounterV2IntegrationSuite) TestInteract_LockedDoor_PromptAndResolve_TwoPlayers() {
+	encID := "enc-locked-1"
+
+	// Seed: alice + bob in mutual LoS; one locked door at distance 4 from
+	// both (matches the unlocked-door test fixture so projection logic is
+	// the same).
+	enc := tkenc.New(core.EncounterID(encID), s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: -1, S: 0}, SightRange: 10,
+	}))
+	enc.AddDoor("door-east", core.Hex{Q: 4, R: 0, S: -4}, false)
+	data := enc.ToData()
+	door := data.Doors[core.EntityID("door-east")]
+	door.Locked = true
+	door.LockDC = 10
+	door.LockAbility = "DEX"
+	door.LockTool = "dnd5e:item:thieves-tools"
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, data))
+
+	ctxA := s.authCtx("alice")
+	ctxB := s.authCtx("bob")
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxA,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxB,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+
+	// Drain replay (Snapshot + 2 EntityAppeared + 1 GeometryRevealed = 4 events
+	// per stream, matching TestInteract_OpenDoor_TwoPlayers).
+	for i := 0; i < 4; i++ {
+		_, recvErr := streamA.Recv()
+		s.Require().NoError(recvErr, "alice replay event %d", i+1)
+		_, recvErr = streamB.Recv()
+		s.Require().NoError(recvErr, "bob replay event %d", i+1)
+	}
+
+	// --- Step 1: alice attempts to open the locked door. ---
+	resp, err := s.srv.EncounterClientV2.Interact(ctxA, &encounterv2pb.InteractRequest{
+		EncounterId:    encID,
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	prompt := resp.GetInputRequired().GetSkillCheck()
+	s.Require().NotNil(prompt, "locked door must return InputRequired{skill_check}")
+	s.Require().Equal(int32(10), prompt.GetDc())
+	s.Require().Equal("DEX", prompt.GetAbility())
+	s.Require().NotNil(prompt.GetTool())
+	s.Require().Equal("dnd5e", prompt.GetTool().GetModule())
+	s.Require().Equal("thieves-tools", prompt.GetTool().GetId())
+
+	// --- Step 2: alice submits a passing roll (20 vs DC 10). ---
+	// We drain bob's stream once after the SubmitCheck below; the cumulative
+	// window covers both Step 1 (which must be silent for bob since the
+	// prompt is caller-private) and Step 2 (which must publish DoorOpened
+	// to both viewers since the door is in their shared LoS). Two
+	// collectStreamEvents calls on the same stream would race on Recv.
+	subResp, err := s.srv.EncounterClientV2.SubmitCheck(ctxA, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: encID,
+		EntityId:    "char-alice",
+		Roll:        20,
+	})
+	s.Require().NoError(err)
+	s.Require().True(subResp.GetSuccess())
+	s.Require().Equal(int32(20), subResp.GetTotal())
+
+	// Both alice and bob now receive DoorOpened (door is in both LoS).
+	postA := s.collectStreamEvents(streamA, 3, 500*time.Millisecond)
+	postB := s.collectStreamEvents(streamB, 3, 500*time.Millisecond)
+
+	var aDoor, bDoor *encounterv2pb.DoorOpened
+	for _, ev := range postA {
+		if d := ev.GetDoorOpened(); d != nil {
+			aDoor = d
+			break
+		}
+	}
+	for _, ev := range postB {
+		if d := ev.GetDoorOpened(); d != nil {
+			bDoor = d
+			break
+		}
+	}
+	s.Require().NotNil(aDoor, "alice should receive DoorOpened (she resolved the prompt)")
+	s.Require().Equal("door-east", aDoor.GetDoorEntityId())
+	s.Require().NotNil(bDoor, "bob should receive DoorOpened (door is in his LoS)")
+	s.Require().Equal("door-east", bDoor.GetDoorEntityId())
+
+	// The prompt was caller-private: walk bob's drained event list and
+	// confirm no extra envelopes arrived ahead of DoorOpened (geometry
+	// events trail DoorOpened in the toolkit's emit order).
+	for _, ev := range postB {
+		if d := ev.GetDoorOpened(); d != nil {
+			break
+		}
+		s.Failf("bob received an unexpected event before DoorOpened",
+			"event %s arrived ahead of DoorOpened", ev.String())
+	}
+
+	// Door is persisted as open + unlocked, prompt cleared.
+	persisted, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	pdoor, ok := persisted.Doors[core.EntityID("door-east")]
+	s.Require().True(ok)
+	s.Require().True(pdoor.Open)
+	s.Require().False(pdoor.Locked, "successful unlock clears Locked")
+	s.Require().Empty(persisted.PendingPrompts, "prompt cleared after successful resolve")
+}
+
+// TestInteract_LockedDoor_FailedRoll_NoEvents covers the failure path of the
+// Wave 2.9 flow: alice issues the prompt, submits a roll that can't beat the
+// DC, and bob's stream sees nothing while alice's response reports failure.
+// The door remains closed + locked; the prompt is cleared so alice can try
+// again from scratch.
+func (s *EncounterV2IntegrationSuite) TestInteract_LockedDoor_FailedRoll_NoEvents() {
+	encID := "enc-locked-fail"
+
+	enc := tkenc.New(core.EncounterID(encID), s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: -1, S: 0}, SightRange: 10,
+	}))
+	enc.AddDoor("door-east", core.Hex{Q: 4, R: 0, S: -4}, false)
+	data := enc.ToData()
+	door := data.Doors[core.EntityID("door-east")]
+	door.Locked = true
+	door.LockDC = 30 // unbeatable with d20 + zero modifiers
+	door.LockAbility = "DEX"
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, data))
+
+	ctxA := s.authCtx("alice")
+	ctxB := s.authCtx("bob")
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxA,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxB,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	for i := 0; i < 4; i++ {
+		_, _ = streamA.Recv()
+		_, _ = streamB.Recv()
+	}
+
+	_, err = s.srv.EncounterClientV2.Interact(ctxA, &encounterv2pb.InteractRequest{
+		EncounterId:    encID,
+		TargetEntityId: "door-east",
+	})
+	s.Require().NoError(err)
+
+	subResp, err := s.srv.EncounterClientV2.SubmitCheck(ctxA, &encounterv2pb.SubmitCheckRequest{
+		EncounterId: encID,
+		EntityId:    "char-alice",
+		Roll:        1, // guaranteed failure vs DC 30
+	})
+	s.Require().NoError(err)
+	s.Require().False(subResp.GetSuccess(), "roll 1 vs DC 30 must fail")
+	s.Require().Equal(int32(1), subResp.GetTotal())
+
+	// Drain each stream once with a settle window. Failure path must not
+	// publish any post-replay events on either stream.
+	silentA := s.collectStreamEvents(streamA, 1, 250*time.Millisecond)
+	s.Require().Empty(silentA, "alice must not see DoorOpened on failed unlock")
+	silentB := s.collectStreamEvents(streamB, 1, 250*time.Millisecond)
+	s.Require().Empty(silentB, "bob must not see anything on failed unlock")
+
+	persisted, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	pdoor, ok := persisted.Doors[core.EntityID("door-east")]
+	s.Require().True(ok)
+	s.Require().False(pdoor.Open, "door stays closed on failed unlock")
+	s.Require().True(pdoor.Locked, "door stays locked on failed unlock")
+	s.Require().Empty(persisted.PendingPrompts, "prompt cleared even on failure")
+}
+
 // TestCombatSlice_TakeActionAndEndTurn_NPCDispatch is the wave-2.8 gate test.
 // It exercises the full attack → endturn → npc-act → endturn loop on bufconn:
 //


### PR DESCRIPTION
Implements the rpg-api slice of the Wave 2.9 encounter contract: locked doors prompt for a skill check on `Interact` and resolve via a new `SubmitCheck` RPC.

Closes #514

## What shipped

- Bumped `rpg-toolkit/encounter` to `v0.4.0` (locked doors + `PendingPrompt` model + `AttemptUnlock`/`SubmitCheck` verbs + `CharacterResolver` hook).
- `Interact` now branches on `door.Locked`: locked doors call `AttemptUnlock`, return `InputRequired{skill_check}` on the response, and persist a `PendingPrompt` for the caller. No broker event is emitted (caller-private, per design.md §4). Unlocked-door behavior is unchanged from Wave 2.7.
- New `SubmitCheck` handler at `internal/handlers/dnd5e/v2/encounter/submit_check.go`. Validates roll in `[1, 20]`, dispatches `enc.SubmitCheck(playerID, roll)`, and maps each toolkit sentinel error to its gRPC status code:

| sentinel | gRPC code |
|---|---|
| `ErrNoPendingPrompt` | `FailedPrecondition` |
| `ErrPromptKindMismatch` | `FailedPrecondition` |
| `ErrInvalidRoll` | `InvalidArgument` |
| `ErrUnsupportedPromptAction` | `Unimplemented` |
| `ErrNoCharacterResolver` | `Internal` (handler always wires one) |
| dispatch failure (wrapped) | `Internal` |

- Success path's `DoorOpened` + `HexRevealed` events flow through the existing Wave 2.7 translator path — no new translator code needed.

## CharacterResolver wiring approach

Implemented `StubCharacterResolver` (returns `(0, true)` for every modifier query) and wired it as the default in `HandlerConfig.Resolver`. All encounter construction sites — `CreateEncounter`, `MoveEntity`, `EndTurn`, `TakeAction`, `Interact`, `SubmitCheck` — now pass `WithCharacterResolver(h.resolver)` so `SubmitCheck` never sees `ErrNoCharacterResolver`.

**Why a stub for now**: `PlayerData.EntityID` currently mirrors `PlayerID`; there's no encounter-side hook that maps a player to a character document for ability/tool lookups. Wiring the real bridge is out of scope for the Wave 2.9 wire-shape gate. The stub makes `SubmitCheck` deterministic (`total = roll + 0 + 0`) which is what the Wave 2.9 web slice needs to verify the prompt → resolve flow.

**Follow-up**: a separate issue should add player→character resolution to the encounter and replace `StubCharacterResolver` with one that pulls real ability modifiers + tool-proficiency bonuses from the character store. The interface contract is stable; only the implementation changes.

## Test coverage

- Handler unit tests (`handler_test.go`): locked-door prompt shape (DC + ability + tool ref), empty-tool case, pending-prompt collision (`FailedPrecondition`), `SubmitCheck` happy/failure paths (success emits `DoorOpened`, failure publishes nothing and clears the prompt), every validation arm (auth, IDs, roll bounds, missing encounter, no pending prompt).
- Integration test (`encounter_v2_test.go`, extending `EncounterV2IntegrationSuite`):
  - **Success path**: alice + bob in mutual LoS, locked door at distance 4. Alice's `Interact` returns `InputRequired{skill_check}`; alice submits roll 20 vs DC 10; both alice and bob receive `DoorOpened` per their PerceptionView; door persists as open + unlocked; prompt clears.
  - **Failure path**: alice's `SubmitCheck` with roll 1 vs DC 30 reports failure; neither stream sees any post-replay event; door stays closed + locked; prompt still clears.

## What's deferred

- Real `CharacterResolver` (filed as follow-up).
- DialogueChoice / TargetSelect prompt kinds (Wave 2.10+).
- Trap-triggered prompts (Wave 2.10+; same `SubmitCheck` path, different trigger source).
- Crit (nat 20) / fumble (nat 1) special handling.

## Test plan

- [x] `go test ./internal/handlers/dnd5e/v2/encounter/... -race` — green
- [x] `go test ./internal/integration/... -race -run TestEncounterV2IntegrationSuite` — green
- [x] `golangci-lint run --new-from-rev=main` on touched packages — 0 issues
- [x] No proto bump (verified — proto types already shipped in current generated version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)