### PR TITLE
chore(devseed): seed real characters + turn-based encounter for harness verification

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -17,9 +17,14 @@
 // so handlers/dnd5e/v2/encounter can Load it without translation.
 //
 // Wave 2.11d wires conditions at load:
-//   - applyReactionConditions Apply()s OpportunityAttack on every melee
-//     combatant (alice, bob) and Shield on characters with a 1st-level
-//     spell slot (wendy). Default readiness: OA on, Shield off.
+//   - applyReactionConditions Apply()s OpportunityAttack on EVERY character
+//     unconditionally (alice, bob, wendy) — the OA predicate gates whether
+//     it actually publishes a trigger event (e.g. by checking weapon reach
+//     and gamectx.IsReactionReady), so it's a silent no-op for characters
+//     with no melee threat range. Shield is Apply()'d only when
+//     hasFirstLevelSpellSlot returns true (wendy). Default readiness: OA on
+//     (seeded by the encounter SDK's AddPlayer for combatants with
+//     DamageDice), Shield off.
 //   - SneakAttack is persisted in alice's Conditions JSON so LoadFromData
 //     re-Apply()s it on every rehydration (the once-per-turn gate persists
 //     via SneakAttackData.UsedThisTurn → rpg-toolkit#655).
@@ -75,6 +80,11 @@ const (
 	// Kept as a literal so devseed doesn't depend on the (currently
 	// unexported) constant in the repository package.
 	charKeyPrefix = "character:"
+
+	// playerIndexPrefix mirrors the same constant in the character repo;
+	// SADD'd here so ListByPlayerID returns seeded characters (per Copilot
+	// review feedback on PR #543).
+	playerIndexPrefix = "character:player:"
 
 	// encKeyPrefix matches internal/repositories/encounters/v2/redis.go.
 	encKeyPrefix = "enc:v2:"
@@ -179,9 +189,13 @@ func run() error {
 		return fmt.Errorf("write encounter: %w", writeErr)
 	}
 
+	// encMode is a core.EncounterMode (int with a String() method); use %v
+	// so the formatter resolves to .String() unambiguously (Copilot review
+	// nit on PR #543 — %s also works via fmt.Stringer dispatch, but %v is
+	// more idiomatic for non-string types).
 	fmt.Fprintf(
 		os.Stderr,
-		"seeded %s%s: mode=%s players=%d monsters=%d ttl=%s\n",
+		"seeded %s%s: mode=%v players=%d monsters=%d ttl=%s\n",
 		encKeyPrefix, encData.ID, encMode, len(encData.Players), len(encData.Monsters), encTTL,
 	)
 	return nil
@@ -202,7 +216,10 @@ func parseMode(s string) (encountercore.EncounterMode, error) {
 
 // writeCharacter serializes the character via the same envelope shape the
 // production character repo uses (entities.Character{Data: ...}) and SETs
-// it under character:<id> with no TTL.
+// it under character:<id> with no TTL. Also SADDs the character ID into
+// the player-index set so ListByPlayerID returns seeded characters — matches
+// the production Create flow in internal/repositories/character/redis.go
+// (Copilot review feedback on PR #543).
 func writeCharacter(ctx context.Context, client redisclient.Client, data *toolkitchar.Data) error {
 	if data == nil || data.ID == "" {
 		return errors.New("character data nil or missing ID")
@@ -215,8 +232,18 @@ func writeCharacter(ctx context.Context, client redisclient.Client, data *toolki
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
-	if err := client.Set(ctx, charKeyPrefix+data.ID, blob, 0).Err(); err != nil {
-		return fmt.Errorf("redis SET: %w", err)
+
+	// Atomic write: character blob + player-index SADD in a single
+	// TxPipeline, matching the production repo's Create implementation
+	// (internal/repositories/character/redis.go:99-114). Session index is
+	// intentionally skipped — devseed never seeds session membership.
+	pipe := client.TxPipeline()
+	pipe.Set(ctx, charKeyPrefix+data.ID, blob, 0)
+	if data.PlayerID != "" {
+		pipe.SAdd(ctx, playerIndexPrefix+data.PlayerID, data.ID)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis pipeline exec: %w", err)
 	}
 	return nil
 }

--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -1,0 +1,490 @@
+// devseed populates Redis with a ready-to-play v2 encounter plus the three
+// canonical playtest characters (alice-rogue, bob-barbarian, wendy-wizard)
+// and a goblin, so the rpg-dnd5e-web playtest harness can verify reaction
+// flows end-to-end without going through CreateDraft/FinalizeDraft.
+//
+// What it writes
+//
+//	character:char-alice    — level-2 rogue with SneakAttack condition pre-applied
+//	character:char-bob      — level-1 barbarian with Rage feature + RageCharges resource
+//	character:char-wendy    — level-1 wizard with 1st-level spell slots (Shield-eligible)
+//	enc:v2:<encounter-id>   — encounter referencing all three by EntityID,
+//	                          plus a single goblin (monster.NewGoblin DataJSON)
+//
+// The character keys use the same schema as the production character repo
+// (entities.Character{Data: *toolkitchar.Data}) so the rpg-api character
+// handler can Get them by ID. The encounter key uses the v2 toolkit shape
+// so handlers/dnd5e/v2/encounter can Load it without translation.
+//
+// Wave 2.11d wires conditions at load:
+//   - applyReactionConditions Apply()s OpportunityAttack on every melee
+//     combatant (alice, bob) and Shield on characters with a 1st-level
+//     spell slot (wendy). Default readiness: OA on, Shield off.
+//   - SneakAttack is persisted in alice's Conditions JSON so LoadFromData
+//     re-Apply()s it on every rehydration (the once-per-turn gate persists
+//     via SneakAttackData.UsedThisTurn → rpg-toolkit#655).
+//   - Rage is persisted as a Feature so the API's Activate flow can call it;
+//     bob is NOT raging at start.
+//
+// Usage
+//
+//	# Seed against local Redis with default encounter id and TURN_BASED mode
+//	go run ./cmd/devseed
+//
+//	# Override encounter id (matches the harness URL ?encounterId=…)
+//	go run ./cmd/devseed --encounter-id=dev-encounter
+//
+//	# Seed for free-roam (no initiative). Default is turn_based.
+//	go run ./cmd/devseed --mode=free_roam
+//
+//	# Custom Redis target
+//	REDIS_ADDR=redis.example.com:6379 go run ./cmd/devseed
+//
+// Positions are aligned with the harness's SEEDED_FALLBACK in
+// rpg-dnd5e-web/src/components/playtest/PlaytestHarness.tsx so the first
+// MoveEntity dispatches against the right starting hexes.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	dnd5eResources "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	// charKeyPrefix matches internal/repositories/character/redis.go.
+	// Kept as a literal so devseed doesn't depend on the (currently
+	// unexported) constant in the repository package.
+	charKeyPrefix = "character:"
+
+	// encKeyPrefix matches internal/repositories/encounters/v2/redis.go.
+	encKeyPrefix = "enc:v2:"
+
+	// encTTL mirrors the production wiring in cmd/server/server.go
+	// (encountersv2.NewRedis(client, 24*time.Hour)). Characters get no TTL
+	// to match the character repo.
+	encTTL = 24 * time.Hour
+
+	defaultEncounterID = "dev-encounter"
+	defaultRedisAddr   = "localhost:6379"
+
+	modeTurnBased = "turn_based"
+	modeFreeRoam  = "free_roam"
+)
+
+var (
+	// Entity IDs are stable across runs so the harness can deep-link to a
+	// specific player and the existing integration tests' EntityID constants
+	// stay aligned.
+	playerAlice = encountercore.PlayerID("alice")
+	playerBob   = encountercore.PlayerID("bob")
+	playerWendy = encountercore.PlayerID("wendy")
+
+	entityAlice  = encountercore.EntityID("char-alice")
+	entityBob    = encountercore.EntityID("char-bob")
+	entityWendy  = encountercore.EntityID("char-wendy")
+	entityGoblin = encountercore.EntityID("goblin-1")
+)
+
+func main() {
+	if err := run(); err != nil {
+		// Single top-level error sink so defers in run() always fire
+		// (gocritic exitAfterDefer); log.Fatalf inside run() would skip
+		// defer cancel() and the Redis client.Close defer.
+		log.Fatalf("devseed: %v", err)
+	}
+}
+
+func run() error {
+	var (
+		redisAddr   = flag.String("redis-addr", "", "Redis address (default: $REDIS_ADDR or "+defaultRedisAddr+")")
+		encounterID = flag.String("encounter-id", defaultEncounterID, "Encounter ID to seed under enc:v2:<id>")
+		mode        = flag.String("mode", modeTurnBased, "Encounter mode: turn_based or free_roam")
+	)
+	flag.Parse()
+
+	addr := *redisAddr
+	if addr == "" {
+		addr = os.Getenv("REDIS_ADDR")
+	}
+	if addr == "" {
+		addr = defaultRedisAddr
+	}
+
+	encMode, err := parseMode(*mode)
+	if err != nil {
+		return fmt.Errorf("invalid --mode: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Log the target before connecting so an error that swallows addr (per
+	// the gosec G706 fix below) still leaves a clear breadcrumb.
+	fmt.Fprintf(os.Stderr, "devseed: target redis=%s\n", addr)
+
+	client, err := redisclient.NewClient(addr, nil)
+	if err != nil {
+		// gosec/G706: addr is operator-supplied via --redis-addr / REDIS_ADDR,
+		// so we intentionally do NOT interpolate it into the error wrap.
+		// The pre-connect breadcrumb above already emitted addr.
+		return fmt.Errorf("connect redis: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if pingErr := client.Ping(ctx).Err(); pingErr != nil {
+		// gosec/G706: same rationale as the NewClient error path.
+		return fmt.Errorf("ping redis: %w", pingErr)
+	}
+
+	// 1. Seed characters first so they exist when the harness or handler
+	//    loads them via the character repo.
+	chars := []*toolkitchar.Data{
+		buildAliceRogueData(),
+		buildBobBarbarianData(),
+		buildWendyWizardData(),
+	}
+	for _, cd := range chars {
+		if writeErr := writeCharacter(ctx, client, cd); writeErr != nil {
+			return fmt.Errorf("write character %s: %w", cd.ID, writeErr)
+		}
+		fmt.Fprintf(os.Stderr, "seeded %s%s (%s level %d)\n", charKeyPrefix, cd.ID, cd.ClassID, cd.Level)
+	}
+
+	// 2. Seed encounter referencing the characters by EntityID.
+	encData, err := buildEncounterData(*encounterID, encMode)
+	if err != nil {
+		return fmt.Errorf("build encounter: %w", err)
+	}
+	if writeErr := writeEncounter(ctx, client, encData); writeErr != nil {
+		return fmt.Errorf("write encounter: %w", writeErr)
+	}
+
+	fmt.Fprintf(
+		os.Stderr,
+		"seeded %s%s: mode=%s players=%d monsters=%d ttl=%s\n",
+		encKeyPrefix, encData.ID, encMode, len(encData.Players), len(encData.Monsters), encTTL,
+	)
+	return nil
+}
+
+// parseMode normalizes the --mode flag against the SDK's EncounterMode enum.
+// Returns an error rather than a default so typos surface loudly.
+func parseMode(s string) (encountercore.EncounterMode, error) {
+	switch strings.ToLower(s) {
+	case modeTurnBased:
+		return encountercore.ModeTurnBased, nil
+	case modeFreeRoam:
+		return encountercore.ModeFreeRoam, nil
+	default:
+		return 0, fmt.Errorf("unknown mode %q (expected %q or %q)", s, modeTurnBased, modeFreeRoam)
+	}
+}
+
+// writeCharacter serializes the character via the same envelope shape the
+// production character repo uses (entities.Character{Data: ...}) and SETs
+// it under character:<id> with no TTL.
+func writeCharacter(ctx context.Context, client redisclient.Client, data *toolkitchar.Data) error {
+	if data == nil || data.ID == "" {
+		return errors.New("character data nil or missing ID")
+	}
+	// Match entities.Character envelope: {"data": {...}}. Appearance is
+	// omitted (the production character repo round-trips it as omitempty;
+	// the harness does not require it for combat-only verification).
+	envelope := map[string]any{"data": data}
+	blob, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := client.Set(ctx, charKeyPrefix+data.ID, blob, 0).Err(); err != nil {
+		return fmt.Errorf("redis SET: %w", err)
+	}
+	return nil
+}
+
+// writeEncounter SETs the encounter under enc:v2:<id> with the same TTL the
+// production v2 encounter repo uses (24h).
+func writeEncounter(ctx context.Context, client redisclient.Client, data *tkenc.Data) error {
+	if data == nil || data.ID == "" {
+		return errors.New("encounter data nil or missing ID")
+	}
+	blob, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := client.Set(ctx, encKeyPrefix+string(data.ID), blob, encTTL).Err(); err != nil {
+		return fmt.Errorf("redis SET: %w", err)
+	}
+	return nil
+}
+
+// buildAliceRogueData mirrors the level-2 rogue fixture used by
+// integration_sneak_attack_test.go (DEX 16 > STR 12, shortsword in main
+// hand, SneakAttack condition persisted). LoadFromData rebuilds the live
+// SneakAttack subscriber on every encounter rehydration; UsedThisTurn
+// round-trips through the JSON via rpg-toolkit#655.
+func buildAliceRogueData() *toolkitchar.Data {
+	sneakCond := conditions.NewSneakAttackCondition(conditions.SneakAttackInput{
+		CharacterID: string(entityAlice),
+		Level:       2, // 1d6 sneak die at level 2
+	})
+	sneakJSON, err := sneakCond.ToJSON()
+	if err != nil {
+		// Constant inputs — a marshal failure here would be a toolkit bug.
+		panic(fmt.Errorf("alice sneak attack ToJSON: %w", err))
+	}
+
+	now := time.Now().UTC()
+	return &toolkitchar.Data{
+		ID:               string(entityAlice),
+		PlayerID:         string(playerAlice),
+		Name:             "Alice the Rogue",
+		Level:            2,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Rogue,
+		HitPoints:        16,
+		MaxHitPoints:     16,
+		ArmorClass:       14,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12, // +1
+			abilities.DEX: 16, // +3 — finesse weapons use DEX
+			abilities.CON: 14,
+			abilities.INT: 12,
+			abilities.WIS: 10,
+			abilities.CHA: 10,
+		},
+		EquipmentSlots: toolkitchar.EquipmentSlots{
+			toolkitchar.SlotMainHand: "shortsword",
+		},
+		Inventory: []toolkitchar.InventoryItemData{
+			{Type: "weapon", ID: "shortsword", Quantity: 1},
+		},
+		Conditions: []json.RawMessage{sneakJSON},
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+// buildBobBarbarianData builds a level-1 barbarian with the Rage feature
+// persisted (so the API's Activate flow can call it) and a RageCharges
+// resource sized for level 1 (2 uses, recovers on long rest). Rage is NOT
+// pre-applied — bob starts not-raging; the player activates Rage as a
+// bonus action.
+//
+// applyReactionConditions (rpg-api side) Apply()s OpportunityAttack at
+// LoadFromData time for every melee combatant; default readiness is ON
+// (seeded by the encounter SDK's AddPlayer for combatants with DamageDice).
+func buildBobBarbarianData() *toolkitchar.Data {
+	now := time.Now().UTC()
+	rageFeatureJSON := json.RawMessage(fmt.Sprintf(`{
+		"ref": %q,
+		"id": "rage",
+		"name": "Rage",
+		"level": 1
+	}`, refs.Features.Rage()))
+
+	return &toolkitchar.Data{
+		ID:               string(entityBob),
+		PlayerID:         string(playerBob),
+		Name:             "Bob the Barbarian",
+		Level:            1,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Barbarian,
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       14, // Unarmored Defense: 10 + DEX(+1) + CON(+3)
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, // +3 — barbarian primary
+			abilities.DEX: 13, // +1
+			abilities.CON: 16, // +3
+			abilities.INT: 8,
+			abilities.WIS: 12,
+			abilities.CHA: 10,
+		},
+		EquipmentSlots: toolkitchar.EquipmentSlots{
+			toolkitchar.SlotMainHand: "greataxe", // two-handed; off hand stays empty
+		},
+		Inventory: []toolkitchar.InventoryItemData{
+			{Type: "weapon", ID: "greataxe", Quantity: 1},
+		},
+		Features: []json.RawMessage{rageFeatureJSON},
+		Resources: map[coreResources.ResourceKey]toolkitchar.RecoverableResourceData{
+			// Level 1 barbarian: 2 rage uses per long rest.
+			dnd5eResources.RageCharges: {
+				Current:   2,
+				Maximum:   2,
+				ResetType: coreResources.ResetLongRest,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// buildWendyWizardData builds a level-1 wizard with 1st-level spell slots
+// so applyReactionConditions.hasFirstLevelSpellSlot returns true and Shield
+// gets Apply()'d at LoadFromData time. Mirrors the wendy fixture in
+// integration_player_shield_test.go.
+//
+// AC 12 (mage armor not active) keeps Shield's reactive band easy to hit
+// in MCP playtest scenarios: any goblin attack roll in [12, 16] would be
+// blocked if Shield were ready.
+//
+// SpellSlots survives Get→LoadFromData→ToData thanks to rpg-toolkit#660
+// (landed in v0.58.1). Pre-fix, this field would silently drop on
+// rehydration and Shield never Apply()'d.
+func buildWendyWizardData() *toolkitchar.Data {
+	now := time.Now().UTC()
+	return &toolkitchar.Data{
+		ID:               string(entityWendy),
+		PlayerID:         string(playerWendy),
+		Name:             "Wendy the Wizard",
+		Level:            1,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Wizard,
+		HitPoints:        8,
+		MaxHitPoints:     8,
+		ArmorClass:       12,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 8,
+			abilities.DEX: 14, // +2
+			abilities.CON: 12,
+			abilities.INT: 16, // +3 — wizard primary
+			abilities.WIS: 10,
+			abilities.CHA: 10,
+		},
+		SpellSlots: map[int]toolkitchar.SpellSlotData{
+			1: {Max: 2, Used: 0},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// buildEncounterData seeds the encounter with all three players + the
+// goblin, then flips it into the requested mode. Positions match the
+// rpg-dnd5e-web PlaytestHarness SEEDED_FALLBACK so the harness renders
+// the same scene whether or not its initial Subscribe has flushed.
+//
+// The encounter SDK is constructed with a fresh in-memory broker because
+// devseed never publishes events; the broker is only used by encounter
+// methods that emit (AddPlayer, SetMode). The persisted Data is what
+// matters — when rpg-api LoadFromData()'s the encounter later, it builds
+// its own broker.
+func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*tkenc.Data, error) {
+	transport := tkenc.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := tkenc.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+
+	enc := tkenc.New(encountercore.EncounterID(encounterID), broker)
+
+	// alice (rogue) — finesse, DEX +3, shortsword 1d6+3. Adjacent to bob so
+	// bob can be the sneak-eligibility ally check pivot.
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    playerAlice,
+		EntityID:    entityAlice,
+		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          16,
+		MaxHP:       16,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d6+3",
+		DamageType:  "piercing",
+	}); err != nil {
+		return nil, fmt.Errorf("add alice: %w", err)
+	}
+
+	// bob (barbarian) — greataxe 1d12+3. Placed adjacent to alice so the
+	// sneak-attack ally adjacency check triggers when alice attacks an
+	// enemy bob is adjacent to (via the encounter chain).
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    playerBob,
+		EntityID:    entityBob,
+		Position:    encountercore.Hex{Q: 1, R: -1, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  "slashing",
+	}); err != nil {
+		return nil, fmt.Errorf("add bob: %w", err)
+	}
+
+	// wendy (wizard) — placed back, fire bolt 1d10. DamageDice set so the
+	// SDK qualifies her as a combatant for TakeAction; AttackBonus uses
+	// INT mod (+3) + proficiency (+2).
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    playerWendy,
+		EntityID:    entityWendy,
+		Position:    encountercore.Hex{Q: -1, R: 1, S: 0},
+		SightRange:  10,
+		HP:          8,
+		MaxHP:       8,
+		AC:          12,
+		AttackBonus: 5,
+		DamageDice:  "1d10",
+		DamageType:  "fire",
+	}); err != nil {
+		return nil, fmt.Errorf("add wendy: %w", err)
+	}
+
+	// goblin: built via monster.NewGoblin so AbilityScores, actions, and
+	// speed are SRD-canonical. DataJSON enables Dnd5eCombatResolver's
+	// rehydration path (vs the AttackBonus/DamageDice snapshot fallback).
+	goblin := monster.NewGoblin(string(entityGoblin))
+	goblinData := goblin.ToData()
+	goblinDataJSON, err := json.Marshal(goblinData)
+	if err != nil {
+		return nil, fmt.Errorf("marshal goblin data: %w", err)
+	}
+
+	if err := enc.AddMonster(tkenc.MonsterInput{
+		ID:          entityGoblin,
+		Position:    encountercore.Hex{Q: 3, R: -1, S: -2},
+		HP:          goblinData.HitPoints,
+		MaxHP:       goblinData.MaxHitPoints,
+		AC:          goblinData.ArmorClass,
+		Speed:       6, // 30ft / 5ft per hex
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, // matches goblin's NewScimitarAction
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+		DataJSON:    goblinDataJSON,
+	}); err != nil {
+		return nil, fmt.Errorf("add goblin: %w", err)
+	}
+
+	// SetMode is a no-op for FreeRoam-from-fresh-create (the SDK's NewData
+	// already defaults to FreeRoam); only call it for TurnBased so the SDK
+	// rolls initiative and seeds ActiveIdx/Round.
+	if mode == encountercore.ModeTurnBased {
+		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
+			return nil, fmt.Errorf("set mode turn_based: %w", err)
+		}
+	}
+
+	return enc.ToData(), nil
+}

--- a/docs/architecture/components/devseed.md
+++ b/docs/architecture/components/devseed.md
@@ -1,0 +1,99 @@
+---
+name: devseed
+description: CLI that seeds Redis with playable characters + a turn-based encounter for the playtest harness
+updated: 2026-05-18
+confidence: high — verified by running against local Redis and round-tripping through character.LoadFromData
+---
+
+# devseed
+
+`cmd/devseed` is a small CLI that writes a ready-to-play v2 encounter plus the three canonical playtest characters (alice-rogue, bob-barbarian, wendy-wizard) and a goblin directly into Redis. It exists so the rpg-dnd5e-web playtest harness and MCP-driven verification flows can hit a populated game state without manually walking through `CreateDraft → UpdateRace → ... → FinalizeDraft → CreateEncounter` every session.
+
+## Why it exists
+
+The Wave 2.11d reaction-flow work requires verifying behaviors that depend on specific character shapes:
+- Alice firing **SneakAttack** on a finesse-weapon hit with an adjacent ally.
+- Bob's **Rage** feature being available to activate (level-1 barbarian, 2 uses).
+- Wendy's **Shield** reaction being Apply()'d at character load (gated on a 1st-level spell slot).
+- The encounter being in **TURN_BASED** mode so the harness can exercise `TakeAction` / `EndTurn` / `SubmitCheck` flows.
+
+Seeding raw `PlayerData` (the previous version of this tool) was enough for plumbing checks but couldn't verify any of the actual reaction behaviors — the rpg-api handler loads a real `*character.Data` from the character repo, and without a properly-shaped character there's nothing to fire.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `cmd/devseed/main.go` | Single-file CLI: flag parsing, Redis client, character + encounter builders |
+
+## What it writes
+
+| Key | Shape | TTL |
+|---|---|---|
+| `character:char-alice` | `entities.Character{Data: *toolkitchar.Data}` — level-2 rogue, shortsword, SneakAttack condition persisted | none |
+| `character:char-bob` | level-1 barbarian, greataxe, Rage feature + RageCharges resource (2/2, long-rest reset) | none |
+| `character:char-wendy` | level-1 wizard, SpellSlots[1] = {Max:2,Used:0} (Shield-eligible) | none |
+| `enc:v2:<encounter-id>` | `*tkenc.Data` with 3 players + 1 goblin, mode=TURN_BASED by default | 24h |
+
+Key prefixes and TTLs match what the production repositories use (`internal/repositories/character/redis.go`, `internal/repositories/encounters/v2/redis.go`). The character envelope mirrors `entities.Character` — the `data` field wraps the toolkit's `*character.Data` directly so the character repo's `Get` can `json.Unmarshal` it without changes.
+
+## How conditions get applied at load
+
+devseed is intentionally narrow about what it persists vs what gets reattached at load time. The split mirrors what `applyReactionConditions` (in `internal/handlers/dnd5e/v2/encounter/reaction_conditions.go`) does on every encounter rehydration:
+
+| Reaction | Persisted in character JSON? | Apply()'d at load? |
+|---|---|---|
+| **SneakAttack** (alice) | yes — in `Conditions: []json.RawMessage{...}` | by `character.LoadFromData` for every condition in the blob |
+| **OpportunityAttack** (alice, bob, wendy) | no | by `applyReactionConditions` for every melee combatant |
+| **Shield** (wendy) | no | by `applyReactionConditions` when `hasFirstLevelSpellSlot(char) == true` |
+| **Rage** (bob) | as a feature, not a condition — Rage isn't reactive, it's activatable | not auto-Apply()'d; player activates via the Rage feature, which then creates the RagingCondition |
+
+This split is the same one the integration tests (`integration_sneak_attack_test.go`, `integration_player_shield_test.go`) use to build their fixtures — devseed is essentially "the integration fixture, but written to Redis."
+
+The split survives Wave 2.11d's `LoadFromData` round-trip fix (rpg-toolkit#660 / dnd5e v0.58.1): SpellSlots, ClassResources, and the rest of the runtime state now round-trip correctly through Get → LoadFromData → ToData. Before that fix, wendy's spell slot would silently drop on rehydration and Shield would never Apply.
+
+## How to invoke
+
+```bash
+# Default: localhost:6379, encounter-id=dev-encounter, mode=turn_based
+go run ./cmd/devseed
+
+# Custom encounter id (matches the harness URL ?encounterId=…)
+go run ./cmd/devseed --encounter-id=my-encounter
+
+# Free-roam mode for non-combat verification (no initiative)
+go run ./cmd/devseed --mode=free_roam
+
+# Custom Redis target
+REDIS_ADDR=redis.example.com:6379 go run ./cmd/devseed
+# or
+go run ./cmd/devseed --redis-addr=redis.example.com:6379
+```
+
+Stderr breadcrumbs report each key written. Stdout is empty — this is not a `redis-cli SET`-pipeable shape any more; devseed connects to Redis directly.
+
+## Verification
+
+After running:
+
+```bash
+redis-cli --scan --pattern 'character:char-*'
+# → character:char-alice, character:char-bob, character:char-wendy
+
+redis-cli GET 'enc:v2:dev-encounter' | python3 -c \
+  'import json,sys; d=json.load(sys.stdin); print("mode:", d["mode"]); print("players:", list(d["players"]))'
+# → mode: 2  (1 = FREE_ROAM, 2 = TURN_BASED)
+#   players: ['alice', 'bob', 'wendy']
+```
+
+## What it deliberately does NOT do
+
+- **No appearance field.** The harness verification target is combat behavior, not rendering. The character repo's `entities.Character.Appearance` is `omitempty`; we leave it nil.
+- **No spell list.** Wendy has spell slots but no `PreparedSpells` / `SpellsKnown` field — Shield Apply() gates on the slot count heuristic in `applyReactionConditions.hasFirstLevelSpellSlot`, not on a real "spell is prepared" check. A future wave can tighten this; devseed mirrors what the runtime gate actually inspects.
+- **No CreateEncounter RPC.** devseed writes Redis keys directly to bypass auth, draft state, dungeon generation, and the full create flow. This is a developer / harness tool, never a production code path.
+- **No goblin variety.** Always one goblin via `monster.NewGoblin` (SRD stats, AC 15, HP 7, scimitar 1d6+2). Add monster variants here if a future scenario needs them; do not invent ad-hoc monster shapes (use `monster.New` or one of the named constructors).
+
+## Known gaps
+
+- **Single encounter, single goblin.** No way to seed multi-room dungeons or multi-encounter scenarios from this tool. If the playtest goal grows past "one room, one fight", extend or supersede.
+- **Character resource recovery state.** Bob's RageCharges write through as `Maximum=2, Current=2`. There's no `Used=N` knob for testing "what happens when bob has only 1 rage left" — would need to be added if a Wave 2.11e+ scenario asks for it.
+- **No reseed-idempotency guard.** Re-running `devseed` against the same Redis overwrites the keys. Acceptable for a dev tool; do not point at production Redis (the connection target is intentionally explicit via `--redis-addr` / `REDIS_ADDR`).

--- a/docs/architecture/components/devseed.md
+++ b/docs/architecture/components/devseed.md
@@ -43,7 +43,7 @@ devseed is intentionally narrow about what it persists vs what gets reattached a
 | Reaction | Persisted in character JSON? | Apply()'d at load? |
 |---|---|---|
 | **SneakAttack** (alice) | yes — in `Conditions: []json.RawMessage{...}` | by `character.LoadFromData` for every condition in the blob |
-| **OpportunityAttack** (alice, bob, wendy) | no | by `applyReactionConditions` for every melee combatant |
+| **OpportunityAttack** (every character) | no | by `applyReactionConditions` on EVERY character unconditionally; the OA predicate (weapon reach + `gamectx.IsReactionReady`) gates whether it actually publishes a trigger, so it's a silent no-op for characters with no melee threat range |
 | **Shield** (wendy) | no | by `applyReactionConditions` when `hasFirstLevelSpellSlot(char) == true` |
 | **Rage** (bob) | as a feature, not a condition — Rage isn't reactive, it's activatable | not auto-Apply()'d; player activates via the Rage feature, which then creates the RagingCondition |
 


### PR DESCRIPTION
## Summary

`cmd/devseed` previously wrote a bare `PlayerData` encounter — enough for plumbing checks but not for behavioral verification of Wave 2.11d's reaction surface (Shield, OA, SneakAttack). Replace it with a CLI that seeds three fully-shaped characters via the production character-repo schema plus a TURN_BASED encounter referencing them.

This unblocks director-led MCP playtest verification: load the harness against `dev-encounter`, drive alice/bob/wendy through real attacks, observe Shield prompts and SneakAttack damage fire end-to-end.

## What it writes

- `character:char-alice` — level-2 rogue, shortsword (finesse), **SneakAttack** condition persisted in `Conditions` JSON
- `character:char-bob` — level-1 barbarian, greataxe; **Rage** feature + RageCharges resource (2/2, long-rest)
- `character:char-wendy` — level-1 wizard, `SpellSlots[1] = {Max:2, Used:0}` → **Shield** Apply()'d via `applyReactionConditions.hasFirstLevelSpellSlot`
- `enc:v2:<encounter-id>` — 3 players + 1 goblin (`monster.NewGoblin` DataJSON), mode=TURN_BASED by default

Key prefixes and TTLs match `internal/repositories/character/redis.go` and `internal/repositories/encounters/v2/redis.go`.

## How conditions get applied at load

| Reaction | Persisted in character JSON? | Apply()'d at load? |
|---|---|---|
| SneakAttack (alice) | yes — `Conditions: []json.RawMessage{...}` | by `character.LoadFromData` |
| OpportunityAttack (alice, bob, wendy) | no | by `applyReactionConditions` (every melee combatant) |
| Shield (wendy) | no | by `applyReactionConditions` when spell slot present |
| Rage (bob) | as a feature, not a condition (Rage is activatable, not reactive) | not auto-Apply()'d; player activates |

This split mirrors the integration test fixtures (`integration_sneak_attack_test.go`, `integration_player_shield_test.go`).

## Verification (run locally)

```
go run ./cmd/devseed
redis-cli --scan --pattern 'character:char-*'
# → character:char-alice, character:char-bob, character:char-wendy
redis-cli GET 'enc:v2:dev-encounter' | python3 -c 'import json,sys; d=json.load(sys.stdin); print("mode:", d["mode"]); print("players:", list(d["players"]))'
# → mode: 2, players: ['alice', 'bob', 'wendy']
```

Also verified that each character round-trips through `character.LoadFromData → ToData` with `SneakAttack`/`Rage`/`SpellSlots` intact (relies on rpg-toolkit#660 / dnd5e v0.58.1 for the SpellSlots fix).

## Docs

Adds `docs/architecture/components/devseed.md` per the platform-docs close-the-loop discipline.

## Test plan

- [ ] CI green (test workflow runs `go test -race`; no devseed tests yet — pure plumbing tool)
- [ ] Director-led MCP playtest verification: seed loads in `/playtest`, alice attack flow fires SneakAttack damage on first eligible hit per turn, wendy with `SetReactionReady(Shield, true)` sees a prompt on incoming goblin attack
- [ ] `--mode=free_roam` flag works for non-combat verification

## Out of scope

- No CreateEncounter RPC path (devseed bypasses auth + draft flow by design)
- No multi-room dungeon or multi-encounter scenarios
- No per-character reseed idempotency guard (re-running overwrites; dev tool only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)