### PR TITLE
feat(encounter/v2): Combatant adapter + CombatantLookup wiring (Wave 2.11b — 1 of 3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.6.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
+	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.55.5
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
@@ -30,7 +31,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 // indirect
-	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 // indirect
 	github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/internal/handlers/dnd5e/v2/encounter/combatant.go
+++ b/internal/handlers/dnd5e/v2/encounter/combatant.go
@@ -1,0 +1,61 @@
+package encounter
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+)
+
+// Interface satisfaction assertions.
+// Both toolkit types already implement combat.Combatant directly — no adapter
+// struct is needed on the rpg-api side. These compile-time checks document
+// the fact and guard against future toolkit breakage.
+var (
+	_ combat.Combatant = (*character.Character)(nil)
+	_ combat.Combatant = (*monster.Monster)(nil)
+)
+
+// CombatantRegistry is a simple per-attack CombatantLookup backed by a
+// string-keyed map. It satisfies the combat.CombatantLookup interface and is
+// injected onto the resolve context via combat.WithCombatantLookup before
+// calling combat.ResolveAttack.
+//
+// Scope: per-attack. Build one registry for the attacker + target of a single
+// attack, thread it onto context, call ResolveAttack, then discard it. The
+// rulebook only looks up two IDs per attack (attacker and target), so
+// registering the full encounter is unnecessary overhead.
+//
+// Concurrency: not safe for concurrent use. CombatantRegistry is intended for
+// single-attack, single-goroutine use; do not share across goroutines.
+type CombatantRegistry struct {
+	entries map[string]combat.Combatant
+}
+
+// NewCombatantRegistry returns an empty CombatantRegistry ready for
+// registration.
+func NewCombatantRegistry() *CombatantRegistry {
+	return &CombatantRegistry{
+		entries: make(map[string]combat.Combatant),
+	}
+}
+
+// Register adds a Combatant under the given id. Overwrites any existing entry
+// for that id, which is intentional: tests may register a replacement combatant
+// to simulate mid-combat HP changes.
+func (r *CombatantRegistry) Register(id string, c combat.Combatant) {
+	r.entries[id] = c
+}
+
+// Get retrieves a Combatant by id. Returns a CodeNotFound rpgerr if no entry
+// exists for the id, matching the convention used by the toolkit's own
+// combatant lookup helpers (combat/combatant.go:122-128).
+func (r *CombatantRegistry) Get(id string) (combat.Combatant, error) {
+	c, ok := r.entries[id]
+	if !ok {
+		return nil, rpgerr.New(rpgerr.CodeNotFound, fmt.Sprintf("combatant not found: %s", id))
+	}
+	return c, nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/combatant.go
+++ b/internal/handlers/dnd5e/v2/encounter/combatant.go
@@ -23,6 +23,10 @@ var (
 // injected onto the resolve context via combat.WithCombatantLookup before
 // calling combat.ResolveAttack.
 //
+// Zero value: a zero-value CombatantRegistry is usable — Register
+// lazy-initialises the internal map on first call. NewCombatantRegistry is
+// provided as a convenience but is not required.
+//
 // Scope: per-attack. Build one registry for the attacker + target of a single
 // attack, thread it onto context, call ResolveAttack, then discard it. The
 // rulebook only looks up two IDs per attack (attacker and target), so
@@ -45,7 +49,13 @@ func NewCombatantRegistry() *CombatantRegistry {
 // Register adds a Combatant under the given id. Overwrites any existing entry
 // for that id, which is intentional: tests may register a replacement combatant
 // to simulate mid-combat HP changes.
+//
+// Register lazy-initialises the internal map so that the zero value of
+// CombatantRegistry is usable without calling NewCombatantRegistry first.
 func (r *CombatantRegistry) Register(id string, c combat.Combatant) {
+	if r.entries == nil {
+		r.entries = make(map[string]combat.Combatant)
+	}
 	r.entries[id] = c
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/combatant_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combatant_test.go
@@ -223,3 +223,18 @@ func (s *CombatantRegistryTestSuite) TestRegistry_SatisfiesCombatantLookupInterf
 	var _ combat.CombatantLookup = reg
 	// If this compiles, the interface is satisfied.
 }
+
+// TestRegistry_ZeroValueUsable verifies that a zero-value CombatantRegistry
+// (not constructed via NewCombatantRegistry) is safe to use. Register must
+// lazy-initialise the internal map rather than panic on a nil-map write.
+func (s *CombatantRegistryTestSuite) TestRegistry_ZeroValueUsable() {
+	var reg v2encounter.CombatantRegistry
+
+	goblin := monster.NewGoblin("goblin-1")
+	// Must not panic — Register lazy-inits the nil map.
+	reg.Register("goblin-1", goblin)
+
+	got, err := reg.Get("goblin-1")
+	s.Require().NoError(err)
+	s.Equal("goblin-1", got.GetID())
+}

--- a/internal/handlers/dnd5e/v2/encounter/combatant_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combatant_test.go
@@ -1,0 +1,225 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+)
+
+// CombatantRegistryTestSuite tests the CombatantRegistry (CombatantLookup
+// implementation) and documents that *character.Character and *monster.Monster
+// already satisfy the combat.Combatant interface without adapter structs.
+type CombatantRegistryTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestCombatantRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(CombatantRegistryTestSuite))
+}
+
+func (s *CombatantRegistryTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// ---------------------------------------------------------------------------
+// Interface satisfaction — documents that no adapter layer is needed
+// ---------------------------------------------------------------------------
+
+// TestCharacterImplementsCombatant verifies that a rehydrated *character.Character
+// satisfies the combat.Combatant interface for all methods used by the
+// rulebook's combat chain: AC, GetHitPoints, GetMaxHitPoints, AbilityScores,
+// ProficiencyBonus, ApplyDamage.
+func (s *CombatantRegistryTestSuite) TestCharacterImplementsCombatant() {
+	bus := events.NewEventBus()
+	data := &character.Data{
+		ID:               "char-test",
+		Name:             "Aethelwynn",
+		Level:            3,
+		ProficiencyBonus: 2,
+		HitPoints:        24,
+		MaxHitPoints:     24,
+		ArmorClass:       16,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 12,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+	}
+
+	char, err := character.LoadFromData(s.ctx, data, bus)
+	s.Require().NoError(err)
+
+	// Verify via the interface — this also confirms the compile-time var
+	// assertions in combatant.go hold at runtime.
+	var c combat.Combatant = char
+
+	s.Equal("char-test", c.GetID())
+	s.Equal(24, c.GetHitPoints())
+	s.Equal(24, c.GetMaxHitPoints())
+	s.Equal(16, c.AC())
+	s.Equal(2, c.ProficiencyBonus())
+	scores := c.AbilityScores()
+	s.Equal(16, scores[abilities.STR])
+
+	// ApplyDamage round-trip: deal 5 points of piercing damage.
+	result := c.ApplyDamage(s.ctx, &combat.ApplyDamageInput{
+		Instances: []combat.DamageInstance{{Amount: 5, Type: "piercing"}},
+	})
+	s.Require().NotNil(result)
+	s.Equal(5, result.TotalDamage)
+	s.Equal(19, result.CurrentHP)
+	s.Equal(24, result.PreviousHP)
+	s.False(result.DroppedToZero)
+
+	// HP is reflected on subsequent call.
+	s.Equal(19, c.GetHitPoints())
+}
+
+// TestMonsterImplementsCombatant verifies that a *monster.Monster (built via
+// monster.New) satisfies the combat.Combatant interface.
+func (s *CombatantRegistryTestSuite) TestMonsterImplementsCombatant() {
+	m := monster.New(monster.Config{
+		ID:               "goblin-1",
+		Name:             "Goblin",
+		HP:               7,
+		AC:               15,
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 8,
+			abilities.DEX: 14,
+			abilities.CON: 10,
+			abilities.INT: 10,
+			abilities.WIS: 8,
+			abilities.CHA: 8,
+		},
+	})
+
+	var c combat.Combatant = m
+
+	s.Equal("goblin-1", c.GetID())
+	s.Equal(7, c.GetHitPoints())
+	s.Equal(7, c.GetMaxHitPoints())
+	s.Equal(15, c.AC())
+	s.Equal(2, c.ProficiencyBonus())
+	scores := c.AbilityScores()
+	s.Equal(8, scores[abilities.STR])
+	s.Equal(14, scores[abilities.DEX])
+
+	// ApplyDamage round-trip: deal 7 points (exactly killing the goblin).
+	result := c.ApplyDamage(s.ctx, &combat.ApplyDamageInput{
+		Instances: []combat.DamageInstance{{Amount: 7, Type: "slashing"}},
+	})
+	s.Require().NotNil(result)
+	s.Equal(7, result.TotalDamage)
+	s.Equal(0, result.CurrentHP)
+	s.True(result.DroppedToZero)
+}
+
+// ---------------------------------------------------------------------------
+// CombatantRegistry — lookup tests
+// ---------------------------------------------------------------------------
+
+// TestRegistry_GetRegistered verifies that a registered combatant is returned
+// correctly by Get.
+func (s *CombatantRegistryTestSuite) TestRegistry_GetRegistered() {
+	reg := v2encounter.NewCombatantRegistry()
+	m := monster.NewGoblin("goblin-1")
+	reg.Register("goblin-1", m)
+
+	got, err := reg.Get("goblin-1")
+	s.Require().NoError(err)
+	s.Equal(m, got)
+}
+
+// TestRegistry_GetUnknown verifies that Get returns a CodeNotFound rpgerr
+// when the requested id is not registered.
+func (s *CombatantRegistryTestSuite) TestRegistry_GetUnknown() {
+	reg := v2encounter.NewCombatantRegistry()
+
+	got, err := reg.Get("nonexistent-id")
+	s.Nil(got)
+	s.Require().Error(err)
+	s.Equal(rpgerr.CodeNotFound, rpgerr.GetCode(err))
+}
+
+// TestRegistry_RegisterMultiple verifies that registering multiple combatants
+// and looking each up works correctly.
+func (s *CombatantRegistryTestSuite) TestRegistry_RegisterMultiple() {
+	bus := events.NewEventBus()
+	reg := v2encounter.NewCombatantRegistry()
+
+	goblin := monster.NewGoblin("goblin-1")
+	reg.Register("goblin-1", goblin)
+
+	charData := &character.Data{
+		ID:               "char-alice",
+		Name:             "Alice",
+		Level:            1,
+		ProficiencyBonus: 2,
+		HitPoints:        10,
+		MaxHitPoints:     10,
+		ArmorClass:       14,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14,
+			abilities.DEX: 12,
+			abilities.CON: 12,
+			abilities.INT: 10,
+			abilities.WIS: 10,
+			abilities.CHA: 10,
+		},
+	}
+	alice, err := character.LoadFromData(s.ctx, charData, bus)
+	s.Require().NoError(err)
+	reg.Register("char-alice", alice)
+
+	gotGoblin, err := reg.Get("goblin-1")
+	s.Require().NoError(err)
+	s.Equal("goblin-1", gotGoblin.GetID())
+
+	gotAlice, err := reg.Get("char-alice")
+	s.Require().NoError(err)
+	s.Equal("char-alice", gotAlice.GetID())
+}
+
+// TestRegistry_OverwriteEntry verifies that registering a new combatant under
+// an existing id replaces the prior entry — useful for tests that inject
+// replaced combatants.
+func (s *CombatantRegistryTestSuite) TestRegistry_OverwriteEntry() {
+	reg := v2encounter.NewCombatantRegistry()
+
+	first := monster.NewGoblin("goblin-1")
+	reg.Register("goblin-1", first)
+
+	// second is a fresh goblin (different pointer) registered under the same id.
+	second := monster.NewGoblin("goblin-1")
+	reg.Register("goblin-1", second)
+
+	got, err := reg.Get("goblin-1")
+	s.Require().NoError(err)
+	s.Same(second, got, "second registration should overwrite first")
+}
+
+// TestRegistry_SatisfiesCombatantLookupInterface verifies that
+// *CombatantRegistry satisfies the combat.CombatantLookup interface at the
+// type level. This ensures it can be passed directly to
+// combat.WithCombatantLookup.
+func (s *CombatantRegistryTestSuite) TestRegistry_SatisfiesCombatantLookupInterface() {
+	reg := v2encounter.NewCombatantRegistry()
+	var _ combat.CombatantLookup = reg
+	// If this compiles, the interface is satisfied.
+}


### PR DESCRIPTION
Closes #522

## Summary

- Adds `CombatantRegistry`, a simple per-attack `combat.CombatantLookup` implementation backed by a `map[string]combat.Combatant`. Exposes `NewCombatantRegistry()`, `Register(id, combatant)`, and `Get(id)`. `Get` returns `rpgerr.CodeNotFound` on miss, matching the toolkit's own lookup convention (`combat/combatant.go:122-128`).
- Adds compile-time interface satisfaction assertions (`var _ combat.Combatant = (*character.Character)(nil)` and `(*monster.Monster)(nil)`) documenting that **no adapter structs are needed** — both toolkit types already implement `Combatant` directly.
- Promotes `rpgerr` from `// indirect` to a direct dependency in `go.mod` (first direct use in this package).

This is **dead code with tests** — no production caller yet. Issue #523 (resolver swap) consumes `CombatantRegistry` and `combat.WithCombatantLookup` next.

## Architecture notes

Per the Wave 2.11b plan decision points:
- **Combatant adapter:** verification confirmed both `*character.Character` and `*monster.Monster` implement `combat.Combatant` directly in toolkit v0.55.5. No thin adapter structs needed.
- **Lookup scope:** per-attack registration only (attacker + target). `CombatantRegistry` is intentionally not concurrent-safe; it is built, used, and discarded within a single attack resolution.

## Test plan

- [ ] `go test ./internal/handlers/dnd5e/v2/encounter/ -run TestCombatantRegistryTestSuite -v` — 7 tests all pass
- [ ] `TestCharacterImplementsCombatant` — verifies HP/AC/AbilityScores/ProficiencyBonus/ApplyDamage round-trip on a rehydrated `*character.Character`
- [ ] `TestMonsterImplementsCombatant` — verifies same surface on `monster.New()`, including `DroppedToZero` on lethal damage
- [ ] `TestRegistry_GetRegistered` — happy path lookup
- [ ] `TestRegistry_GetUnknown` — returns `rpgerr.CodeNotFound`
- [ ] `TestRegistry_RegisterMultiple` — multiple combatants coexist correctly
- [ ] `TestRegistry_OverwriteEntry` — second registration replaces first (same pointer check)
- [ ] `TestRegistry_SatisfiesCombatantLookupInterface` — compile-time assertion `*CombatantRegistry` satisfies `combat.CombatantLookup`
- [ ] `go build ./...` — clean build
- [ ] `go test ./...` — all existing tests continue to pass
- [ ] Lint: no new issues introduced (67 pre-existing issues unrelated to this PR)

## Cross-references

- Wave 2.11b plan: `rpg-project/ideas/encounter/v1alpha2/plans/10-wave-2.11b-real-combat-chain.md`
- Resolver swap (depends on this): #523
- Weapon-equipping verification: #524