### PR TITLE
feat(encounter/v2): translate death events + encounter-end terminal-state guard (Wave 2.10)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260507051118-0443dec90664
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.4.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.5.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.55.5
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.4.0 h1:0sonOGSTP5HVwR5O+z0Mh3cmWIvvksclDsmBAlt0Pl8=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.4.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.5.0 h1:W5ZLv9Trm//N3aqNOLtk8duHk6Df8IYnOLRzhoj/ZW4=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.5.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -312,12 +312,23 @@ func (s *HandlerSuite) TestTakeAction_AttackHappyPath_PersistsMonsterHP() {
 	s.Require().NotNil(resp)
 
 	// Reload — toolkit may or may not have hit (random d20). The contract is
-	// that the encounter is saved post-attack. HP <= preHP regardless of
-	// hit/miss; on hit it's strictly less.
+	// that the encounter is saved post-attack. Three valid post-states:
+	//   - miss: goblin still in map, HP unchanged
+	//   - hit (non-lethal): goblin still in map, HP strictly less than preHP
+	//   - hit (lethal): goblin removed from map by Wave 2.10 killEntity chain
+	// Wave 2.10 guarantees the lethal path: the seed fixture has goblin HP=7
+	// and alice deals 1d8+2 (3-10), so a single hit can kill. Don't index the
+	// monsters map blindly — check membership first to differentiate the
+	// surviving from the killed branch.
 	postData, err := s.repo.Get(s.ctx, combatEncID)
 	s.Require().NoError(err)
-	s.Require().LessOrEqual(postData.Monsters[monsterGoblin1].HP, preHP,
-		"goblin HP must not increase after attack")
+	if postGob, alive := postData.Monsters[monsterGoblin1]; alive {
+		s.Require().LessOrEqual(postGob.HP, preHP,
+			"goblin HP must not increase after attack")
+	}
+	// Lethal-hit branch: goblin absent from map. Implicit pass — the kill
+	// chain (toolkit's killEntity) already covers the post-state in
+	// Wave 2.10's TestCombatSlice_KillLastHostile_FiresDeathChainAndEnds.
 }
 
 // EndTurn tests -----------------------------------------------------------

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -483,3 +483,52 @@ func (s *HandlerSuite) TestEndTurn_NPCDispatchLoop_CyclesPastNPC() {
 	_, postIsPlayer := s.findPlayerByEntity(postData, postActive)
 	s.Require().True(postIsPlayer, "after EndTurn, active actor must be a player (not goblin)")
 }
+
+// Wave 2.10: terminal-state guard tests --------------------------------
+//
+// These verify the handler maps tkenc.ErrEncounterEnded → FailedPrecondition.
+// Direct-mutation seeding (set data.Mode = ModeEnded after Save) keeps the
+// fixture deterministic — we don't depend on running an attack chain to
+// drive the encounter to ModeEnded; the toolkit's own death tests cover the
+// transition.
+
+// seedEndedEncounter saves a turn-based encounter with Mode rewritten to
+// ModeEnded so combat verbs return ErrEncounterEnded on the next call.
+// Returns the entity id of whichever player is in the (now-ignored)
+// initiative roster — handler tests need a syntactically valid actor /
+// entity id to exercise the post-validation, post-load gate.
+func (s *HandlerSuite) seedEndedEncounter() string {
+	s.seedCombatEncounter()
+	data, err := s.repo.Get(s.ctx, combatEncID)
+	s.Require().NoError(err)
+	// Pick alice if she's in the roster (always is, per fixture); fallback
+	// to whatever active actor was seeded.
+	actorEntity := entityAliceID
+	// Flip to terminal state — the combat verbs check this gate first
+	// (before turn-violation / non-combatant checks).
+	data.Mode = core.ModeEnded
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+	return actorEntity
+}
+
+func (s *HandlerSuite) TestTakeAction_EncounterEnded_FailedPrecondition() {
+	actorEntity := s.seedEndedEncounter()
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	_, err := s.handler.TakeAction(ctx, makeAttackRequest(actorEntity, monsterGoblin1))
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code(),
+		"TakeAction against an ended encounter must return FailedPrecondition, got: %v", err)
+}
+
+func (s *HandlerSuite) TestEndTurn_EncounterEnded_FailedPrecondition() {
+	actorEntity := s.seedEndedEncounter()
+	ctx := contextWithPlayer(s.ctx, playerAliceID)
+	_, err := s.handler.EndTurn(ctx, &encounterv2pb.EndTurnRequest{
+		EncounterId: combatEncID, EntityId: actorEntity,
+	})
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.FailedPrecondition, st.Code(),
+		"EndTurn against an ended encounter must return FailedPrecondition, got: %v", err)
+}

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -94,6 +94,15 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 	// the new active actor is an NPC the handler runs its turn server-side
 	// and ends it, then re-checks. The cap is initiative-size + margin so an
 	// all-NPC roster cycles all the way through rather than freezing the RPC.
+	//
+	// Wave 2.10: after each NPCAct / EndTurn cycle, if the encounter has
+	// transitioned to ModeEnded (e.g., NPC's attack killed the last hostile
+	// — not possible today since killEntity only runs in TakeAction's
+	// player-attack path, but cheap insurance for future paths like
+	// faction-on-faction NPC kills, environmental damage, etc.), break out
+	// of the loop. The post-loop save persists the terminal state and the
+	// RPC returns success — the EncounterEnded event already fired through
+	// the broker, and the next combat verb will get ErrEncounterEnded.
 	npcChainCap := len(data.Initiative) + npcChainSafetyMargin
 	for depth := 0; isNPC && depth < npcChainCap; depth++ {
 		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
@@ -108,10 +117,31 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 			}
 			return nil, status.Errorf(codes.Internal, "npc act %q: %v", string(newActive), actErr)
 		}
+		// Post-NPCAct end-of-encounter check (Wave 2.10 guard).
+		if enc.Mode() == core.ModeEnded {
+			isNPC = false
+			break
+		}
 		var endErr error
 		newActive, isNPC, endErr = enc.EndTurn(newActive)
 		if endErr != nil {
+			// ErrEncounterEnded here means the NPC's action ended the
+			// encounter and the subsequent EndTurn rejected the call.
+			// Treat as success — the encounter has terminated, the events
+			// already fired, and we just need to persist the terminal
+			// state. Fall through to the post-loop save by clearing isNPC.
+			if errors.Is(endErr, tkenc.ErrEncounterEnded) {
+				isNPC = false
+				break
+			}
 			return nil, endTurnStatusError(endErr)
+		}
+		// Post-EndTurn end-of-encounter check (Wave 2.10 guard, defensive
+		// — EndTurn doesn't mutate liveness today, but stays robust to
+		// future paths that fold post-turn cleanup into EndTurn).
+		if enc.Mode() == core.ModeEnded {
+			isNPC = false
+			break
 		}
 	}
 
@@ -141,8 +171,14 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 // endTurnStatusError maps toolkit EndTurn sentinel errors onto gRPC status
 // codes. All EndTurn errors are state-dependent → FailedPrecondition,
 // except wrapping/internal failures which surface as Internal.
+//
+// Wave 2.10: ErrEncounterEnded is the terminal-state sentinel returned
+// when EndTurn is called against an encounter whose mode is ModeEnded.
+// State-dependent → FailedPrecondition.
 func endTurnStatusError(err error) error {
 	switch {
+	case errors.Is(err, tkenc.ErrEncounterEnded):
+		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, tkenc.ErrNotTurnBased):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, tkenc.ErrNotYourTurn):

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -177,6 +177,55 @@ func (s *ProjectSuite) TestProjectFor_FreeRoam_NoTurnState() {
 	s.Require().Nil(pb.GetTurnState(), "TurnState must be omitted outside TURN_BASED mode")
 }
 
+// TestProjectFor_ModeEnded_NoTurnStateAndOmitsRemovedMonsters verifies the
+// Wave 2.10 snapshot replay contract for terminal-state encounters: a player
+// who reconnects after the encounter ended must see (a) no TurnState (so the
+// UI doesn't render "your turn" / "alice acting" stale prompts), and (b) no
+// trace of monsters removed by the kill chain (the toolkit's killEntity
+// deletes them from data.Monsters before publishing EntityRemoved). The
+// dedicated EncounterEndedEvent — replayed via the broker's per-stream queue
+// — carries the "this is over" wire signal; the snapshot's Mode field is
+// mapped to FREE_ROAM since the proto has no _ENDED variant.
+func (s *ProjectSuite) TestProjectFor_ModeEnded_NoTurnStateAndOmitsRemovedMonsters() {
+	data := tkenc.NewData("enc-ended")
+	data.Mode = core.ModeEnded
+	// Surviving fields that ModeEnded clears in the toolkit kill path:
+	// Initiative, ActiveIdx, Round are reset by checkEncounterEnd. Mirror
+	// that here so the fixture reflects post-end persisted state.
+	data.Initiative = nil
+	data.ActiveIdx = 0
+	data.Round = 0
+
+	alice := newPlayerData("player-alice", "char-alice", originHex, 5)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
+	// data.Monsters intentionally empty — killEntity removed the last hostile
+	// before flipping mode to ModeEnded. Snapshot must not synthesize one.
+
+	pb, err := v2encounter.ProjectFor(data, "player-alice", s.broker, s.now)
+	s.Require().NoError(err)
+
+	// Mode maps to FREE_ROAM because the proto has no _ENDED variant; the
+	// dedicated EncounterEndedEvent is the canonical wire signal that the
+	// encounter has terminated.
+	s.Require().Equal(
+		encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
+		pb.GetMode(),
+		"ModeEnded must map to FREE_ROAM (proto has no _ENDED variant); EncounterEndedEvent carries the terminal-state signal",
+	)
+	// No TurnState — buildTurnState gates on ModeTurnBased and ModeEnded
+	// is neither, so the UI doesn't render stale "your turn" prompts.
+	s.Require().Nil(pb.GetTurnState(), "TurnState must be omitted post-end")
+	// Space remains populated for the viewer's revealed hexes + their own
+	// entity, but no monster entities should appear (data.Monsters is empty).
+	s.Require().NotNil(pb.GetSpace())
+	for _, e := range pb.GetSpace().GetEntities() {
+		s.Require().NotEqual(
+			encounterv2pb.EntityType_ENTITY_TYPE_MONSTER, e.GetType(),
+			"removed monster %q must not appear in post-end snapshot", e.GetId(),
+		)
+	}
+}
+
 func (s *ProjectSuite) TestProjectFor_Unspecified_TreatedAsFreeRoam() {
 	// Toolkit doc convention: ModeUnspecified is treated as ModeFreeRoam. Make
 	// sure ProjectFor reflects that on the wire so late-joining clients don't

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -105,8 +105,14 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 // don't exist in the encounter — though the toolkit overloads
 // ErrUnknownTarget to also mean state-dependent missing-monster, so we
 // map it to FailedPrecondition).
+//
+// Wave 2.10: ErrEncounterEnded is the terminal-state sentinel returned
+// when verbs are called against an encounter whose mode is ModeEnded.
+// State-dependent → FailedPrecondition.
 func takeActionStatusError(err error) error {
 	switch {
+	case errors.Is(err, tkenc.ErrEncounterEnded):
+		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, tkenc.ErrNotTurnBased):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, tkenc.ErrNotYourTurn):

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -82,6 +82,12 @@ func TranslateEvent(evt events.EncounterEvent, viewer core.PlayerID, now time.Ti
 		return translateTurnStartedEvent(e, viewer, now)
 	case *events.TurnEndedEvent:
 		return translateTurnEndedEvent(e, viewer, now)
+	case *events.EntityDiedEvent:
+		return translateEntityDiedEvent(e, viewer, now)
+	case *events.EntityRemovedEvent:
+		return translateEntityRemovedEvent(e, viewer, now)
+	case *events.EncounterEndedEvent:
+		return translateEncounterEndedEvent(e, viewer, now)
 	default:
 		return nil, fmt.Errorf("%w: %T", ErrUnknownEventType, evt)
 	}
@@ -367,6 +373,84 @@ func translateTurnEndedEvent(e *events.TurnEndedEvent, viewer core.PlayerID, now
 	}, nil
 }
 
+// translateEntityDiedEvent maps the toolkit's EntityDiedEvent (cause /
+// narrative) to the proto EntityDied envelope. Per-viewer projection: the
+// toolkit publishes a Visible:false slice for viewers who lack LoS to both
+// the dying entity and the killer; the stream loop must drop those via
+// ErrViewerSawNothing rather than send a Visible:false event downstream
+// (no wire shape carries visibility metadata for death).
+//
+// KillerEntityId is a proto optional field (oneof). The toolkit emits
+// KillerID="" when the cause has no single attributable attacker
+// (environmental damage, future indirect-kill paths); leave the proto
+// field unset in that case so clients can distinguish "killed by X" from
+// "killed by something".
+func translateEntityDiedEvent(e *events.EntityDiedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	slice, ok := e.PerPlayer[viewer]
+	if !ok || !slice.Visible {
+		return nil, ErrViewerSawNothing
+	}
+	out := &encounterv2pb.EntityDied{
+		EntityId: string(e.EntityID),
+	}
+	if e.KillerID != "" {
+		k := string(e.KillerID)
+		out.KillerEntityId = &k
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_EntityDied{
+			EntityDied: out,
+		},
+	}, nil
+}
+
+// translateEntityRemovedEvent maps the toolkit's EntityRemovedEvent
+// (effect / state mutation) to the proto EntityRemoved envelope. The
+// toolkit's audience for this event is BROADCAST: every viewer in the
+// encounter is in PerPlayer with Visible:true so even out-of-LoS clients
+// drop the entity from their local mirror. The translator therefore only
+// gates on viewer-presence, not Visible — a missing PerPlayer entry would
+// indicate a toolkit-side audience bug (the contract is broadcast), and
+// returning ErrViewerSawNothing in that defensive case is the safest
+// stream-loop behavior.
+func translateEntityRemovedEvent(e *events.EntityRemovedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	if _, ok := e.PerPlayer[viewer]; !ok {
+		return nil, ErrViewerSawNothing
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_EntityRemoved{
+			EntityRemoved: &encounterv2pb.EntityRemoved{
+				EntityId: string(e.EntityID),
+				Reason:   e.Reason,
+			},
+		},
+	}, nil
+}
+
+// translateEncounterEndedEvent maps the toolkit's EncounterEndedEvent
+// (terminal-state transition) to the proto EncounterEnded envelope. Like
+// EntityRemoved, the toolkit's audience is BROADCAST — every viewer must
+// observe the end so subsequent verbs are gated client-side. Gate only on
+// viewer-presence per the broadcast-contract reasoning above.
+func translateEncounterEndedEvent(e *events.EncounterEndedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	if _, ok := e.PerPlayer[viewer]; !ok {
+		return nil, ErrViewerSawNothing
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_EncounterEnded{
+			EncounterEnded: &encounterv2pb.EncounterEnded{
+				Reason: e.Reason,
+			},
+		},
+	}, nil
+}
+
 // damageRefFor builds a proto Ref for a toolkit damage-type string. The
 // toolkit emits bare strings (e.g. "slashing", "fire", "untyped"); the proto
 // wire shape uses a Ref triple. For Wave 2.8 we hardwire module=dnd5e and
@@ -420,11 +504,19 @@ func splitRef(s string) []string {
 // snapshot projector (ProjectFor) and the ModeChanged event translator
 // share this helper so the wire is consistent across snapshot vs.
 // live-event paths.
+//
+// Wave 2.10: core.ModeEnded is the terminal-state value, but the
+// v1alpha2 proto has no _ENDED enum variant (the wire signal is the
+// dedicated EncounterEnded event, not the mode enum). Map ModeEnded to
+// FREE_ROAM so a snapshot of a terminal encounter renders without turn
+// structure (no active actor, no initiative) rather than UNSPECIFIED
+// which clients would treat as "never set". The EncounterEndedEvent
+// remains the canonical signal that combat verbs are now gated.
 func encounterModeToProto(m core.EncounterMode) encounterv2pb.EncounterMode {
 	switch m {
 	case core.ModeTurnBased:
 		return encounterv2pb.EncounterMode_ENCOUNTER_MODE_TURN_BASED
-	case core.ModeFreeRoam, core.ModeUnspecified:
+	case core.ModeFreeRoam, core.ModeUnspecified, core.ModeEnded:
 		return encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM
 	}
 	return encounterv2pb.EncounterMode_ENCOUNTER_MODE_UNSPECIFIED

--- a/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
@@ -255,3 +255,195 @@ func (s *TranslateSuite) TestTranslateEvent_TurnEndedEvent_ViewerNotInPerPlayer_
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
 }
+
+// EntityDied translator tests --------------------------------------------
+
+func (s *TranslateSuite) TestTranslateEvent_EntityDiedEvent_HappyPath_WithKiller() {
+	evt := events.NewEntityDiedEvent(
+		"enc-1", uint64(60),
+		"goblin-1", "char-A",
+		map[core.PlayerID]events.EntityDiedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	died := out.GetEntityDied()
+	s.Require().NotNil(died, "expected EntityDied envelope")
+	s.Require().Equal("goblin-1", died.GetEntityId())
+	s.Require().Equal("char-A", died.GetKillerEntityId())
+	s.Require().Equal(int64(60), out.Sequence)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EntityDiedEvent_EmptyKiller_OmitsKillerField() {
+	// KillerID="" represents environmental damage / indirect kill — the
+	// proto optional field should remain unset so clients can distinguish
+	// "killed by X" from "killed by something untracked".
+	evt := events.NewEntityDiedEvent(
+		"enc-1", uint64(61),
+		"goblin-1", "",
+		map[core.PlayerID]events.EntityDiedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	died := out.GetEntityDied()
+	s.Require().NotNil(died)
+	s.Require().Equal("goblin-1", died.GetEntityId())
+	s.Require().Nil(died.KillerEntityId, "empty killer must leave proto field unset (oneof)")
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EntityDiedEvent_NotVisible_ReturnsErrViewerSawNothing() {
+	// Per-viewer projection: viewer has no LoS to dying entity OR killer →
+	// Visible:false → drop on the floor (stream-loop continues silently).
+	evt := events.NewEntityDiedEvent(
+		"enc-1", uint64(62),
+		"goblin-1", "char-A",
+		map[core.PlayerID]events.EntityDiedSlice{
+			"player-A": {Visible: false},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EntityDiedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewEntityDiedEvent(
+		"enc-1", uint64(63),
+		"goblin-1", "char-A",
+		map[core.PlayerID]events.EntityDiedSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+// EntityRemoved translator tests -----------------------------------------
+
+func (s *TranslateSuite) TestTranslateEvent_EntityRemovedEvent_HappyPath_BroadcastAudience() {
+	// Audience is broadcast: every viewer is in PerPlayer with Visible:true.
+	evt := events.NewEntityRemovedEvent(
+		"enc-1", uint64(70),
+		"goblin-1", "destroyed",
+		map[core.PlayerID]events.EntityRemovedSlice{
+			"player-A": {Visible: true},
+			"player-B": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	rem := out.GetEntityRemoved()
+	s.Require().NotNil(rem, "expected EntityRemoved envelope")
+	s.Require().Equal("goblin-1", rem.GetEntityId())
+	s.Require().Equal("destroyed", rem.GetReason())
+	s.Require().Equal(int64(70), out.Sequence)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EntityRemovedEvent_BothViewersGetEvent() {
+	// Same event, two viewers — both must receive a populated envelope.
+	evt := events.NewEntityRemovedEvent(
+		"enc-1", uint64(71),
+		"goblin-1", "destroyed",
+		map[core.PlayerID]events.EntityRemovedSlice{
+			"player-A": {Visible: true},
+			"player-B": {Visible: true},
+		},
+	)
+	outA, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(outA.GetEntityRemoved())
+
+	outB, err := v2encounter.TranslateEvent(evt, "player-B", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(outB.GetEntityRemoved())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EntityRemovedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	// Defensive case: toolkit contract is broadcast, so a missing entry
+	// would be a toolkit bug. Translator returns ErrViewerSawNothing so the
+	// stream loop drops it silently rather than emitting a malformed event.
+	evt := events.NewEntityRemovedEvent(
+		"enc-1", uint64(72),
+		"goblin-1", "destroyed",
+		map[core.PlayerID]events.EntityRemovedSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
+// EncounterEnded translator tests ---------------------------------------
+
+func (s *TranslateSuite) TestTranslateEvent_EncounterEndedEvent_HappyPath() {
+	evt := events.NewEncounterEndedEvent(
+		"enc-1", uint64(80),
+		"all_hostiles_defeated",
+		map[core.PlayerID]events.EncounterEndedSlice{
+			"player-A": {Visible: true},
+			"player-B": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+
+	end := out.GetEncounterEnded()
+	s.Require().NotNil(end, "expected EncounterEnded envelope")
+	s.Require().Equal("all_hostiles_defeated", end.GetReason())
+	s.Require().Equal(int64(80), out.Sequence)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EncounterEndedEvent_BothViewersGetEvent() {
+	// Broadcast audience — same event reaches every viewer.
+	evt := events.NewEncounterEndedEvent(
+		"enc-1", uint64(81),
+		"all_hostiles_defeated",
+		map[core.PlayerID]events.EncounterEndedSlice{
+			"player-A": {Visible: true},
+			"player-B": {Visible: true},
+		},
+	)
+	outA, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(outA.GetEncounterEnded())
+	outB, err := v2encounter.TranslateEvent(evt, "player-B", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(outB.GetEncounterEnded())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EncounterEndedEvent_EmptyReason_PassesThrough() {
+	// Reason is documented as a free-form string — empty is valid, the
+	// proto field stays empty.
+	evt := events.NewEncounterEndedEvent(
+		"enc-1", uint64(82),
+		"",
+		map[core.PlayerID]events.EncounterEndedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(out.GetEncounterEnded())
+	s.Require().Equal("", out.GetEncounterEnded().GetReason())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_EncounterEndedEvent_ViewerNotInPerPlayer_ReturnsErrViewerSawNothing() {
+	evt := events.NewEncounterEndedEvent(
+		"enc-1", uint64(83),
+		"all_hostiles_defeated",
+		map[core.PlayerID]events.EncounterEndedSlice{
+			"player-X": {Visible: true},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -993,6 +993,372 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 		"after EndTurn + NPC dispatch loop, active actor must be a player, got %q", finalActive)
 }
 
+// Wave 2.10 integration tests: death + encounter end ----------------------
+//
+// Two scenarios verify the full death-resolution slice end-to-end:
+//
+//   1. Last-hostile kill: 2 players + 1 goblin. Active player attacks the
+//      goblin to HP=0; both streams must receive EntityDied + EntityRemoved
+//      + EncounterEnded. A subsequent TakeAction must return
+//      FailedPrecondition (mapped from tkenc.ErrEncounterEnded).
+//
+//   2. Mid-fight kill (no end): 2 players + 2 goblins. Active player kills
+//      goblin-1; both streams must receive EntityDied + EntityRemoved for
+//      goblin-1 only — no EncounterEnded. The active player ends turn; the
+//      NPC dispatch loop skips dead goblin-1 (now spliced out of
+//      initiative) and brings combat back around. Active player kills
+//      goblin-2; EncounterEnded fires.
+//
+// Determinism: monsters are seeded with HP=1 and the killing player has
+// AttackBonus=20 (so any d20 roll except nat-1 hits AC=10). Damage dice
+// "1d6" guarantees >=1 dmg on hit, killing HP=1 monster. Tests loop
+// TakeAction up to maxKillAttempts to absorb the rare nat-1 miss without
+// flakiness.
+
+// maxKillAttempts caps the number of TakeAction calls used to drive a
+// goblin (HP=1, AC=10) to zero HP from a player with AttackBonus=20.
+// Each attack misses only on nat-1 (5% chance), so 20 attempts give a
+// failure probability of (1/20)^20 ≈ 9.5e-27 — well below CI flakiness
+// floors.
+const maxKillAttempts = 20
+
+// killGoblinFixturePlayerInput returns a PlayerInput tuned for the death
+// integration tests: AttackBonus=20 + DamageDice "1d6" makes the player a
+// reliable HP=1 monster killer (assuming AC=10 monsters).
+func killGoblinFixturePlayerInput(playerID core.PlayerID, entityID core.EntityID, pos core.Hex) tkenc.PlayerInput {
+	return tkenc.PlayerInput{
+		PlayerID: playerID, EntityID: entityID,
+		Position: pos, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+		AttackBonus: 20,
+		DamageDice:  "1d6",
+		DamageType:  "slashing",
+	}
+}
+
+// killGoblinFixtureMonsterInput returns a MonsterInput tuned for the death
+// integration tests: HP=1 + AC=10 goes down to any d20-roll-except-nat-1
+// + 1+ damage attack from the killGoblinFixturePlayerInput player.
+func killGoblinFixtureMonsterInput(id core.EntityID, pos core.Hex) tkenc.MonsterInput {
+	return tkenc.MonsterInput{
+		ID: id, Position: pos,
+		HP: 1, MaxHP: 1, AC: 10, Speed: 6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}
+}
+
+// killMonsterViaTakeActionLoop calls TakeAction up to maxKillAttempts times
+// against monsterID using the active player's context. Returns when the
+// goblin HP reaches 0 (verified via repo read after each call) or after the
+// cap. Stops early if TakeAction errors with FailedPrecondition (e.g., the
+// encounter ended).
+func (s *EncounterV2IntegrationSuite) killMonsterViaTakeActionLoop(
+	ctx context.Context,
+	encID, actorEntityID, monsterID string,
+) {
+	for attempt := 0; attempt < maxKillAttempts; attempt++ {
+		_, err := s.srv.EncounterClientV2.TakeAction(ctx, &encounterv2pb.TakeActionRequest{
+			EncounterId:   encID,
+			ActorEntityId: actorEntityID,
+			ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+			Target: &encounterv2pb.ActionTarget{
+				Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: monsterID},
+			},
+		})
+		if err != nil {
+			// FailedPrecondition surfaces when the encounter ended (last
+			// hostile dropped). That's the success exit for the last-monster
+			// case — the kill landed on the prior call and this attempt
+			// raced past the terminal-state gate.
+			if st, ok := status.FromError(err); ok && st.Code() == codes.FailedPrecondition {
+				return
+			}
+			s.Require().NoError(err, "TakeAction attempt %d failed unexpectedly", attempt+1)
+		}
+		// Read state to see if the monster's gone (killEntity removes it
+		// from data.Monsters once HP hits zero).
+		data, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+		s.Require().NoError(err)
+		if _, stillAlive := data.Monsters[core.EntityID(monsterID)]; !stillAlive {
+			return
+		}
+	}
+	s.Require().Failf("kill loop exhausted",
+		"failed to kill %q in %d attempts", monsterID, maxKillAttempts)
+}
+
+// TestCombatSlice_KillLastHostile_FiresDeathChainAndEnds verifies the
+// Wave 2.10 happy path: 2 players + 1 goblin, active player kills the
+// goblin via attack loop. Both streams must receive EntityDied (with
+// killer attribution) + EntityRemoved (broadcast) + EncounterEnded
+// (broadcast). A follow-up TakeAction returns FailedPrecondition.
+func (s *EncounterV2IntegrationSuite) TestCombatSlice_KillLastHostile_FiresDeathChainAndEnds() {
+	encID := "enc-kill-last"
+
+	enc := tkenc.New(core.EncounterID(encID), s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(killGoblinFixturePlayerInput(
+		"alice", "char-alice", core.Hex{Q: 0, R: 0, S: 0})))
+	s.Require().NoError(enc.AddPlayer(killGoblinFixturePlayerInput(
+		"bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0})))
+	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
+		"goblin-1", core.Hex{Q: 2, R: -1, S: -1})))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	// Cycle past any leading NPC turn so a player is active and TakeAction
+	// runs in the happy path.
+	s.advanceUntilPlayerActiveByDirectToolkit(enc)
+
+	// Discover the active player (initiative is rolled randomly).
+	data, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	activeEntity := string(data.Initiative[data.ActiveIdx])
+	var activePlayer string
+	for pid, pd := range data.Players {
+		if string(pd.EntityID) == activeEntity {
+			activePlayer = string(pid)
+			break
+		}
+	}
+	s.Require().NotEmpty(activePlayer)
+
+	ctxAlice := s.authCtx("alice")
+	ctxBob := s.authCtx("bob")
+	ctxActive := s.authCtx(activePlayer)
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxAlice,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxBob,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+
+	aSink := newEventSink()
+	bSink := newEventSink()
+	go aSink.drain(streamA)
+	go bSink.drain(streamB)
+
+	// Wait for replay to complete on both streams; watermark.
+	s.Require().Eventually(func() bool {
+		return aSink.hasReplayComplete() && bSink.hasReplayComplete()
+	}, 2*time.Second, 25*time.Millisecond,
+		"both streams must complete replay before the kill chain begins")
+	aSink.snapshot()
+	bSink.snapshot()
+
+	// Kill the goblin. The loop bounds the rare-nat-1 miss case.
+	s.killMonsterViaTakeActionLoop(ctxActive, encID, activeEntity, "goblin-1")
+
+	// Wait for the death chain to fan out to both streams.
+	// The toolkit publishes Died → Removed → Ended in that order; the
+	// broker queue preserves it per-stream.
+	s.Require().Eventually(func() bool {
+		return aSink.hasEncounterEnded() && bSink.hasEncounterEnded()
+	}, 2*time.Second, 50*time.Millisecond,
+		"both streams must receive EncounterEnded after the last hostile dies")
+
+	// Both streams must have seen the full chain.
+	s.Require().True(aSink.hasEntityDiedFor("goblin-1"),
+		"alice's stream must include EntityDied for goblin-1")
+	s.Require().True(aSink.hasEntityRemovedFor("goblin-1"),
+		"alice's stream must include EntityRemoved for goblin-1")
+	s.Require().True(aSink.hasEncounterEnded(),
+		"alice's stream must include EncounterEnded")
+
+	s.Require().True(bSink.hasEntityDiedFor("goblin-1"),
+		"bob's stream must include EntityDied for goblin-1")
+	s.Require().True(bSink.hasEntityRemovedFor("goblin-1"),
+		"bob's stream must include EntityRemoved for goblin-1")
+	s.Require().True(bSink.hasEncounterEnded(),
+		"bob's stream must include EncounterEnded")
+
+	// Killer attribution: EntityDied for goblin-1 should carry the killer
+	// entity id. The killer is whichever player landed the last attack —
+	// both players in the fixture use identical kill-tuned stats, so the
+	// killer is the active player.
+	died := aSink.findEntityDied("goblin-1")
+	s.Require().NotNil(died)
+	s.Require().Equal(activeEntity, died.GetKillerEntityId(),
+		"EntityDied.KillerEntityId must be the active attacker")
+
+	// EncounterEnded reason must be the toolkit's documented value for
+	// "all hostiles defeated."
+	end := aSink.findEncounterEnded()
+	s.Require().NotNil(end)
+	s.Require().Equal("all_hostiles_defeated", end.GetReason(),
+		"EncounterEnded.Reason should attribute to all-hostiles-defeated")
+
+	// Persisted state: monsters table empty, mode is ModeEnded.
+	finalData, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	s.Require().Empty(finalData.Monsters,
+		"persisted monsters table must be empty post-kill")
+	s.Require().Equal(core.ModeEnded, finalData.Mode,
+		"persisted Mode must be ModeEnded")
+
+	// A follow-up TakeAction must return FailedPrecondition (terminal state).
+	_, err = s.srv.EncounterClientV2.TakeAction(ctxActive, &encounterv2pb.TakeActionRequest{
+		EncounterId:   encID,
+		ActorEntityId: activeEntity,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: "goblin-1"},
+		},
+	})
+	s.Require().Error(err)
+	st, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Require().Equal(codes.FailedPrecondition, st.Code(),
+		"TakeAction post-end must return FailedPrecondition, got: %v", err)
+
+	// Same for EndTurn.
+	_, err = s.srv.EncounterClientV2.EndTurn(ctxActive, &encounterv2pb.EndTurnRequest{
+		EncounterId: encID, EntityId: activeEntity,
+	})
+	s.Require().Error(err)
+	st, ok = status.FromError(err)
+	s.Require().True(ok)
+	s.Require().Equal(codes.FailedPrecondition, st.Code(),
+		"EndTurn post-end must return FailedPrecondition, got: %v", err)
+}
+
+// TestCombatSlice_KillOneOfTwoHostiles_NoEncounterEnd verifies the
+// Wave 2.10 mid-fight slice: 2 players + 2 goblins. Active player kills
+// goblin-1 only; both streams receive EntityDied + EntityRemoved for
+// goblin-1, but NOT EncounterEnded. After EndTurn, the NPC dispatch
+// loop runs goblin-2's turn (skipping the dead goblin-1, which is now
+// spliced out of initiative) and lands turn back on a player. A second
+// kill targeting goblin-2 finally fires EncounterEnded.
+func (s *EncounterV2IntegrationSuite) TestCombatSlice_KillOneOfTwoHostiles_NoEncounterEnd() {
+	encID := "enc-kill-one-of-two"
+
+	enc := tkenc.New(core.EncounterID(encID), s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(killGoblinFixturePlayerInput(
+		"alice", "char-alice", core.Hex{Q: 0, R: 0, S: 0})))
+	s.Require().NoError(enc.AddPlayer(killGoblinFixturePlayerInput(
+		"bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0})))
+	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
+		"goblin-1", core.Hex{Q: 2, R: -1, S: -1})))
+	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
+		"goblin-2", core.Hex{Q: 3, R: -2, S: -1})))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	s.advanceUntilPlayerActiveByDirectToolkit(enc)
+
+	data, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	activeEntity := string(data.Initiative[data.ActiveIdx])
+	var activePlayer string
+	for pid, pd := range data.Players {
+		if string(pd.EntityID) == activeEntity {
+			activePlayer = string(pid)
+			break
+		}
+	}
+	s.Require().NotEmpty(activePlayer)
+
+	ctxAlice := s.authCtx("alice")
+	ctxBob := s.authCtx("bob")
+	ctxActive := s.authCtx(activePlayer)
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxAlice,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxBob,
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+
+	aSink := newEventSink()
+	bSink := newEventSink()
+	go aSink.drain(streamA)
+	go bSink.drain(streamB)
+
+	s.Require().Eventually(func() bool {
+		return aSink.hasReplayComplete() && bSink.hasReplayComplete()
+	}, 2*time.Second, 25*time.Millisecond, "replay must complete on both streams")
+	aSink.snapshot()
+	bSink.snapshot()
+
+	// --- Step 1: kill goblin-1 only. ---
+	s.killMonsterViaTakeActionLoop(ctxActive, encID, activeEntity, "goblin-1")
+
+	// Wait for goblin-1's death chain on both streams. We do NOT expect
+	// EncounterEnded here — goblin-2 is still alive.
+	s.Require().Eventually(func() bool {
+		return aSink.hasEntityRemovedFor("goblin-1") && bSink.hasEntityRemovedFor("goblin-1")
+	}, 2*time.Second, 50*time.Millisecond,
+		"both streams must receive EntityRemoved for goblin-1")
+
+	// Verify EntityDied + EntityRemoved fired only for goblin-1 (not
+	// goblin-2). And NOT EncounterEnded.
+	s.Require().True(aSink.hasEntityDiedFor("goblin-1"))
+	s.Require().False(aSink.hasEntityDiedFor("goblin-2"),
+		"goblin-2 is still alive; EntityDied must NOT fire for it")
+	s.Require().False(aSink.hasEncounterEnded(),
+		"EncounterEnded must NOT fire while goblin-2 is alive")
+	s.Require().False(bSink.hasEncounterEnded(),
+		"EncounterEnded must NOT fire (bob's view) while goblin-2 is alive")
+
+	// Persisted: goblin-1 gone, goblin-2 still present, mode unchanged.
+	midData, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	_, goblin1Gone := midData.Monsters[core.EntityID("goblin-1")]
+	s.Require().False(goblin1Gone, "goblin-1 must be removed from monsters table")
+	_, goblin2Alive := midData.Monsters[core.EntityID("goblin-2")]
+	s.Require().True(goblin2Alive, "goblin-2 must still be in monsters table")
+	s.Require().Equal(core.ModeTurnBased, midData.Mode,
+		"Mode must remain TurnBased — encounter is not over")
+
+	// --- Step 2: end the active player's turn. The NPC dispatch loop
+	// must skip the dead goblin-1 (no longer in initiative) and run
+	// goblin-2's turn server-side. After the loop, control should land
+	// back on a player. ---
+	_, err = s.srv.EncounterClientV2.EndTurn(ctxActive, &encounterv2pb.EndTurnRequest{
+		EncounterId: encID, EntityId: activeEntity,
+	})
+	s.Require().NoError(err)
+
+	// Reload to find whoever's active now (likely a player after the
+	// dispatch loop).
+	postEndData, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	postEndActive := string(postEndData.Initiative[postEndData.ActiveIdx])
+	// Initiative must NOT contain goblin-1 (it was spliced out).
+	for _, id := range postEndData.Initiative {
+		s.Require().NotEqual(core.EntityID("goblin-1"), id,
+			"dead goblin-1 must be spliced out of initiative")
+	}
+	// Active should be a player (NPC dispatch loop runs goblin-2 then
+	// lands on a player). With 2 players + 1 NPC, this is guaranteed
+	// per the loop's roster cap.
+	var nextActivePlayer string
+	for pid, pd := range postEndData.Players {
+		if string(pd.EntityID) == postEndActive {
+			nextActivePlayer = string(pid)
+			break
+		}
+	}
+	s.Require().NotEmpty(nextActivePlayer,
+		"after EndTurn + NPC dispatch loop, active actor must be a player")
+
+	// --- Step 3: kill goblin-2. EncounterEnded must now fire on both
+	// streams. ---
+	ctxNextActive := s.authCtx(nextActivePlayer)
+	s.killMonsterViaTakeActionLoop(ctxNextActive, encID, postEndActive, "goblin-2")
+
+	s.Require().Eventually(func() bool {
+		return aSink.hasEncounterEnded() && bSink.hasEncounterEnded()
+	}, 2*time.Second, 50*time.Millisecond,
+		"both streams must receive EncounterEnded after goblin-2 dies")
+
+	s.Require().True(aSink.hasEntityDiedFor("goblin-2"),
+		"alice's stream must include EntityDied for goblin-2")
+	s.Require().True(aSink.hasEntityRemovedFor("goblin-2"),
+		"alice's stream must include EntityRemoved for goblin-2")
+}
+
 // advanceUntilPlayerActiveByDirectToolkit drives toolkit verbs directly to
 // cycle past any leading NPC turns in initiative. Used in test setup so the
 // integration test starts with a player active and TakeAction runs in its
@@ -1102,6 +1468,62 @@ func (s *eventSink) hasReplayComplete() bool {
 		}
 	}
 	return sawSnap && sawAppeared && sawGeo
+}
+
+// hasEntityDiedFor reports whether the sink has observed an EntityDied
+// envelope with the given entity id, AFTER the most recent snapshot.
+func (s *eventSink) hasEntityDiedFor(entityID string) bool {
+	for _, ev := range s.eventsAfterSnapshot() {
+		if d := ev.GetEntityDied(); d != nil && d.GetEntityId() == entityID {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEntityRemovedFor reports whether the sink has observed an
+// EntityRemoved envelope with the given entity id, AFTER the most recent
+// snapshot.
+func (s *eventSink) hasEntityRemovedFor(entityID string) bool {
+	for _, ev := range s.eventsAfterSnapshot() {
+		if r := ev.GetEntityRemoved(); r != nil && r.GetEntityId() == entityID {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEncounterEnded reports whether the sink has observed any
+// EncounterEnded envelope AFTER the most recent snapshot.
+func (s *eventSink) hasEncounterEnded() bool {
+	for _, ev := range s.eventsAfterSnapshot() {
+		if ev.GetEncounterEnded() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// findEntityDied returns the first EntityDied event in the sink's events
+// after snapshot with a matching entity id, or nil.
+func (s *eventSink) findEntityDied(entityID string) *encounterv2pb.EntityDied {
+	for _, ev := range s.eventsAfterSnapshot() {
+		if d := ev.GetEntityDied(); d != nil && d.GetEntityId() == entityID {
+			return d
+		}
+	}
+	return nil
+}
+
+// findEncounterEnded returns the first EncounterEnded event in the
+// sink's events after snapshot, or nil.
+func (s *eventSink) findEncounterEnded() *encounterv2pb.EncounterEnded {
+	for _, ev := range s.eventsAfterSnapshot() {
+		if e := ev.GetEncounterEnded(); e != nil {
+			return e
+		}
+	}
+	return nil
 }
 
 // findEntityDamaged returns the first EntityDamaged event in the slice, or


### PR DESCRIPTION
## Summary

Closes #517. Wave 2.10 of the v1alpha2 encounter contract — translates rpg-toolkit's new death-resolution events to the wire and enforces terminal-state on combat verbs.

Toolkit dependency: `encounter/v0.5.0` (already shipped via #642).

## What ships

**Translator extensions** (`internal/handlers/dnd5e/v2/encounter/translate.go`):
- `*events.EntityDiedEvent` → `EncounterEvent_EntityDied`. Per-viewer; `Visible: false` → `ErrViewerSawNothing` so the stream loop drops it. Empty `KillerID` leaves the proto optional `killer_entity_id` unset (distinguishes attributed kills from environmental).
- `*events.EntityRemovedEvent` → `EncounterEvent_EntityRemoved`. Broadcast audience.
- `*events.EncounterEndedEvent` → `EncounterEvent_EncounterEnded`. Broadcast audience.

**Sentinel-error mapping** in `take_action.go` and `end_turn.go`:
```go
case errors.Is(err, tkenc.ErrEncounterEnded):
    return status.Error(codes.FailedPrecondition, ...)
```

**NPC dispatch loop guard** (`end_turn.go`): after each `enc.NPCAct` / `enc.EndTurn` cycle, if `enc.Mode() == core.ModeEnded`, break out and let the post-loop save persist terminal state. Cheap insurance for future paths (NPC-on-NPC kills, environmental damage) — `killEntity` only runs in TakeAction's player-attack path today, but the guard forward-loads cleanly. Also collapses the rare `EndTurn-returns-ErrEncounterEnded` race into the same success exit.

**Snapshot replay** (`project.go` + `translate.go`): `encounterModeToProto(core.ModeEnded)` maps to `ENCOUNTER_MODE_FREE_ROAM` since the proto has no `_ENDED` variant — the dedicated `EncounterEndedEvent` is the canonical wire signal. `buildTurnState` already gates on `ModeTurnBased`, so terminal snapshots have no TurnState. Removed monsters are absent from the snapshot's entity table because `killEntity` deletes them from `data.Monsters`. Verified by `TestProjectFor_ModeEnded_NoTurnStateAndOmitsRemovedMonsters` — no other code change needed.

## Test coverage

- **Translator** (11 new tests in `translate_combat_test.go`): happy path + `ErrViewerSawNothing` for each new event type, plus killer-attribution and reason-passthrough subtests.
- **Handler** (`combat_handlers_test.go`): `TakeAction` + `EndTurn` against a pre-flipped `ModeEnded` encounter both return `FailedPrecondition`.
- **Project** (`project_test.go`): snapshot of an ended encounter has no TurnState, no monster entities, mode renders as `FREE_ROAM`.
- **Integration** (`encounter_v2_test.go`):
  - `TestCombatSlice_KillLastHostile_FiresDeathChainAndEnds` — full chain on both streams (Died/Removed/Ended), killer attribution, reason `"all_hostiles_defeated"`, persisted `ModeEnded`, follow-up `TakeAction`/`EndTurn` return `FailedPrecondition`.
  - `TestCombatSlice_KillOneOfTwoHostiles_NoEncounterEnd` — mid-fight kill (only goblin-1's events), encounter stays `TurnBased`, EndTurn dispatches goblin-2 server-side (skipping dead goblin-1 spliced from initiative), control returns to a player, second kill fires `EncounterEnded`.

Determinism: monsters seeded HP=1 / AC=10, attacker AttackBonus=20 + DamageDice "1d6" — only nat-1 misses, loop bounded by `maxKillAttempts=20` (failure probability ≈ 9.5e-27).

## What's deferred

- Real `CharacterResolver` wiring (#516).
- Player dying-state machinery / death saves / TPK detection (Wave 2.11+).
- Indirect-kill chain (DoT, environmental damage).
- Death animations (web concern).

## Test plan

- [x] `go test -race ./...`
- [x] `go test ./internal/integration/` (with Docker / Redis)
- [x] `go build ./...`
- [x] `make lint` adds 0 new issues vs main
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)