### PR TITLE
feat(encounter/v2): populate damage_breakdown in EntityDamaged events (#556)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,9 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// LOCAL REPLACES — strip before opening PRs; see feedback_local_override_until_unit_done
+replace (
+	github.com/KirkDiggler/rpg-api-protos/gen/go => /home/kirk/personal/rpg-api-protos/gen/go
+	github.com/KirkDiggler/rpg-toolkit/encounter => /home/kirk/personal/rpg-toolkit/encounter
+)

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/KirkDiggler/rpg-api
 go 1.25.3
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260518182430-cdd9e0e3945d
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260527223626-3a5e2bc47447
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.14.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.15.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.59.0
@@ -88,10 +88,4 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-// LOCAL REPLACES — strip before opening PRs; see feedback_local_override_until_unit_done
-replace (
-	github.com/KirkDiggler/rpg-api-protos/gen/go => /home/kirk/personal/rpg-api-protos/gen/go
-	github.com/KirkDiggler/rpg-toolkit/encounter => /home/kirk/personal/rpg-toolkit/encounter
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,14 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260527223626-3a5e2bc47447 h1:mUAa1bQ/5qdLbsvzsf+cWaxLJtLbn6g7/+ADFyg1oJY=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260527223626-3a5e2bc47447/go.mod h1:z4Ka1UqEslbSHcldcYvysxeer8uosHun7Dz9Iji2PFw=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.15.0 h1:qnU2ybqY4P3fGhAIbZZZptkVu95g+4uw059ahiYTxwo=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.15.0/go.mod h1:oeo/6WNu7Z8+lQ3vGEC/qvZilTbmCUabglbuEiL0tQM=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/go.sum
+++ b/go.sum
@@ -4,14 +4,10 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260518182430-cdd9e0e3945d h1:7TrxySP+VhCg6w+l5JEmz0DhHRrXFiZiNvQPrWcqHNs=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260518182430-cdd9e0e3945d/go.mod h1:z4Ka1UqEslbSHcldcYvysxeer8uosHun7Dz9Iji2PFw=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.14.0 h1:7rHYSxPHGUaQ2+ERbH0CdSVhMLNtepmrbm6es08lUEA=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.14.0/go.mod h1:oeo/6WNu7Z8+lQ3vGEC/qvZilTbmCUabglbuEiL0tQM=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver_phased.go
+++ b/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver_phased.go
@@ -24,9 +24,11 @@ import (
 	"fmt"
 
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
@@ -232,7 +234,37 @@ func (r *Dnd5eCombatResolver) ApplyAttackOutcome(
 		TargetAC:    result.TargetAC,
 		Damage:      result.TotalDamage,
 		DamageType:  string(result.DamageType),
+		Components:  translateDamageComponents(result.Breakdown),
 	}, nil
+}
+
+// translateDamageComponents converts a dnd5e DamageBreakdown into the
+// encounter SDK's generic []core.DamageComponent slice. Returns nil when
+// breakdown is nil or empty (stand-in resolver, NPC attack).
+func translateDamageComponents(breakdown *combat.DamageBreakdown) []encountercore.DamageComponent {
+	if breakdown == nil || len(breakdown.Components) == 0 {
+		return nil
+	}
+	out := make([]encountercore.DamageComponent, 0, len(breakdown.Components))
+	for _, c := range breakdown.Components {
+		out = append(out, encountercore.DamageComponent{
+			Source:     damageComponentSource(c),
+			Amount:     c.Total(),
+			DamageType: string(c.DamageType),
+			IsCritical: c.IsCritical,
+		})
+	}
+	return out
+}
+
+// damageComponentSource derives the opaque source string for a DamageComponent.
+// Uses SourceRef.String() when a ref is available (e.g. "dnd5e:features:sneak_attack"),
+// falls back to the category string (e.g. "weapon", "ability") otherwise.
+func damageComponentSource(c dnd5eEvents.DamageComponent) string {
+	if c.SourceRef != nil {
+		return c.SourceRef.String()
+	}
+	return string(c.Source)
 }
 
 // prepareAttack centralizes the shared "resolve entities + build registry +

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -56,6 +56,7 @@ import (
 	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	tkencevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
@@ -352,6 +353,72 @@ func (s *SneakAttackIntegrationSuite) TestIntegration_ReactionReadinessExposedVi
 	s.advanceToAlice()
 	_, err = s.handler.TakeAction(s.aliceCtx, s.attackAliceVsGoblin())
 	s.Require().NoError(err, "attack must resolve with readiness map wired into gamectx")
+}
+
+// TestIntegration_SneakAttackDamageBreakdown_HasWeaponAndSneakComponents verifies
+// that when alice (rogue) fires a sneak attack, the DamageDealtEvent published on
+// the broker carries two Components: a "dnd5e:weapons:shortsword" component and a
+// "dnd5e:features:sneak_attack" component. This proves the breakdown survives
+// the full chain: combat resolver → AttackOutcome.Components → DamageDealtEvent.Components
+// → broker JSON round-trip.
+func (s *SneakAttackIntegrationSuite) TestIntegration_SneakAttackDamageBreakdown_HasWeaponAndSneakComponents() {
+	aliceData := s.buildAliceRogueData()
+	s.setupCharRepoMock(aliceData)
+	s.seedSneakEncounter()
+	s.advanceToAlice()
+
+	// Subscribe for alice before the attack so we capture the DamageDealtEvent.
+	sub, err := s.broker.Subscribe(encountercore.EncounterID(sneakIntegEncID), encountercore.PlayerID(sneakPlayerAlice))
+	s.Require().NoError(err, "broker subscribe must succeed")
+	defer sub.Close() //nolint:errcheck
+
+	_, err = s.handler.TakeAction(s.aliceCtx, s.attackAliceVsGoblin())
+	s.Require().NoError(err, "attack must resolve without error")
+
+	// Drain events until we find the DamageDealtEvent (or timeout).
+	var damageEvt *tkencevents.DamageDealtEvent
+	timeout := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drain
+			}
+			if d, ok := evt.(*tkencevents.DamageDealtEvent); ok {
+				damageEvt = d
+				break drain
+			}
+		case <-timeout:
+			break drain
+		}
+	}
+
+	s.Require().NotNil(damageEvt, "DamageDealtEvent must be published on the broker for alice's attack")
+	s.Require().NotEmpty(damageEvt.Components,
+		"DamageDealtEvent.Components must be non-empty when sneak attack fires")
+
+	// Verify component sources. The dnd5e rulebook uses SourceRef.String() which
+	// produces "dnd5e:weapons:<id>" for the weapon, "dnd5e:abilities:<id>" for the
+	// ability modifier, and "dnd5e:features:sneak_attack" for the sneak attack dice.
+	sources := make([]string, 0, len(damageEvt.Components))
+	for _, c := range damageEvt.Components {
+		sources = append(sources, c.Source)
+	}
+	s.Contains(sources, "dnd5e:weapons:shortsword",
+		"damage breakdown must include a weapon component; got %v", sources)
+	s.Contains(sources, "dnd5e:features:sneak_attack",
+		"damage breakdown must include a sneak attack feature component; got %v", sources)
+
+	// The weapon component carries only dice (6 from fixedRoller). The DEX modifier
+	// is emitted as a separate "dnd5e:abilities:dex" component (amount=3).
+	const weaponDiceOnly = 6 // fixedRoller{10}.Roll(6) = min(10,6) = 6
+	for _, c := range damageEvt.Components {
+		if c.Source == "dnd5e:weapons:shortsword" {
+			s.Equal(weaponDiceOnly, c.Amount,
+				"weapon component amount must equal %d (fixed dice roll)", weaponDiceOnly)
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -361,6 +361,20 @@ func translateDamageDealtEvent(e *events.DamageDealtEvent, viewer core.PlayerID,
 		s := string(e.SourceID)
 		out.SourceEntityId = &s
 	}
+	if len(e.Components) > 0 {
+		out.DamageBreakdown = make([]*encounterv2pb.DamageComponent, 0, len(e.Components))
+		for _, c := range e.Components {
+			pb := &encounterv2pb.DamageComponent{
+				Source:     c.Source,
+				Amount:     int32(c.Amount), //nolint:gosec // damage amounts are bounded game values that fit int32
+				IsCritical: c.IsCritical,
+			}
+			if c.DamageType != "" {
+				pb.DamageType = damageRefFor(c.DamageType)
+			}
+			out.DamageBreakdown = append(out.DamageBreakdown, pb)
+		}
+	}
 	return &encounterv2pb.EncounterEvent{
 		Sequence:  int64(e.Sequence()),
 		Timestamp: timestamppb.New(now),

--- a/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
@@ -61,6 +61,86 @@ func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_HappyPath() {
 	s.Require().Equal(int64(11), out.Sequence)
 }
 
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_WithBreakdown_PopulatesProto() {
+	// Verify that DamageDealtEvent.Components are forwarded into the proto's
+	// damage_breakdown field. Two components: weapon + sneak attack.
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(15),
+		"goblin-1", "char-A",
+		14, "slashing",
+		6, 20,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	evt.Components = []core.DamageComponent{
+		{Source: "weapon", Amount: 9, DamageType: "slashing", IsCritical: false},
+		{Source: "dnd5e:conditions:sneak_attack", Amount: 5, DamageType: "slashing", IsCritical: false},
+	}
+
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+
+	dmg := out.GetEntityDamaged()
+	s.Require().NotNil(dmg, "expected EntityDamaged envelope")
+	s.Require().Len(dmg.GetDamageBreakdown(), 2, "expected 2 damage components")
+
+	weapon := dmg.GetDamageBreakdown()[0]
+	s.Require().Equal("weapon", weapon.GetSource())
+	s.Require().Equal(int32(9), weapon.GetAmount())
+	s.Require().Equal("slashing", weapon.GetDamageType().GetId())
+	s.Require().False(weapon.GetIsCritical())
+
+	sneak := dmg.GetDamageBreakdown()[1]
+	s.Require().Equal("dnd5e:conditions:sneak_attack", sneak.GetSource())
+	s.Require().Equal(int32(5), sneak.GetAmount())
+	s.Require().Equal("slashing", sneak.GetDamageType().GetId())
+	s.Require().False(sneak.GetIsCritical())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_NoComponents_EmptyBreakdown() {
+	// When Components is nil (stand-in resolver), damage_breakdown must be empty.
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(16),
+		"goblin-1", "char-A",
+		5, "slashing",
+		2, 7,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	// Components is nil by default.
+
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	dmg := out.GetEntityDamaged()
+	s.Require().NotNil(dmg)
+	s.Require().Empty(dmg.GetDamageBreakdown(), "no components → empty breakdown")
+}
+
+func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_CritBreakdown_SetsCritFlag() {
+	// IsCritical on a component must pass through to the proto.
+	evt := events.NewDamageDealtEvent(
+		"enc-1", uint64(17),
+		"goblin-1", "char-A",
+		18, "slashing",
+		2, 20,
+		map[core.PlayerID]events.DamageDealtSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	evt.Components = []core.DamageComponent{
+		{Source: "weapon", Amount: 18, DamageType: "slashing", IsCritical: true},
+	}
+
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	dmg := out.GetEntityDamaged()
+	s.Require().Len(dmg.GetDamageBreakdown(), 1)
+	s.Require().True(dmg.GetDamageBreakdown()[0].GetIsCritical(), "critical component flag must propagate")
+}
+
 func (s *TranslateSuite) TestTranslateEvent_DamageDealtEvent_EmptyDamageTypeSkipsRef() {
 	evt := events.NewDamageDealtEvent(
 		"enc-1", uint64(12),

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -980,12 +980,14 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 		"bob's stream must not surface unmapped envelopes")
 
 	// On hit, EntityDamaged should target goblin-1 with the active entity as source.
-	if dmg := findEntityDamaged(aPost); dmg != nil {
+	// Use findEntityDamagedBySource to identify the player's attack specifically —
+	// the goblin's NPC-turn attack on bob also produces EntityDamaged events in
+	// alice's stream (alice has LoS to both bob and the goblin), so using
+	// findEntityDamaged (first-seen) would pick up the wrong event on a player miss.
+	if dmg := findEntityDamagedBySource(aPost, activeEntity); dmg != nil {
 		s.Require().Equal("goblin-1", dmg.GetEntityId(), "alice's damage event targets goblin-1")
-		s.Require().Equal(activeEntity, dmg.GetSourceEntityId(),
-			"alice's damage event source is the attacking entity")
 	}
-	if dmg := findEntityDamaged(bPost); dmg != nil {
+	if dmg := findEntityDamagedBySource(bPost, activeEntity); dmg != nil {
 		s.Require().Equal("goblin-1", dmg.GetEntityId(), "bob's damage event targets goblin-1")
 	}
 
@@ -1569,6 +1571,20 @@ func (s *eventSink) findEncounterEnded() *encounterv2pb.EncounterEnded {
 func findEntityDamaged(events []*encounterv2pb.EncounterEvent) *encounterv2pb.EntityDamaged {
 	for _, ev := range events {
 		if d := ev.GetEntityDamaged(); d != nil {
+			return d
+		}
+	}
+	return nil
+}
+
+// findEntityDamagedBySource returns the first EntityDamaged event whose
+// SourceEntityId matches sourceID, or nil if no such event is present.
+// Use this instead of findEntityDamaged when multiple EntityDamaged events may
+// appear on a viewer's stream (e.g. the player's attack and the NPC's
+// retaliatory attack both deliver EntityDamaged to all LoS viewers).
+func findEntityDamagedBySource(events []*encounterv2pb.EncounterEvent, sourceID string) *encounterv2pb.EntityDamaged {
+	for _, ev := range events {
+		if d := ev.GetEntityDamaged(); d != nil && d.GetSourceEntityId() == sourceID {
 			return d
 		}
 	}


### PR DESCRIPTION
## Summary

- `dnd5e_combat_resolver_phased.go`: new `translateDamageComponents` maps dnd5e `DamageBreakdown.Components` → `[]encountercore.DamageComponent`; populates `AttackOutcome.Components` from `ApplyAttackOutcome` result
- `translate.go`: `translateDamageDealtEvent` maps `DamageDealtEvent.Components` → proto `EntityDamaged.damage_breakdown` (with damage type Ref + is_critical flag)
- `translate_combat_test.go`: three new unit tests — weapon + sneak_attack components flow to proto; nil components → empty breakdown; is_critical propagates
- `integration_sneak_attack_test.go`: new test subscribes to broker before alice's attack and asserts `DamageDealtEvent` carries `dnd5e:weapons:shortsword` and `dnd5e:features:sneak_attack` components through the broker JSON round-trip

Rolls up to: #550 (Wave 1 Rogue damage breakdown)

## Dependencies

This PR depends on (must merge first):
- rpg-api-protos#161: adds `DamageComponent` proto message + `damage_breakdown` field to `EntityDamaged`  
- rpg-toolkit#682: adds `DamageComponent` to `AttackOutcome` + `DamageDealtEvent`; wires through broker JSON

**Local replace directives in go.mod** pin to local rpg-api-protos gen/go and rpg-toolkit/encounter. These must be stripped and replaced with real pseudo-versions before merging. Will be done after upstream PRs merge.

## Test plan

- [ ] All three upstream PRs merged and stripped from go.mod before this PR merges
- [ ] `make ci-check` passes with real dependency versions
- [ ] Integration test `TestIntegration_SneakAttackDamageBreakdown_HasWeaponAndSneakComponents` passes
- [ ] Three new translate unit tests pass
- [ ] MCP playtest: alice's attack log line shows breakdown suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #556
Part of #550 (Chapter 2 Wave 1)