### PR TITLE
fix+test(encounter/v2): Wave 2.11d closeout — publish/save + single-reactor + Shield gate test + v0.58.1 dep bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.9.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.58.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.58.1
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.58.0 h1:t7ac3UG1aNmtBvImK7njNHplJxzOmIx/PZmMol1sqgc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.58.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.58.1 h1:gQ/HVY62hpuJsIrB8V3kjwB/zcyt6qKsWCsiRAs6oiQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.58.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -157,6 +157,17 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 			// layer without changing the SDK contract — the publish happens
 			// inside NPCAct, before we return here.
 			if tkenc.IsNPCPausedForReaction(actErr) {
+				// Single-reactor enforcement (Wave 2.11d closeout #538 C,
+				// Option 1): if the SDK persisted multiple prompts for this
+				// pause, drop all but the first. Orphan InputRequiredDelivered
+				// events already went out from inside NPCAct; subscribers
+				// reloading from repo will find no matching prompt and drop
+				// silently — acceptable behavior under single-reactor
+				// semantics. See take_action.go's persistPendingReactions for
+				// the design rationale + Wave 2.11e follow-up
+				// https://github.com/KirkDiggler/rpg-api/issues/540 for the
+				// proper aggregate-then-complete fix.
+				enforceSingleReactor(enc)
 				if err := h.serializePendingPhasedAttacks(enc); err != nil {
 					return nil, status.Errorf(codes.Internal, "serialize npc pending reactions: %v", err)
 				}
@@ -232,6 +243,39 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 	}
 
 	return &encounterv2pb.EndTurnResponse{}, nil
+}
+
+// enforceSingleReactor drops all but the first PendingReactionPrompt on the
+// encounter. Used after the SDK's NPCAct path persists multiple reactor
+// prompts during a single paused attack (npc.go's playerTriggers loop) —
+// CompleteTakeAction is destructive per call, so multiple persisted prompts
+// risk double-resolution.
+//
+// Wave 2.11d closeout (#538 C, Option 1): single-reactor enforcement.
+// Wave 2.11e (https://github.com/KirkDiggler/rpg-api/issues/540) replaces
+// this with aggregate-then-complete once a second post-hit reaction ships
+// (Counterspell, etc.). Until then, first-eligible-wins.
+//
+// Map iteration order in Go is unspecified, so "first" here means "any one"
+// — acceptable for the Wave 2.11d Shield-only scope where the only
+// multi-reactor case is two wizards both having Shield ready against the
+// same target (1-target-per-attack scenario; both wouldn't both be the
+// target of the same attack).
+func enforceSingleReactor(enc *tkenc.Encounter) {
+	prompts := enc.ToData().PendingReactionPrompts
+	if len(prompts) <= 1 {
+		return
+	}
+	var kept core.PlayerID
+	for pid := range prompts {
+		kept = pid
+		break
+	}
+	for pid := range prompts {
+		if pid != kept {
+			enc.ClearPendingReactionPrompt(pid)
+		}
+	}
 }
 
 // serializePendingPhasedAttacks marshals each in-process PhasedAttackContext

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -136,10 +136,26 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
 			// Wave 2.11d: NPC turn paused for a player reaction. The encounter
 			// has the pending reaction prompt + the InputRequiredDelivered event
-			// already published. Marshal the cached PhasedAttackContext into
-			// the prompt's AttackContextJSON so SubmitCheck can rebuild it on
-			// resume, then save and return success — the player must respond
+			// already published BY THE SDK from inside NPCAct (encounter/npc.go
+			// at the player-trigger loop). Marshal the cached PhasedAttackContext
+			// into the prompt's AttackContextJSON so SubmitCheck can rebuild it
+			// on resume, then save and return success — the player must respond
 			// before the NPC's turn (and the rest of the dispatch loop) continues.
+			//
+			// Wave 2.11d closeout (#538 B): the SDK-side publish-then-host-
+			// serialize ordering creates a race window where a fast stream
+			// subscriber reloads from repo BEFORE the host's
+			// serializePendingPhasedAttacks call + Save below. The subscriber
+			// could see either the old snapshot (no prompt at all) or a
+			// snapshot with a prompt but AttackContextJSON=nil. The proper
+			// fix lives in the SDK: a resolver-supplied serializer callback
+			// that lets the SDK populate AttackContextJSON itself BEFORE
+			// publishing the event. Tracked in
+			// https://github.com/KirkDiggler/rpg-toolkit/issues/657 (implicit
+			// in https://github.com/KirkDiggler/rpg-toolkit/issues/658 for
+			// movement-paused reactions). We cannot fix this at the rpg-api
+			// layer without changing the SDK contract — the publish happens
+			// inside NPCAct, before we return here.
 			if tkenc.IsNPCPausedForReaction(actErr) {
 				if err := h.serializePendingPhasedAttacks(enc); err != nil {
 					return nil, status.Errorf(codes.Internal, "serialize npc pending reactions: %v", err)

--- a/internal/handlers/dnd5e/v2/encounter/integration_player_shield_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_player_shield_test.go
@@ -1,0 +1,337 @@
+package encounter_test
+
+// integration_player_shield_test.go — Wave 2.11d closeout, partial #536.
+//
+// Ships ONE Shield integration test: TestPlayerShield_NotReady_NoPrompt.
+// Proves the readiness gate: when Shield is Apply()'d to a spellcaster
+// (gated on hasFirstLevelSpellSlot — unblocked by rpg-toolkit#660 LoadFromData
+// fix landed in v0.58.1) but readiness is OFF (default), Shield's predicate
+// does NOT publish a ReactionTriggerEvent. No PendingReactionPrompts gets
+// persisted. The attack proceeds inline and hits.
+//
+// Two other originally-scoped Shield tests deferred to rpg-api#541 +
+// rpg-toolkit#662 per closeout B12 finding:
+//   - TestPlayerShield_ReadyAndPrompted_Blocks: blocked by SDK gap —
+//     Encounter.CompleteTakeAction rejects NPC attackers, so the only Shield-
+//     fires direction in PvE scope (NPC → player) can't be resumed.
+//   - TestPlayerShield_ReadyAndSkipped_Hits: same B12 blocker.
+//
+// Shield predicate band (rulebooks/dnd5e/conditions/shield_spell.go):
+//   - Target of the attack is the bearer (the wizard)
+//   - WouldHit == true (attack total >= AC)
+//   - Not nat-20
+//   - TotalAttack < AC + 5 (so +5 AC would deflect)
+//   - gamectx.IsReactionReady(wizard, Shield) == true
+//
+// The not-ready scenario gates on the last bullet: the predicate's first
+// four checks all match (attack lands in band), but the readiness flag
+// returns false → no trigger event published → no prompt → attack hits
+// inline at the legacy single-phase path.
+//
+// Scenario:
+//   - wendy (level-1 wizard, AC 12, HP 8) with SpellSlots[1].Max=2 to qualify
+//     for Shield-Apply via applyReactionConditions.hasFirstLevelSpellSlot.
+//     SpellSlots survive Get→LoadFromData lifecycle thanks to v0.58.1.
+//   - goblin (NewGoblin DataJSON: AB +4, scimitar 1d6+2) attacks wendy.
+//
+// Deterministic roller: fixedRoller{val: 12} makes goblin's d20 = 12,
+// total = 12 + 4 = 16. With wendy's AC 12: 16 >= 12 (hits), 16 < 17 (Shield
+// WOULD deflect if ready). Squarely in the Shield-eligible band — so this
+// test proves the readiness gate is the only thing stopping the prompt.
+//
+// Damage 1d6+2: Roll(6) = min(12,6) = 6; +2 = 8. Drops wendy 8 → 0.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	shieldIntegEncID  = "enc-shield-integration"
+	shieldPlayerWendy = "wendy"
+	shieldEntityWendy = "char-wendy"
+	shieldGoblinID    = "goblin-shield"
+
+	// shieldFullHP is wendy's HP — chosen so unblocked = 0 (clear signal).
+	shieldFullHP = 8
+
+	// shieldRollVal: fixedRoller{val:12} → goblin d20=12 + AB 4 = 16.
+	// Wendy AC 12: 16 >= 12 hits; 16 < 17 = AC + Shield's +5 — in-band.
+	shieldRollVal = 12
+
+	// shieldExpectedDamage: weapon 1d6+2 → Roll(6) = min(12,6)=6; +2 = 8.
+	// Drops wendy from 8 → 0 if Shield doesn't block.
+	shieldExpectedDamage = 8
+)
+
+// PlayerShieldIntegrationSuite tests the Shield readiness gate end-to-end
+// through the v2 handler. Wave 2.11d ships this test; the prompted/skipped
+// scenarios deferred to Wave 2.11e (rpg-api#541, blocked by rpg-toolkit#662).
+type PlayerShieldIntegrationSuite struct {
+	suite.Suite
+	ctrl         *gomock.Controller
+	mockCharRepo *charactermock.MockRepository
+	charStore    *inMemoryCharStore // hoisted from sneak test
+	broker       *tkenc.Broker
+	repo         encountersv2.Repository
+	handler      *v2encounter.Handler
+	wendyCtx     context.Context
+}
+
+// TestPlayerShieldIntegrationSuite runs the Wave 2.11d Shield-gate suite.
+func TestPlayerShieldIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(PlayerShieldIntegrationSuite))
+}
+
+// SetupTest constructs a fresh broker + repo + handler per test for isolation.
+func (s *PlayerShieldIntegrationSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
+	s.charStore = newInMemoryCharStore()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	h, err := v2encounter.New(&v2encounter.HandlerConfig{
+		Broker: s.broker,
+		Repo:   s.repo,
+		Now:    func() time.Time { return fixedNow },
+		CombatResolverConfig: &v2encounter.Dnd5eCombatResolverConfig{
+			CharacterRepo: s.mockCharRepo,
+			Roller:        fixedRoller{val: shieldRollVal},
+		},
+	})
+	s.Require().NoError(err)
+	s.handler = h
+
+	s.wendyCtx = auth.WithPlayerID(context.Background(), shieldPlayerWendy)
+}
+
+// TearDownTest closes the gomock controller (asserts all EXPECT()s satisfied).
+func (s *PlayerShieldIntegrationSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// TestPlayerShield_NotReady_NoPrompt verifies the unreadied path: wendy
+// is a spellcaster with Shield Apply()'d during character rehydration
+// (qualified by hasFirstLevelSpellSlot — relies on rpg-toolkit#660's
+// LoadFromData SpellSlots fix). She does NOT call SetReactionReady, so
+// Shield's gamectx.IsReactionReady gate blocks the trigger publish entirely.
+//
+// Assertions:
+//   - No PendingReactionPrompts populated (the readiness gate held)
+//   - Goblin attack hits inline (legacy single-phase path)
+//   - wendy HP drops by full weapon damage
+//
+// This is the one Shield path that ships end-to-end in Wave 2.11d. The two
+// prompted paths (Ready+Take, Ready+Skip) need rpg-toolkit#662 (CompleteTakeAction
+// symmetry for NPC attackers) which is deferred to Wave 2.11e per
+// closeout B12 finding.
+func (s *PlayerShieldIntegrationSuite) TestPlayerShield_NotReady_NoPrompt() {
+	wendyData := s.buildWendyWizardData()
+	s.setupCharRepoMock(wendyData)
+	s.seedShieldEncounter()
+
+	// Do NOT call SetReactionReady. Shield stays off (default per
+	// applyReactionConditions — spell-cost reactions are opt-in).
+
+	s.advanceToWendyActiveTurn()
+
+	_, err := s.handler.EndTurn(s.wendyCtx, &encounterv2pb.EndTurnRequest{
+		EncounterId: shieldIntegEncID,
+		EntityId:    shieldEntityWendy,
+	})
+	s.Require().NoError(err, "EndTurn must succeed; goblin attack runs inline since Shield is unready")
+
+	// No prompt should have been persisted — Shield's readiness gate held.
+	data, err := s.repo.Get(context.Background(), shieldIntegEncID)
+	s.Require().NoError(err)
+	_, ok := data.PendingReactionPrompts[encountercore.PlayerID(shieldPlayerWendy)]
+	s.False(ok,
+		"PendingReactionPrompts must NOT contain wendy's prompt — Shield was unready, predicate gated")
+
+	// Wendy took the full hit (no Shield to deflect).
+	hpAfter := s.wendyHP()
+	delta := shieldFullHP - hpAfter
+	s.Equal(shieldExpectedDamage, delta,
+		"wendy HP delta (%d) must equal weapon damage (%d) — Shield was unready so the goblin's 16 hits cleanly",
+		delta, shieldExpectedDamage)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — Shield-specific. Generic helpers (fixedRoller, inMemoryCharStore)
+// live in integration_sneak_attack_test.go in the same package.
+// ---------------------------------------------------------------------------
+
+// setupCharRepoMock wires the mockCharRepo to read/write through inMemoryCharStore.
+// Mirror of the sneak suite's setup but for wendy as the sole player character;
+// non-wendy lookups return an error so the resolver falls back to StandIn.
+func (s *PlayerShieldIntegrationSuite) setupCharRepoMock(wendyData *character.Data) {
+	s.charStore.set(wendyData)
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: shieldEntityWendy}).
+		DoAndReturn(func(_ context.Context, _ characterrepo.GetInput) (*characterrepo.GetOutput, error) {
+			d := s.charStore.get(shieldEntityWendy)
+			if d == nil {
+				return nil, fmt.Errorf("wendy not found in charStore")
+			}
+			return &characterrepo.GetOutput{
+				Character: &entities.Character{Data: d},
+			}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			if input.Character != nil && input.Character.Data != nil {
+				s.charStore.update(input.Character.Data)
+			}
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), gomock.Not(characterrepo.GetInput{ID: shieldEntityWendy})).
+		Return(nil, fmt.Errorf("character not configured in integration test mock")).
+		AnyTimes()
+}
+
+// wendyHP returns wendy's HP from the persisted encounter snapshot.
+func (s *PlayerShieldIntegrationSuite) wendyHP() int {
+	data, err := s.repo.Get(context.Background(), shieldIntegEncID)
+	s.Require().NoError(err, "repo.Get for wendy HP check")
+	pd, ok := data.Players[encountercore.PlayerID(shieldPlayerWendy)]
+	s.Require().True(ok, "wendy must be in encounter player map")
+	return pd.HP
+}
+
+// buildWendyWizardData constructs a level-1 wizard with Shield-eligible
+// shape: SpellSlots[1].Max=2 → applyReactionConditions.hasFirstLevelSpellSlot
+// returns true → ShieldSpellCondition.Apply() on every encounter rehydration.
+// AC 12 keeps the Shield band test deterministic against fixedRoller{val:12}.
+//
+// SpellSlots round-trip cleanly through Data → LoadFromData → ToData thanks
+// to rpg-toolkit#660 (landed v0.58.1). Before that fix, this field would
+// silently drop on rehydration and Shield would never Apply.
+func (s *PlayerShieldIntegrationSuite) buildWendyWizardData() *character.Data {
+	return &character.Data{
+		ID:               shieldEntityWendy,
+		Name:             "Wendy the Wizard",
+		Level:            1,
+		ClassID:          "wizard",
+		ProficiencyBonus: 2,
+		HitPoints:        shieldFullHP,
+		MaxHitPoints:     shieldFullHP,
+		ArmorClass:       12,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 8,
+			abilities.DEX: 14,
+			abilities.CON: 12,
+			abilities.INT: 16, // wizard primary
+			abilities.WIS: 10,
+			abilities.CHA: 10,
+		},
+		SpellSlots: map[int]character.SpellSlotData{
+			1: {Max: 2, Used: 0},
+		},
+	}
+}
+
+// seedShieldEncounter creates the fixture encounter. Wendy at Q:0,R:0;
+// goblin at Q:2,R:0 (within scimitar reach after moveTowardEnemy in
+// monster.TakeTurn).
+//
+// Goblin needs DataJSON so NPCAct goes through the rehydration +
+// monster.TakeTurn → applyCapturedAttacks path. Without DataJSON, NPCAct
+// falls back to npcActScripted which bypasses the phased path. We use
+// monster.NewGoblin so the monster has realistic AbilityScores (a
+// monster.New with zero AbilityScores produces a STR -5 modifier and can
+// never hit anything).
+func (s *PlayerShieldIntegrationSuite) seedShieldEncounter() {
+	enc := tkenc.New(shieldIntegEncID, s.broker)
+
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   encountercore.PlayerID(shieldPlayerWendy),
+		EntityID:   encountercore.EntityID(shieldEntityWendy),
+		Position:   encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		HP:         shieldFullHP, MaxHP: shieldFullHP, AC: 12,
+		AttackBonus: 0, // wizard isn't attacking; satisfies AddPlayer's combatant qualifier
+		DamageDice:  "1d4",
+		DamageType:  "force",
+	}))
+
+	goblin := monster.NewGoblin(shieldGoblinID)
+	// Override HP so the goblin survives even if a test extends to multiple attacks.
+	goblinData := goblin.ToData()
+	goblinData.HitPoints = 100
+	goblinData.MaxHitPoints = 100
+	goblinDataJSON, err := json.Marshal(goblinData)
+	s.Require().NoError(err, "marshal goblin data")
+
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID:          encountercore.EntityID(shieldGoblinID),
+		Position:    encountercore.Hex{Q: 2, R: 0, S: -2},
+		HP:          100, MaxHP: 100, AC: 15,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, // matches scimitar action
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+		DataJSON:    goblinDataJSON,
+	}))
+
+	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
+}
+
+// advanceToWendyActiveTurn walks initiative forward until wendy is the
+// active actor. NPC turns encountered en route are force-ended via the SDK
+// directly to avoid triggering NPCAct in this helper (the test method
+// controls when the goblin's turn fires).
+//
+// Initiative is randomly rolled by SetMode, so this loop accepts either
+// initial order. In practice ends in 1-2 iterations for a 2-combatant
+// encounter.
+func (s *PlayerShieldIntegrationSuite) advanceToWendyActiveTurn() {
+	for i := 0; i < 4; i++ {
+		data, err := s.repo.Get(context.Background(), shieldIntegEncID)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(data.Initiative)
+		if data.ActiveIdx < 0 || data.ActiveIdx >= len(data.Initiative) {
+			s.Fail("invalid ActiveIdx", data.ActiveIdx)
+		}
+		active := string(data.Initiative[data.ActiveIdx])
+		if active == shieldEntityWendy {
+			return // caller's EndTurn will fire next, kicking off the goblin's NPCAct
+		}
+		// Active is the goblin — end its turn directly via SDK so we can
+		// loop back to wendy first.
+		enc, loadErr := tkenc.LoadFromData(data, s.broker)
+		s.Require().NoError(loadErr)
+		_, _, err = enc.EndTurn(encountercore.EntityID(active))
+		s.Require().NoError(err)
+		s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
+	}
+	s.Fail("advanceToWendyActiveTurn: wendy did not become active within 4 turns")
+}

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -101,42 +101,63 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 		return nil, takeActionStatusError(takeErr)
 	}
 
+	// Wave 2.11d closeout (#538 A): split persist from publish so the save
+	// lands BEFORE InputRequiredDelivered fires. The stream translator
+	// reloads PendingReactionPrompts from the repo when it receives the
+	// event; if we published first, a fast subscriber could see the
+	// pre-prompt snapshot and drop the event as "no matching prompt."
+	var promptsToPublish []core.PlayerID
 	if outcome != nil && len(outcome.Reactions) > 0 {
-		if err := h.persistPendingReactions(enc, outcome); err != nil {
+		pids, err := h.persistPendingReactions(enc, outcome)
+		if err != nil {
 			return nil, status.Errorf(codes.Internal, "persist pending reactions: %v", err)
 		}
+		promptsToPublish = pids
 	}
 
 	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
 		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
 	}
 
+	// Save committed — now safe to publish prompt events. Stream subscribers
+	// that reload from repo will see the persisted prompts.
+	for _, pid := range promptsToPublish {
+		if err := enc.PublishInputRequiredDelivered(pid, tkevents.PromptKindReaction); err != nil {
+			return nil, status.Errorf(codes.Internal, "publish reaction prompt event: %v", err)
+		}
+	}
+
 	return &encounterv2pb.TakeActionResponse{}, nil
 }
 
 // persistPendingReactions records each player-reaction trigger from the
-// phased outcome as a PendingReactionPrompt on the encounter Data and
-// emits an InputRequiredDelivered event to each reactor's per-viewer
-// stream.
+// phased outcome as a PendingReactionPrompt on the encounter Data. Returns
+// the list of reactor PlayerIDs whose prompts were persisted; the caller
+// publishes InputRequiredDelivered for each AFTER the snapshot save commits
+// (Wave 2.11d closeout #538 A: save-before-publish ordering).
 //
 // The PhasedAttackContext (opaque to the SDK; *combat.AttackContext under
 // the hood) is JSON-marshaled and stored on the prompt so SubmitCheck +
 // CompleteTakeAction can rehydrate it on the resume path. This is the
 // load-bearing reason combat.AttackContext was refactored to be pure data
 // in Wave 2.11d (no eventBus/roller fields).
-func (h *Handler) persistPendingReactions(enc *tkenc.Encounter, outcome *tkenc.TakeActionOutcome) error {
+func (h *Handler) persistPendingReactions(
+	enc *tkenc.Encounter,
+	outcome *tkenc.TakeActionOutcome,
+) ([]core.PlayerID, error) {
 	if outcome.AttackContext == nil {
-		return errors.New("phased outcome has reactions but no attack context")
+		return nil, errors.New("phased outcome has reactions but no attack context")
 	}
 	rulebookCtx, ok := outcome.AttackContext.Rulebook.(*combat.AttackContext)
 	if !ok {
-		return fmt.Errorf("AttackContext.Rulebook is %T, expected *combat.AttackContext", outcome.AttackContext.Rulebook)
+		return nil, fmt.Errorf("AttackContext.Rulebook is %T, expected *combat.AttackContext", outcome.AttackContext.Rulebook)
 	}
 	ctxJSON, err := json.Marshal(rulebookCtx)
 	if err != nil {
-		return fmt.Errorf("marshal attack context: %w", err)
+		return nil, fmt.Errorf("marshal attack context: %w", err)
 	}
 
+	persisted := make([]core.PlayerID, 0, len(outcome.Reactions))
 	for _, trig := range outcome.Reactions {
 		reactorPlayerID, ok := h.reactorPlayerID(enc, trig.ReactorID)
 		if !ok {
@@ -153,12 +174,9 @@ func (h *Handler) persistPendingReactions(enc *tkenc.Encounter, outcome *tkenc.T
 			SourceEntity:      trig.SourceEntity,
 			AttackContextJSON: ctxJSON,
 		})
-
-		if err := enc.PublishInputRequiredDelivered(reactorPlayerID, tkevents.PromptKindReaction); err != nil {
-			return fmt.Errorf("publish reaction prompt event: %w", err)
-		}
+		persisted = append(persisted, reactorPlayerID)
 	}
-	return nil
+	return persisted, nil
 }
 
 // reactorPlayerID resolves the controlling player ID for a reactor entity.

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -130,9 +130,10 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 	return &encounterv2pb.TakeActionResponse{}, nil
 }
 
-// persistPendingReactions records each player-reaction trigger from the
-// phased outcome as a PendingReactionPrompt on the encounter Data. Returns
-// the list of reactor PlayerIDs whose prompts were persisted; the caller
+// persistPendingReactions records the first eligible player-reaction trigger
+// from the phased outcome as a PendingReactionPrompt on the encounter Data.
+// Returns the list of reactor PlayerIDs whose prompts were persisted (0 or
+// 1 entries — see single-reactor enforcement note below); the caller
 // publishes InputRequiredDelivered for each AFTER the snapshot save commits
 // (Wave 2.11d closeout #538 A: save-before-publish ordering).
 //
@@ -141,6 +142,24 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 // CompleteTakeAction can rehydrate it on the resume path. This is the
 // load-bearing reason combat.AttackContext was refactored to be pure data
 // in Wave 2.11d (no eventBus/roller fields).
+//
+// Single-reactor enforcement (Wave 2.11d closeout #538 C, Option 1):
+// CompleteTakeAction is destructive — it publishes the AttackResolvedEvent +
+// applies damage once per call. Persisting multiple reactor prompts on the
+// same paused attack risks double-resolution when the second SubmitCheck
+// arrives (each would call CompleteTakeAction with its own modifier list,
+// double-applying damage). For Wave 2.11d's shipped scope (Shield is the
+// only post-hit modifier; OA is fan-out as separate attacks, not modifier
+// stacking) this is correct: the only realistic multi-reactor case in
+// 2.11d would be two wizards both having Shield ready against the same
+// attack, which is a 1-target-per-attack scenario (only the attack target
+// can Shield-self).
+//
+// TODO(wave-2.11e): multi-reactor aggregation for stacked post-hit
+// modifiers (Shield + Counterspell + Lucky reroll). Replace the first-
+// trigger pick with: persist all eligible triggers + gate
+// CompleteTakeAction on all-reactors-responded (or deadline). See
+// https://github.com/KirkDiggler/rpg-api/issues/540 for the design.
 func (h *Handler) persistPendingReactions(
 	enc *tkenc.Encounter,
 	outcome *tkenc.TakeActionOutcome,
@@ -157,13 +176,15 @@ func (h *Handler) persistPendingReactions(
 		return nil, fmt.Errorf("marshal attack context: %w", err)
 	}
 
-	persisted := make([]core.PlayerID, 0, len(outcome.Reactions))
+	// Single-reactor enforcement: pick the first trigger whose reactor we
+	// can resolve to a player. Subsequent triggers are dropped (see TODO
+	// above for the Wave 2.11e aggregation design).
 	for _, trig := range outcome.Reactions {
 		reactorPlayerID, ok := h.reactorPlayerID(enc, trig.ReactorID)
 		if !ok {
 			// SDK contract: only player reactors are surfaced (NPC triggers
 			// auto-resolve inside TakeActionPhased). Missing playerID means
-			// data inconsistency; skip rather than fail the attack.
+			// data inconsistency; skip and try the next trigger.
 			continue
 		}
 
@@ -174,9 +195,11 @@ func (h *Handler) persistPendingReactions(
 			SourceEntity:      trig.SourceEntity,
 			AttackContextJSON: ctxJSON,
 		})
-		persisted = append(persisted, reactorPlayerID)
+		return []core.PlayerID{reactorPlayerID}, nil
 	}
-	return persisted, nil
+
+	// No eligible player-reactor trigger found.
+	return []core.PlayerID{}, nil
 }
 
 // reactorPlayerID resolves the controlling player ID for a reactor entity.


### PR DESCRIPTION
## Summary

Wave 2.11d closeout PR. Lands the 3 fixes promised by the wave + the readiness-gate integration test that proves the one Shield path which works end-to-end in shipped scope. Verification surfaced 3 separate SDK-shape gaps along the way — 1 fixed via dep bump, 2 deferred to Wave 2.11e with filed issues.

Per the discipline Kirk asked for (\"ensure choices don't go against the goal — or adjust the idea to fit nuances discovered\"), the Wave 2.11d wave-goal sentence is being revised in rpg-project#47 to match what actually ships. See [#47 comment](https://github.com/KirkDiggler/rpg-project/issues/47) for the full scope-adjustment rationale.

## What ships

### Fixes (#538)

- **B1 — `877ef3c` fix(encounter/v2): save encounter snapshot before publishing reaction prompt event (#538 A+B)** — `take_action.go` now persists `PendingReactionPrompts` and runs `encRepo.Save` BEFORE publishing `InputRequiredDelivered`. Closes the race where a fast stream subscriber could reload from repo and see the pre-prompt snapshot. The NPC-pause path in `end_turn.go` has the same race shape but the fix is structurally toolkit-bound (the SDK publishes from inside `NPCAct` before the host can intervene) — documented + tracked in [rpg-toolkit#657](https://github.com/KirkDiggler/rpg-toolkit/issues/657).
- **B2 — `bc1acfd` fix(encounter/v2): single-reactor enforcement on phased reaction persist (#538 C)** — `persistPendingReactions` now stores only the first eligible reactor's prompt; subsequent triggers dropped with a Wave 2.11e TODO referencing [rpg-api#540](https://github.com/KirkDiggler/rpg-api/issues/540) (aggregate-then-complete design). `enforceSingleReactor` helper added to `end_turn.go` for the NPC-pause symmetry. Today's `CompleteTakeAction` is destructive (publishes outcome + applies damage once per call); multi-reactor persist would risk double-resolution.

### Dep bump (T5)

- **`b170c99` chore(deps): bump rpg-toolkit/rulebooks/dnd5e to v0.58.1 for SpellSlots load fix** — picks up [rpg-toolkit#660](https://github.com/KirkDiggler/rpg-toolkit/pull/660) (closes [rpg-toolkit#659](https://github.com/KirkDiggler/rpg-toolkit/issues/659)). `character.LoadFromData` now loads `Data.SpellSlots` and `Data.ClassResources` into the runtime Character (silently dropped before). Unblocked `applyReactionConditions.hasFirstLevelSpellSlot` — every spellcaster coming out of the encounter repo now retains spell slots, so Shield is actually `Apply()`'d.

### Integration test (T6 — #536 partial)

- **`2cbafb1` test(encounter/v2): Wave 2.11d player Shield readiness-gate integration test (#536 partial)** — `TestPlayerShield_NotReady_NoPrompt` ships. Verifies that when wendy (level-1 wizard with SpellSlots populated) does NOT call SetReactionReady, Shield's predicate gates the trigger publish: no PendingReactionPrompts persisted; goblin attack hits inline; HP delta = 8 (full damage).

## Wave 2.11e deferrals (with traceability)

Closeout-phase verification surfaced 3 SDK gaps. 1 fixed, 2 deferred:

| Gap | B-call | Status | Tracked in |
|---|---|---|---|
| `Encounter.Move` bypasses MovementChain → player-OA-on-move broken | B8 | Deferred | [rpg-toolkit#658](https://github.com/KirkDiggler/rpg-toolkit/issues/658) (SDK MovementResolver) + [rpg-api#539](https://github.com/KirkDiggler/rpg-api/issues/539) (rpg-api wire-up + 2 deferred OA tests) |
| `character.LoadFromData` drops `Data.SpellSlots` → Shield never Apply()'d | B10 | **FIXED** | [rpg-toolkit#659](https://github.com/KirkDiggler/rpg-toolkit/issues/659) → [rpg-toolkit#660](https://github.com/KirkDiggler/rpg-toolkit/pull/660) merged → v0.58.1 → bumped here |
| `Encounter.CompleteTakeAction` rejects NPC attackers → Shield resume broken | B12 | Deferred | [rpg-toolkit#662](https://github.com/KirkDiggler/rpg-toolkit/issues/662) (SDK CompleteTakeAction symmetry) + [rpg-api#541](https://github.com/KirkDiggler/rpg-api/issues/541) (rpg-api wire-up + 2 deferred Shield tests) |

Sibling Wave 2.11e item not surfaced by verification but designed alongside the above:

- Multi-reactor aggregation for stacked post-hit modifiers → [rpg-api#540](https://github.com/KirkDiggler/rpg-api/issues/540) (becomes needed when a 2nd post-hit reaction like Counterspell ships)

Sibling toolkit cleanup found during the #660 audit:

- `Data.BackgroundID` not read by LoadFromData (no runtime field exists for it) → [rpg-toolkit#661](https://github.com/KirkDiggler/rpg-toolkit/issues/661) (different bug class; needs runtime struct field + serializer wiring — not gating Wave 2.11d)

## Test plan

- [x] All 5 Wave 2.11c sneak-attack canary tests still pass against v0.58.1
- [x] New `TestPlayerShield_NotReady_NoPrompt` passes
- [x] Full `internal/handlers/dnd5e/v2/encounter/` test suite passes
- [x] `golangci-lint run ./internal/handlers/dnd5e/v2/encounter/` returns 0 issues on Wave 2.11d files
- [x] Full integration suites pass (`internal/integration`, `.../encounter`, `.../character`, `.../harness`)

## Four-question gate

**Goal (honest).** Wave 2.11d ships the **orchestration plumbing** (`PhasedCombatResolver` + `TakeActionPhased` SDK verb + `Dnd5eCombatResolver` host impl), the **readiness toggle infrastructure** (`SetReactionReady` RPC + per-character per-condition map), **Shield + OA condition predicate verification** (toolkit unit tests + the one rpg-api integration test that exercises the readiness gate), and the **publish-vs-save + single-reactor enforcement fixes** from #538. End-to-end Shield-fires-and-blocks + player-OA-on-move are deferred to Wave 2.11e along with their SDK-extension prerequisites (#658, #662). Three structural SDK gaps surfaced during closeout verification (B8/B10/B12); 1 fixed, 2 filed cleanly for the next wave.

**Pattern.** Mirrors existing v2 encounter handler patterns: per-file scope (take_action.go, end_turn.go, integration_player_shield_test.go), suite-pattern tests with `inMemoryCharStore` + `fixedRoller` helpers hoisted from `integration_sneak_attack_test.go`, no boundary violations (no proto types in resolver code), no `--no-verify`. Single-reactor enforcement structurally mirrors what the SDK was already doing for the inline NPC path, just made explicit. Fix-shape cross-referenced against the established `maps.Clone(d.X)` idiom for the toolkit-side companion change.

**Test.** New: 1 integration test (`TestPlayerShield_NotReady_NoPrompt`) exercises Shield's readiness gate end-to-end through the v2 handler. Existing: 5 Wave 2.11c sneak-attack canaries still green, full handler suite green, full integration suite green, lint-clean. Toolkit-side: rpg-toolkit#660 added 3 round-trip regression tests for SpellSlots + ClassResources, all passing on v0.58.1.

**Pushback.** Three scope/discipline calls:
1. **Only 1 of 5 originally-scoped Shield/OA integration tests landed** (per the deferrals above). This is an honest accounting per the wave-goal verification discipline — the alternative would have been claiming Shield works end-to-end when it doesn't yet, or burning closeout into a 4th multi-repo round to fix the structural gaps. Filed and deferred cleanly.
2. **`end_turn.go` NPC-pause-path race (#538 B) is documented but not fixed at the rpg-api layer** — the publish happens inside `NPCAct` before the host runs, so the proper fix is a toolkit-side serializer callback ([rpg-toolkit#657](https://github.com/KirkDiggler/rpg-toolkit/issues/657)). Documented inline so future readers don't re-derive the analysis.
3. **`BackgroundID` round-trip drop NOT fixed in #660** despite finding it during the T2 audit — it's a different bug class (no runtime field exists; fixing requires struct + ToData + LoadFromData triple-change). Tracked in [#661](https://github.com/KirkDiggler/rpg-toolkit/issues/661) but not gating Wave 2.11d.

## Wave tracker

- [rpg-project#47](https://github.com/KirkDiggler/rpg-project/issues/47) — Wave 2.11d goal sentence revised in comment (see Step X5 of the closeout dispatch).

## Commit chain

- `877ef3c` fix #538 A+B (save-before-publish ordering)
- `bc1acfd` fix #538 C (single-reactor enforcement)
- `b170c99` chore: bump rulebooks/dnd5e v0.58.0 → v0.58.1 (LoadFromData SpellSlots fix)
- `2cbafb1` test: Shield readiness-gate integration test (#536 partial — 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)