### PR TITLE
feat(encounter/v2): wire dnd5e CombatResolver via stand-in (Wave 2.11a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260507051118-0443dec90664
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.5.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.6.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.55.5
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.5.0 h1:W5ZLv9Trm//N3aqNOLtk8duHk6Df8IYnOLRzhoj/ZW4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.5.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.6.0 h1:sKaetpEsrqQ5sa0mu3adQvjeGhNZrNR3r47WbFa1AO0=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.6.0/go.mod h1:fU5kpV7e9KlBCSrZ5ZwjgLBfgy4T4hqx/AFEN8GfBIE=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/combat_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_resolver.go
@@ -1,0 +1,122 @@
+package encounter
+
+import (
+	"context"
+	"fmt"
+
+	tkdice "github.com/KirkDiggler/rpg-toolkit/dice"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+)
+
+// CombatResolver is the rpg-api-side alias for the toolkit's
+// CombatResolver interface. The handler wires an implementation via
+// HandlerConfig.CombatResolver; without one, the toolkit returns
+// ErrNoCombatResolver from TakeAction.
+//
+// Wave 2.11a ships StandInCombatResolver, which mimics the pre-2.11a
+// behavior the toolkit's encounter SDK used to provide internally
+// (d20+bonus vs AC; damage from the attacker's stored damage dice).
+// This preserves end-to-end behavior while the resolver pattern
+// settles in. A real implementation that goes through the dnd5e
+// rulebook's combat.ResolveAttack chain (with character store lookup,
+// effective AC, equipped weapons, ActionEconomy persistence) ships in
+// a follow-up wave.
+type CombatResolver = tkenc.CombatResolver
+
+// StandInCombatResolver computes attacks using the d20+bonus vs AC
+// formula the toolkit's stand-in used pre-2.11a, sourcing combat stats
+// from the AttackInput snapshots (the encounter SDK fills these in from
+// PlayerData / MonsterData at attack time, so the resolver never needs
+// to look up encounter state).
+//
+// Behavior matches the toolkit's old internal stand-in:
+//   - d20 roll (nat-1 always misses; nat-20 always crits)
+//   - hit = (roll + AttackBonus) >= TargetAC, with nat-1 / nat-20 overrides
+//   - crit doubles the damage dice
+//   - damage notation defaults to "1d4" if unspecified
+//
+// Tests can supply a deterministic Roller; production uses dice.NewRoller().
+type StandInCombatResolver struct {
+	Roller tkdice.Roller
+}
+
+// NewStandInCombatResolver constructs a StandInCombatResolver. If roller
+// is nil, a default dice.NewRoller() is used.
+func NewStandInCombatResolver(roller tkdice.Roller) *StandInCombatResolver {
+	if roller == nil {
+		roller = tkdice.NewRoller()
+	}
+	return &StandInCombatResolver{Roller: roller}
+}
+
+// ResolveAttack computes a single attack outcome using the AttackInput's
+// stat snapshots. The encounter SDK applies HP changes + publishes
+// events from the returned AttackOutcome.
+func (r *StandInCombatResolver) ResolveAttack(input tkenc.AttackInput) (*tkenc.AttackOutcome, error) {
+	if r.Roller == nil {
+		return nil, fmt.Errorf("stand-in combat resolver: nil roller")
+	}
+
+	roll, err := r.Roller.Roll(context.Background(), 20)
+	if err != nil || roll <= 0 {
+		// Fall back to d20 average (10) on roller error so a roller
+		// hiccup doesn't abort a TakeAction call.
+		roll = 10
+	}
+
+	out := &tkenc.AttackOutcome{
+		AttackRoll:  roll,
+		AttackBonus: input.AttackerAttackBonus,
+		TargetAC:    input.TargetAC,
+		DamageType:  input.AttackerDamageType,
+	}
+
+	switch {
+	case roll == 20:
+		out.Hit = true
+		out.Critical = true
+	case roll == 1:
+		// Auto-miss; outcome is already zero.
+		return out, nil
+	default:
+		out.Hit = (roll + input.AttackerAttackBonus) >= input.TargetAC
+	}
+
+	if !out.Hit {
+		return out, nil
+	}
+
+	dice := input.AttackerDamageDice
+	if dice == "" {
+		dice = "1d4"
+	}
+	dmg, err := rollDamage(r.Roller, dice, out.Critical)
+	if err != nil {
+		return nil, fmt.Errorf("stand-in combat resolver: roll damage %q: %w", dice, err)
+	}
+	out.Damage = dmg
+	return out, nil
+}
+
+// rollDamage parses dice notation, rolls it, and applies the crit
+// doubling approximation matching the toolkit's pre-2.11a stand-in
+// (total*2 - modifier on a crit, so only the dice portion doubles).
+// On parse / roll failure, returns 1 to keep the verb non-blocking.
+func rollDamage(roller tkdice.Roller, notation string, critical bool) (int, error) {
+	pool, err := tkdice.ParseNotation(notation)
+	if err != nil {
+		return 1, nil
+	}
+	rolled := pool.RollContext(context.Background(), roller)
+	if rolled.Error() != nil {
+		return 1, nil
+	}
+	dmg := rolled.Total()
+	if critical {
+		dmg += rolled.Total() - rolled.Modifier()
+	}
+	if dmg < 0 {
+		dmg = 0
+	}
+	return dmg, nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/combat_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_resolver.go
@@ -90,26 +90,24 @@ func (r *StandInCombatResolver) ResolveAttack(input tkenc.AttackInput) (*tkenc.A
 	if dice == "" {
 		dice = "1d4"
 	}
-	dmg, err := rollDamage(r.Roller, dice, out.Critical)
-	if err != nil {
-		return nil, fmt.Errorf("stand-in combat resolver: roll damage %q: %w", dice, err)
-	}
-	out.Damage = dmg
+	out.Damage = rollDamage(r.Roller, dice, out.Critical)
 	return out, nil
 }
 
 // rollDamage parses dice notation, rolls it, and applies the crit
 // doubling approximation matching the toolkit's pre-2.11a stand-in
 // (total*2 - modifier on a crit, so only the dice portion doubles).
-// On parse / roll failure, returns 1 to keep the verb non-blocking.
-func rollDamage(roller tkdice.Roller, notation string, critical bool) (int, error) {
+// Parse / roll failures fall back to 1 — the resolver keeps the verb
+// non-blocking rather than aborting an attack on a malformed dice
+// notation, matching the toolkit's old internal behavior.
+func rollDamage(roller tkdice.Roller, notation string, critical bool) int {
 	pool, err := tkdice.ParseNotation(notation)
 	if err != nil {
-		return 1, nil
+		return 1
 	}
 	rolled := pool.RollContext(context.Background(), roller)
 	if rolled.Error() != nil {
-		return 1, nil
+		return 1
 	}
 	dmg := rolled.Total()
 	if critical {
@@ -118,5 +116,5 @@ func rollDamage(roller tkdice.Roller, notation string, critical bool) (int, erro
 	if dmg < 0 {
 		dmg = 0
 	}
-	return dmg, nil
+	return dmg
 }

--- a/internal/handlers/dnd5e/v2/encounter/create.go
+++ b/internal/handlers/dnd5e/v2/encounter/create.go
@@ -44,7 +44,7 @@ func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.Create
 	// future SubmitCheck against this encounter. CreateEncounter doesn't
 	// itself issue prompts, but persisting a resolver-less New encounter
 	// would leave subsequent SubmitCheck calls with ErrNoCharacterResolver.
-	enc := tkenc.New(encID, h.broker, tkenc.WithCharacterResolver(h.resolver))
+	enc := tkenc.New(encID, h.broker, tkenc.WithCharacterResolver(h.resolver), tkenc.WithCombatResolver(h.combatResolver))
 	// The creator is automatically added as the encounter's first player.
 	// Entity ID mirrors the player ID for the initial seat; future PRs can
 	// wire in a character-selection step that replaces this with the

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -80,7 +80,7 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 		return nil, status.Error(codes.PermissionDenied, "entity_id does not match player's controlled entity")
 	}
 
-	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))
+	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver), tkenc.WithCombatResolver(h.combatResolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -18,10 +18,11 @@ import (
 
 // HandlerConfig configures a v2 encounter Handler.
 type HandlerConfig struct {
-	Broker   *encounter.Broker
-	Repo     encountersv2.Repository
-	Resolver CharacterResolver // optional; defaults to StubCharacterResolver
-	Now      func() time.Time  // optional; defaults to time.Now
+	Broker         *encounter.Broker
+	Repo           encountersv2.Repository
+	Resolver       CharacterResolver // optional; defaults to StubCharacterResolver
+	CombatResolver CombatResolver    // optional; defaults to StandInCombatResolver
+	Now            func() time.Time  // optional; defaults to time.Now
 }
 
 // Handler implements dnd5e.api.v1alpha2.encounter.EncounterServiceServer.
@@ -30,10 +31,11 @@ type HandlerConfig struct {
 // returns codes.Unimplemented via the embedded server.
 type Handler struct {
 	encounterv2pb.UnimplementedEncounterServiceServer
-	broker   *encounter.Broker
-	encRepo  encountersv2.Repository
-	resolver CharacterResolver
-	now      func() time.Time
+	broker         *encounter.Broker
+	encRepo        encountersv2.Repository
+	resolver       CharacterResolver
+	combatResolver CombatResolver
+	now            func() time.Time
 }
 
 // New constructs a Handler. Returns error on missing required deps.
@@ -59,7 +61,21 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 		// resolution lands on the encounter (follow-up to #514).
 		resolver = StubCharacterResolver{}
 	}
-	return &Handler{broker: cfg.Broker, encRepo: cfg.Repo, resolver: resolver, now: now}, nil
+	combatResolver := cfg.CombatResolver
+	if combatResolver == nil {
+		// Wave 2.11a default: ports the toolkit's pre-2.11a stand-in math
+		// (d20+bonus vs AC; damage from attacker's stored damage dice). Real
+		// dnd5e/combat.ResolveAttack integration ships in a follow-up wave
+		// once character store + weapon equipping land in the v2 stack.
+		combatResolver = NewStandInCombatResolver(nil)
+	}
+	return &Handler{
+		broker:         cfg.Broker,
+		encRepo:        cfg.Repo,
+		resolver:       resolver,
+		combatResolver: combatResolver,
+		now:            now,
+	}, nil
 }
 
 // MoveEntity loads the encounter, validates that the request's entity_id matches
@@ -98,7 +114,7 @@ func (h *Handler) MoveEntity(ctx context.Context, req *encounterv2pb.MoveEntityR
 		return nil, status.Error(codes.InvalidArgument, "proposed_path is required")
 	}
 
-	enc, err := encounter.LoadFromData(data, h.broker, encounter.WithCharacterResolver(h.resolver))
+	enc, err := encounter.LoadFromData(data, h.broker, encounter.WithCharacterResolver(h.resolver), encounter.WithCombatResolver(h.combatResolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/interact.go
+++ b/internal/handlers/dnd5e/v2/encounter/interact.go
@@ -68,7 +68,7 @@ func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractReque
 		return nil, status.Error(codes.NotFound, "target entity is not a door, or door does not exist")
 	}
 
-	enc, err := encounter.LoadFromData(data, h.broker, encounter.WithCharacterResolver(h.resolver))
+	enc, err := encounter.LoadFromData(data, h.broker, encounter.WithCharacterResolver(h.resolver), encounter.WithCombatResolver(h.combatResolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/submit_check.go
+++ b/internal/handlers/dnd5e/v2/encounter/submit_check.go
@@ -94,7 +94,7 @@ func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitChec
 			"entity_id does not match player's controlled entity")
 	}
 
-	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))
+	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver), tkenc.WithCombatResolver(h.combatResolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"load from data %q: %v", req.GetEncounterId(), err)

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -75,7 +75,7 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 		return nil, status.Error(codes.PermissionDenied, "actor_entity_id does not match player's controlled entity")
 	}
 
-	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver))
+	enc, err := tkenc.LoadFromData(data, h.broker, tkenc.WithCharacterResolver(h.resolver), tkenc.WithCombatResolver(h.combatResolver))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
 	}


### PR DESCRIPTION
## Summary

Wires the rpg-api side of the new `CombatResolver` interface from rpg-toolkit/encounter v0.6.0. Wave 2.11a ships a `StandInCombatResolver` that mimics the toolkit's pre-2.11a internal stand-in math (d20+bonus vs AC; damage from attacker's stored notation; nat-1 miss; nat-20 crit doubling the dice). End-to-end behavior is preserved while the resolver pattern settles in. Real `dnd5e/combat.ResolveAttack` integration ships in **Wave 2.11b**.

## Wave 2.11a scope

- **rpg-toolkit/encounter v0.6.0** (already merged via #644) introduces `CombatResolver` and routes `TakeAction` (player attacks) through the wired implementation. NPC attacks still use the in-package stand-in.
- **rpg-api** (this PR) implements `StandInCombatResolver` and threads `WithCombatResolver` at every `Load/New` site per pat-v2-thread-resolver-everywhere.

## Changes

- `internal/handlers/dnd5e/v2/encounter/combat_resolver.go` (new):
  - Type alias `CombatResolver = tkenc.CombatResolver`
  - `StandInCombatResolver` with configurable `Roller` (defaults to `dice.NewRoller()`)
  - Mirrors toolkit pre-2.11a stand-in math exactly
- `handler.go`: `HandlerConfig.CombatResolver` (optional); `New()` defaults to `NewStandInCombatResolver(nil)`; `combatResolver` field on `Handler`
- 6 wiring sites threaded with `WithCombatResolver`: `MoveEntity`, `TakeAction`, `EndTurn`, `CreateEncounter`, `SubmitCheck`, `Interact`
- `go.mod`: encounter SDK bumped `v0.5.0 → v0.6.0`

## Out of scope (Wave 2.11b)

- Real `dnd5e/combat.ResolveAttack` chain (needs character store + weapon-equipping + `Combatant` adapters; deferred until those land in v2)
- Folding `NPCAct` onto the same resolver (toolkit side currently uses internal stand-in; planned together with the dnd5e chain swap)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/handlers/dnd5e/v2/encounter/...` — pass
- [x] `go test ./internal/integration/...` — passes on rerun. **Pre-existing flake**: `TestCombatSlice_TakeActionAndEndTurn_NPCDispatch` has a ~12.5% chance of one-shotting goblin-1 (HP=7 vs 1d8+2 player attack), which now triggers the Wave 2.10 `ErrEncounterEnded` path on subsequent EndTurn. Will file follow-up to make the test deterministic (HP bump or fixture swap to the Wave 2.10 `killGoblinFixture` style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)