### PR TITLE
fix(integration): deterministic goblin HP for TestCombatSlice flake (#520)

### DIFF
--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -875,14 +875,16 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 		HP: 10, MaxHP: 10, AC: 13, AttackBonus: 3, DamageDice: "1d6+1", DamageType: "piercing",
 	}))
 	// Goblin HP intentionally bumped to 30 (vs canonical 7) so the one-shot
-	// path is statistically impossible (player damage caps at 1d8+2 = 10,
-	// 1d6+1 = 7). Pre-Wave-2.10 a kill here was harmless — the encounter
-	// just had no monsters and EndTurn still worked. Wave 2.10 added the
-	// ErrEncounterEnded terminal-state guard, so a kill here now flips
-	// EndTurn to FailedPrecondition mid-test. The test was never trying
-	// to exercise lethality (Wave 2.10's death suite covers that with
-	// killGoblinFixture); bumping HP keeps the attack/endturn/npc-dispatch
-	// loop the actual subject under test. Closes #520.
+	// path is statistically impossible. Player damage including crits caps
+	// at 1d8+2 → 18 max (alice, nat-20 doubles the d8) and 1d6+1 → 13 max
+	// (bob, nat-20 doubles the d6) — both well under 30. Pre-Wave-2.10 a
+	// kill here was harmless — the encounter just had no monsters and
+	// EndTurn still worked. Wave 2.10 added the ErrEncounterEnded
+	// terminal-state guard, so a kill here now flips EndTurn to
+	// FailedPrecondition mid-test. The test was never trying to exercise
+	// lethality (Wave 2.10's death suite covers that with killGoblinFixture);
+	// bumping HP keeps the attack/endturn/npc-dispatch loop the actual
+	// subject under test. Closes #520.
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 2, R: -1, S: -1},
 		HP: 30, MaxHP: 30, AC: 15, Speed: 6,

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -874,9 +874,18 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 		Position: core.Hex{Q: 1, R: -1, S: 0}, SightRange: 10,
 		HP: 10, MaxHP: 10, AC: 13, AttackBonus: 3, DamageDice: "1d6+1", DamageType: "piercing",
 	}))
+	// Goblin HP intentionally bumped to 30 (vs canonical 7) so the one-shot
+	// path is statistically impossible (player damage caps at 1d8+2 = 10,
+	// 1d6+1 = 7). Pre-Wave-2.10 a kill here was harmless — the encounter
+	// just had no monsters and EndTurn still worked. Wave 2.10 added the
+	// ErrEncounterEnded terminal-state guard, so a kill here now flips
+	// EndTurn to FailedPrecondition mid-test. The test was never trying
+	// to exercise lethality (Wave 2.10's death suite covers that with
+	// killGoblinFixture); bumping HP keeps the attack/endturn/npc-dispatch
+	// loop the actual subject under test. Closes #520.
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 2, R: -1, S: -1},
-		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		HP: 30, MaxHP: 30, AC: 15, Speed: 6,
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
 	}))


### PR DESCRIPTION
## Summary

Closes #520. The flaky test `TestEncounterV2IntegrationSuite/TestCombatSlice_TakeActionAndEndTurn_NPCDispatch` failed intermittently (~12.5% per run) because goblin-1's HP=7 was within one-shot range of the player damage dice. After Wave 2.10 added the `ErrEncounterEnded` terminal-state guard, a one-shot now flips the subsequent EndTurn RPC to FailedPrecondition.

## Fix

Bump goblin-1 HP from 7 → 30 in the fixture. Player damage caps at 1d8+2 = 10 (alice) and 1d6+1 = 7 (bob), so a one-shot is now statistically impossible.

## Test plan

- [x] Local 3x consecutive runs of the failing test — all pass
- [ ] CI clears

The test was never trying to exercise lethality — that's covered by Wave 2.10's `killGoblinFixture` death suite. This wave's subject is the attack/EndTurn/NPC-dispatch loop, which only requires the goblin to *survive* the player's swing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)