### PR TITLE
feat(devseed): --fixture flag + wave-1-rogue fixture; L1 rogue SA integration test

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -1,14 +1,14 @@
-// devseed populates Redis with a ready-to-play v2 encounter plus the three
-// canonical playtest characters (alice-rogue, bob-barbarian, wendy-wizard)
-// and a goblin, so the rpg-dnd5e-web playtest harness can verify reaction
-// flows end-to-end without going through CreateDraft/FinalizeDraft.
+// devseed populates Redis with a ready-to-play v2 encounter plus the
+// canonical playtest characters and a goblin, so the rpg-dnd5e-web playtest
+// harness can verify reaction flows end-to-end without going through
+// CreateDraft/FinalizeDraft.
 //
 // What it writes
 //
-//	character:char-alice    — level-2 rogue with SneakAttack condition pre-applied
+//	character:char-alice    — rogue with SneakAttack condition pre-applied
 //	character:char-bob      — level-1 barbarian with Rage feature + RageCharges resource
-//	character:char-wendy    — level-1 wizard with 1st-level spell slots (Shield-eligible)
-//	enc:v2:<encounter-id>   — encounter referencing all three by EntityID,
+//	character:char-wendy    — level-1 wizard with 1st-level spell slots (Shield-eligible, default fixture only)
+//	enc:v2:<encounter-id>   — encounter referencing characters by EntityID,
 //	                          plus a single goblin (monster.NewGoblin DataJSON)
 //
 // The character keys use the same schema as the production character repo
@@ -18,13 +18,10 @@
 //
 // Wave 2.11d wires conditions at load:
 //   - applyReactionConditions Apply()s OpportunityAttack on EVERY character
-//     unconditionally (alice, bob, wendy) — the OA predicate gates whether
-//     it actually publishes a trigger event (e.g. by checking weapon reach
-//     and gamectx.IsReactionReady), so it's a silent no-op for characters
-//     with no melee threat range. Shield is Apply()'d only when
-//     hasFirstLevelSpellSlot returns true (wendy). Default readiness: OA on
-//     (seeded by the encounter SDK's AddPlayer for combatants with
-//     DamageDice), Shield off.
+//     unconditionally — the OA predicate gates whether it actually publishes
+//     a trigger event. Shield is Apply()'d only when hasFirstLevelSpellSlot
+//     returns true (wendy). Default readiness: OA on (seeded by the encounter
+//     SDK's AddPlayer for combatants with DamageDice), Shield off.
 //   - SneakAttack is persisted in alice's Conditions JSON so LoadFromData
 //     re-Apply()s it on every rehydration (the once-per-turn gate persists
 //     via SneakAttackData.UsedThisTurn → rpg-toolkit#655).
@@ -35,6 +32,9 @@
 //
 //	# Seed against local Redis with default encounter id and TURN_BASED mode
 //	go run ./cmd/devseed
+//
+//	# Seed the wave-1-rogue fixture (L1 alice, L1 bob, goblin — no wendy)
+//	go run ./cmd/devseed --fixture=wave-1-rogue
 //
 //	# Override encounter id (matches the harness URL ?encounterId=…)
 //	go run ./cmd/devseed --encounter-id=dev-encounter
@@ -99,6 +99,17 @@ const (
 
 	modeTurnBased = "turn_based"
 	modeFreeRoam  = "free_roam"
+
+	fixtureDefault    = ""
+	fixtureWave1Rogue = "wave-1-rogue"
+
+	weaponShortsword    = "shortsword"
+	weaponGreataxe      = "greataxe"
+	inventoryTypeWeapon = "weapon"
+
+	damageTypePiercing = "piercing"
+	damageTypeSlashing = "slashing"
+	damageTypeFire     = "fire"
 )
 
 var (
@@ -129,6 +140,7 @@ func run() error {
 		redisAddr   = flag.String("redis-addr", "", "Redis address (default: $REDIS_ADDR or "+defaultRedisAddr+")")
 		encounterID = flag.String("encounter-id", defaultEncounterID, "Encounter ID to seed under enc:v2:<id>")
 		mode        = flag.String("mode", modeTurnBased, "Encounter mode: turn_based or free_roam")
+		fixture     = flag.String("fixture", fixtureDefault, "Named fixture to seed (e.g. wave-1-rogue). Default seeds alice L2 + bob + wendy.")
 	)
 	flag.Parse()
 
@@ -150,7 +162,7 @@ func run() error {
 
 	// Log the target before connecting so an error that swallows addr (per
 	// the gosec G706 fix below) still leaves a clear breadcrumb.
-	fmt.Fprintf(os.Stderr, "devseed: target redis=%s\n", addr)
+	fmt.Fprintf(os.Stderr, "devseed: target redis=%s fixture=%q\n", addr, *fixture)
 
 	client, err := redisclient.NewClient(addr, nil)
 	if err != nil {
@@ -166,13 +178,34 @@ func run() error {
 		return fmt.Errorf("ping redis: %w", pingErr)
 	}
 
+	var chars []*toolkitchar.Data
+	var encData *tkenc.Data
+
+	switch *fixture {
+	case fixtureWave1Rogue:
+		chars = []*toolkitchar.Data{
+			buildAliceRogueL1Data(),
+			buildBobBarbarianData(),
+		}
+		encData, err = buildWave1RogueEncounterData(*encounterID, encMode)
+		if err != nil {
+			return fmt.Errorf("build encounter: %w", err)
+		}
+	default:
+		// Default: alice L2 + bob + wendy (original behavior).
+		chars = []*toolkitchar.Data{
+			buildAliceRogueData(),
+			buildBobBarbarianData(),
+			buildWendyWizardData(),
+		}
+		encData, err = buildEncounterData(*encounterID, encMode)
+		if err != nil {
+			return fmt.Errorf("build encounter: %w", err)
+		}
+	}
+
 	// 1. Seed characters first so they exist when the harness or handler
 	//    loads them via the character repo.
-	chars := []*toolkitchar.Data{
-		buildAliceRogueData(),
-		buildBobBarbarianData(),
-		buildWendyWizardData(),
-	}
 	for _, cd := range chars {
 		if writeErr := writeCharacter(ctx, client, cd); writeErr != nil {
 			return fmt.Errorf("write character %s: %w", cd.ID, writeErr)
@@ -181,10 +214,6 @@ func run() error {
 	}
 
 	// 2. Seed encounter referencing the characters by EntityID.
-	encData, err := buildEncounterData(*encounterID, encMode)
-	if err != nil {
-		return fmt.Errorf("build encounter: %w", err)
-	}
 	if writeErr := writeEncounter(ctx, client, encData); writeErr != nil {
 		return fmt.Errorf("write encounter: %w", writeErr)
 	}
@@ -300,10 +329,10 @@ func buildAliceRogueData() *toolkitchar.Data {
 			abilities.CHA: 10,
 		},
 		EquipmentSlots: toolkitchar.EquipmentSlots{
-			toolkitchar.SlotMainHand: "shortsword",
+			toolkitchar.SlotMainHand: weaponShortsword,
 		},
 		Inventory: []toolkitchar.InventoryItemData{
-			{Type: "weapon", ID: "shortsword", Quantity: 1},
+			{Type: inventoryTypeWeapon, ID: weaponShortsword, Quantity: 1},
 		},
 		Conditions: []json.RawMessage{sneakJSON},
 		CreatedAt:  now,
@@ -348,10 +377,10 @@ func buildBobBarbarianData() *toolkitchar.Data {
 			abilities.CHA: 10,
 		},
 		EquipmentSlots: toolkitchar.EquipmentSlots{
-			toolkitchar.SlotMainHand: "greataxe", // two-handed; off hand stays empty
+			toolkitchar.SlotMainHand: weaponGreataxe, // two-handed; off hand stays empty
 		},
 		Inventory: []toolkitchar.InventoryItemData{
-			{Type: "weapon", ID: "greataxe", Quantity: 1},
+			{Type: inventoryTypeWeapon, ID: weaponGreataxe, Quantity: 1},
 		},
 		Features: []json.RawMessage{rageFeatureJSON},
 		Resources: map[coreResources.ResourceKey]toolkitchar.RecoverableResourceData{
@@ -437,7 +466,7 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 		AC:          14,
 		AttackBonus: 5,
 		DamageDice:  "1d6+3",
-		DamageType:  "piercing",
+		DamageType:  damageTypePiercing,
 	}); err != nil {
 		return nil, fmt.Errorf("add alice: %w", err)
 	}
@@ -455,7 +484,7 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 		AC:          14,
 		AttackBonus: 5,
 		DamageDice:  "1d12+3",
-		DamageType:  "slashing",
+		DamageType:  damageTypeSlashing,
 	}); err != nil {
 		return nil, fmt.Errorf("add bob: %w", err)
 	}
@@ -473,7 +502,7 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 		AC:          12,
 		AttackBonus: 5,
 		DamageDice:  "1d10",
-		DamageType:  "fire",
+		DamageType:  damageTypeFire,
 	}); err != nil {
 		return nil, fmt.Errorf("add wendy: %w", err)
 	}
@@ -498,7 +527,7 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, // matches goblin's NewScimitarAction
 		DamageDice:  "1d6+2",
-		DamageType:  "slashing",
+		DamageType:  damageTypeSlashing,
 		DataJSON:    goblinDataJSON,
 	}); err != nil {
 		return nil, fmt.Errorf("add goblin: %w", err)
@@ -507,6 +536,126 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 	// SetMode is a no-op for FreeRoam-from-fresh-create (the SDK's NewData
 	// already defaults to FreeRoam); only call it for TurnBased so the SDK
 	// rolls initiative and seeds ActiveIdx/Round.
+	if mode == encountercore.ModeTurnBased {
+		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
+			return nil, fmt.Errorf("set mode turn_based: %w", err)
+		}
+	}
+
+	return enc.ToData(), nil
+}
+
+// buildAliceRogueL1Data is the wave-1-rogue variant of buildAliceRogueData:
+// level 1, HP 10. AbilityScores and equipment are identical to the L2 version;
+// only Level, HitPoints/MaxHitPoints, and the SneakAttackInput.Level differ
+// (L1 = 1d6, same as L2 per (level+1)/2).
+func buildAliceRogueL1Data() *toolkitchar.Data {
+	sneakCond := conditions.NewSneakAttackCondition(conditions.SneakAttackInput{
+		CharacterID: string(entityAlice),
+		Level:       1,
+	})
+	sneakJSON, err := sneakCond.ToJSON()
+	if err != nil {
+		panic(fmt.Errorf("alice L1 sneak attack ToJSON: %w", err))
+	}
+
+	now := time.Now().UTC()
+	return &toolkitchar.Data{
+		ID:               string(entityAlice),
+		PlayerID:         string(playerAlice),
+		Name:             "Alice the Rogue",
+		Level:            1,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Rogue,
+		HitPoints:        10,
+		MaxHitPoints:     10,
+		ArmorClass:       14,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12, // +1
+			abilities.DEX: 16, // +3 — finesse weapons use DEX
+			abilities.CON: 12,
+			abilities.INT: 12,
+			abilities.WIS: 10,
+			abilities.CHA: 10,
+		},
+		EquipmentSlots: toolkitchar.EquipmentSlots{
+			toolkitchar.SlotMainHand: weaponShortsword,
+		},
+		Inventory: []toolkitchar.InventoryItemData{
+			{Type: inventoryTypeWeapon, ID: weaponShortsword, Quantity: 1},
+		},
+		Conditions: []json.RawMessage{sneakJSON},
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+// buildWave1RogueEncounterData seeds the wave-1-rogue encounter: alice + bob +
+// goblin only (no wendy). Positions match the default fixture so the harness
+// SEEDED_FALLBACK still aligns.
+func buildWave1RogueEncounterData(encounterID string, mode encountercore.EncounterMode) (*tkenc.Data, error) {
+	transport := tkenc.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := tkenc.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+
+	enc := tkenc.New(encountercore.EncounterID(encounterID), broker)
+
+	// alice L1 rogue — DEX +3, shortsword 1d6+3.
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    playerAlice,
+		EntityID:    entityAlice,
+		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          10,
+		MaxHP:       10,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d6+3",
+		DamageType:  damageTypePiercing,
+	}); err != nil {
+		return nil, fmt.Errorf("add alice: %w", err)
+	}
+
+	// bob (barbarian) — adjacent to alice so ally-adjacency sneak attack triggers.
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    playerBob,
+		EntityID:    entityBob,
+		Position:    encountercore.Hex{Q: 1, R: -1, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  damageTypeSlashing,
+	}); err != nil {
+		return nil, fmt.Errorf("add bob: %w", err)
+	}
+
+	goblin := monster.NewGoblin(string(entityGoblin))
+	goblinData := goblin.ToData()
+	goblinDataJSON, err := json.Marshal(goblinData)
+	if err != nil {
+		return nil, fmt.Errorf("marshal goblin data: %w", err)
+	}
+
+	if err := enc.AddMonster(tkenc.MonsterInput{
+		ID:          entityGoblin,
+		Position:    encountercore.Hex{Q: 3, R: -1, S: -2},
+		HP:          goblinData.HitPoints,
+		MaxHP:       goblinData.MaxHitPoints,
+		AC:          goblinData.ArmorClass,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  damageTypeSlashing,
+		DataJSON:    goblinDataJSON,
+	}); err != nil {
+		return nil, fmt.Errorf("add goblin: %w", err)
+	}
+
 	if mode == encountercore.ModeTurnBased {
 		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
 			return nil, fmt.Errorf("set mode turn_based: %w", err)

--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -620,11 +620,11 @@ func buildWave1RogueEncounterData(encounterID string, mode encountercore.Encount
 		return nil, fmt.Errorf("add alice: %w", err)
 	}
 
-	// bob (barbarian) — adjacent to alice so ally-adjacency sneak attack triggers.
+	// bob (barbarian) — adjacent to goblin so ally-adjacency sneak attack triggers.
 	if err := enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID:    playerBob,
 		EntityID:    entityBob,
-		Position:    encountercore.Hex{Q: 1, R: -1, S: 0},
+		Position:    encountercore.Hex{Q: 2, R: -1, S: -1},
 		SightRange:  10,
 		HP:          14,
 		MaxHP:       14,

--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -191,7 +191,7 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("build encounter: %w", err)
 		}
-	default:
+	case fixtureDefault:
 		// Default: alice L2 + bob + wendy (original behavior).
 		chars = []*toolkitchar.Data{
 			buildAliceRogueData(),
@@ -202,6 +202,9 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("build encounter: %w", err)
 		}
+	default:
+		return fmt.Errorf("unknown fixture %q: supported values are %q and %q",
+			*fixture, fixtureDefault, fixtureWave1Rogue)
 	}
 
 	// 1. Seed characters first so they exist when the harness or handler
@@ -571,7 +574,7 @@ func buildAliceRogueL1Data() *toolkitchar.Data {
 		MaxHitPoints:     10,
 		ArmorClass:       14,
 		AbilityScores: shared.AbilityScores{
-			abilities.STR: 12, // +1
+			abilities.STR: 12,
 			abilities.DEX: 16, // +3 — finesse weapons use DEX
 			abilities.CON: 12,
 			abilities.INT: 12,

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-25
+updated: 2026-05-27
 confidence: high — Wave 2.11e entries verified against shipped code and passing integration tests
 ---
 
@@ -11,9 +11,12 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
-**Chapter 2 Wave 1 (rogue) — devseed fixture landed (2026-05-27)** — `--fixture=wave-1-rogue`
-seeds alice (L1 rogue, 1d6 SneakAttack, HP 10) + bob (L1 barbarian) + goblin into
-`enc:v2:dev-encounter`. No wendy in this fixture. Closes issue #551.
+**Chapter 2 Wave 1 (rogue) — devseed fixture + L1 SA integration test (2026-05-27)** —
+`--fixture=wave-1-rogue` seeds alice (L1 rogue, 1d6 SneakAttack, HP 10) + bob (L1 barbarian) +
+goblin into `enc:v2:dev-encounter` (closes #551). `TestSneakAttackIntegrationL1Suite` proves the
+full SA chain (gamectx wiring, once-per-turn enforcement, turn-end reset) end-to-end via the real
+`TakeAction` RPC for L1 alice with ally-adjacent bob — same 5-test scenario as the existing L2 suite,
+parameterized by `rogueLevel` (closes #552).
 
 **Wave 2.11e rpg-api — PR open (2026-05-25)** — MovementResolver wiring: OA-class
 reactions end-to-end in both movement directions (player retreats past NPC → NPC OA;

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,10 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**Chapter 2 Wave 1 (rogue) — devseed fixture landed (2026-05-27)** — `--fixture=wave-1-rogue`
+seeds alice (L1 rogue, 1d6 SneakAttack, HP 10) + bob (L1 barbarian) + goblin into
+`enc:v2:dev-encounter`. No wendy in this fixture. Closes issue #551.
+
 **Wave 2.11e rpg-api — PR open (2026-05-25)** — MovementResolver wiring: OA-class
 reactions end-to-end in both movement directions (player retreats past NPC → NPC OA;
 NPC retreats past player → player OA) plus Disengage suppression. Pins

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -86,9 +86,7 @@ func (r fixedRoller) Roll(_ context.Context, size int) (int, error) {
 	if v < 1 {
 		v = 1
 	}
-	if v > size {
-		v = size
-	}
+	v = min(v, size)
 	return v, nil
 }
 
@@ -97,9 +95,7 @@ func (r fixedRoller) RollN(_ context.Context, count, size int) ([]int, error) {
 	if v < 1 {
 		v = 1
 	}
-	if v > size {
-		v = size
-	}
+	v = min(v, size)
 	result := make([]int, count)
 	for i := range result {
 		result[i] = v
@@ -551,7 +547,7 @@ func (s *SneakAttackIntegrationSuite) seedSneakEncounter() {
 // up alice or bob as targets, requiring additional mock setup). Bob's turns
 // are ended via the handler using bob's auth context.
 func (s *SneakAttackIntegrationSuite) advanceToAlice() {
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		data, err := s.repo.Get(context.Background(), sneakIntegEncID)
 		s.Require().NoError(err)
 		s.Require().NotEmpty(data.Initiative, "initiative must be rolled")

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -140,10 +140,12 @@ func (s *inMemoryCharStore) update(data *character.Data) {
 	s.chars[data.ID] = data
 }
 
-// SneakAttackIntegrationSuite tests the Wave 2.11c sign-off scenario:
-// encounter-scoped bus, gamectx wiring, and TurnEnd bridge.
+// SneakAttackIntegrationSuite tests the sign-off scenario for Sneak Attack across
+// rogue levels: encounter-scoped bus, gamectx wiring, and TurnEnd bridge.
+// rogueLevel controls the character level for alice (1 or 2); both yield 1d6 SA dice.
 type SneakAttackIntegrationSuite struct {
 	suite.Suite
+	rogueLevel   int
 	ctrl         *gomock.Controller
 	mockCharRepo *charactermock.MockRepository
 	charStore    *inMemoryCharStore
@@ -155,7 +157,14 @@ type SneakAttackIntegrationSuite struct {
 }
 
 func TestSneakAttackIntegrationSuite(t *testing.T) {
-	suite.Run(t, new(SneakAttackIntegrationSuite))
+	suite.Run(t, &SneakAttackIntegrationSuite{rogueLevel: 2})
+}
+
+// TestSneakAttackIntegrationL1Suite proves Sneak Attack works end-to-end for a
+// level-1 rogue (Chapter 2 Wave 1 #552). calculateSneakAttackDice(1) = 1d6,
+// same as L2, so all assertions are identical — only alice's Level and HP differ.
+func TestSneakAttackIntegrationL1Suite(t *testing.T) {
+	suite.Run(t, &SneakAttackIntegrationSuite{rogueLevel: 1})
 }
 
 func (s *SneakAttackIntegrationSuite) SetupTest() {
@@ -416,26 +425,38 @@ func (s *SneakAttackIntegrationSuite) goblinHP() int {
 	return md.HP
 }
 
-// buildAliceRogueData constructs a character.Data for alice — a level-2 rogue
-// with DEX 16 > STR 12 (so finesse weapons use DEX), a shortsword in the main
+// aliceHP returns the HP for alice based on s.rogueLevel.
+// L1: 10 (8 base + CON mod 2), L2+: 16 (8+5+CON mod 2+1).
+func (s *SneakAttackIntegrationSuite) aliceHP() int {
+	if s.rogueLevel == 1 {
+		return 10
+	}
+	return 16
+}
+
+// buildAliceRogueData constructs a character.Data for alice — a rogue with
+// DEX 16 > STR 12 (so finesse weapons use DEX), a shortsword in the main
 // hand slot, and the SneakAttack condition persisted in her Conditions blob.
+// Level and HP are driven by s.rogueLevel so L1 and L2 share this builder.
+// calculateSneakAttackDice(level) = (level+1)/2: L1 → 1d6, L2 → 1d6.
 func (s *SneakAttackIntegrationSuite) buildAliceRogueData() *character.Data {
-	// Build the SneakAttack condition JSON (level 2 rogue → 1d6 sneak attack).
 	sneakCond := conditions.NewSneakAttackCondition(conditions.SneakAttackInput{
 		CharacterID: sneakEntityAlice,
-		Level:       2, // 1d6 at level 2
+		Level:       s.rogueLevel,
 	})
 	sneakJSON, err := sneakCond.ToJSON()
 	s.Require().NoError(err, "marshal SneakAttack condition")
 
+	hp := s.aliceHP()
+
 	return &character.Data{
 		ID:               sneakEntityAlice,
 		Name:             "Alice the Rogue",
-		Level:            2,
+		Level:            s.rogueLevel,
 		ClassID:          "rogue",
 		ProficiencyBonus: 2,
-		HitPoints:        16,
-		MaxHitPoints:     16,
+		HitPoints:        hp,
+		MaxHitPoints:     hp,
 		ArmorClass:       14,
 		AbilityScores: shared.AbilityScores{
 			abilities.STR: 12, // +1 modifier
@@ -476,13 +497,14 @@ func (s *SneakAttackIntegrationSuite) buildAliceRogueData() *character.Data {
 func (s *SneakAttackIntegrationSuite) seedSneakEncounter() {
 	enc := tkenc.New(sneakIntegEncID, s.broker)
 
+	aliceHP := s.aliceHP()
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID:    encountercore.PlayerID(sneakPlayerAlice),
 		EntityID:    encountercore.EntityID(sneakEntityAlice),
 		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
 		SightRange:  10,
-		HP:          16,
-		MaxHP:       16,
+		HP:          aliceHP,
+		MaxHP:       aliceHP,
 		AC:          14,
 		AttackBonus: 5, // DEX +3 + proficiency +2
 		DamageDice:  "1d6+3",

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -421,8 +421,8 @@ func (s *SneakAttackIntegrationSuite) goblinHP() int {
 	return md.HP
 }
 
-// aliceHP returns the HP for alice based on s.rogueLevel.
-// L1: 10 (8 base + CON mod 2), L2+: 16 (8+5+CON mod 2+1).
+// aliceHP returns hardcoded HP for alice based on s.rogueLevel.
+// Values are test-fixture numbers, not strict 5e math.
 func (s *SneakAttackIntegrationSuite) aliceHP() int {
 	if s.rogueLevel == 1 {
 		return 10


### PR DESCRIPTION
## Summary

- Parameterizes `SneakAttackIntegrationSuite` with a `rogueLevel int` field so the same 5-test scenario runs for both L2 (Wave 2.11c) and L1 (this issue)
- Adds `TestSneakAttackIntegrationL1Suite` driver alongside the existing `TestSneakAttackIntegrationSuite` — 10 tests total, all green
- `calculateSneakAttackDice(1) = 1d6 == calculateSneakAttackDice(2)`, so HP-delta assertions are identical across levels; only alice's `Level` (2→1) and `HP` (16→10) differ
- Drive-by lint cleanup: `min(v, size)` builtin replaces `if/assign` in `fixedRoller`; `for range 20` replaces C-style loop (Go 1.22+)

## Test plan

- [x] `go test ./internal/handlers/dnd5e/v2/encounter/ -run SneakAttack -v` — 10/10 pass (L2 suite + L1 suite)
- [x] No new lint issues in modified file
- [x] Pre-existing lint failures in other packages are unrelated to this change

Closes #552. Part of Wave 1 #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)