### PR TITLE
feat(wave-2-monk): devseed fixture + v2 unarmed-strike integration test

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -102,28 +102,35 @@ const (
 
 	fixtureDefault    = ""
 	fixtureWave1Rogue = "wave-1-rogue"
+	fixtureWave2Monk  = "wave-2-monk"
 
 	weaponShortsword    = "shortsword"
 	weaponGreataxe      = "greataxe"
 	inventoryTypeWeapon = "weapon"
 
-	damageTypePiercing = "piercing"
-	damageTypeSlashing = "slashing"
-	damageTypeFire     = "fire"
+	damageTypePiercing    = "piercing"
+	damageTypeSlashing    = "slashing"
+	damageTypeFire        = "fire"
+	damageTypeBludgeoning = "bludgeoning"
+
+	monsterRefGoblin     = "dnd5e:monsters:goblin"
+	goblinBaseDamageDice = "1d6+2"
 )
 
 var (
 	// Entity IDs are stable across runs so the harness can deep-link to a
 	// specific player and the existing integration tests' EntityID constants
 	// stay aligned.
-	playerAlice = encountercore.PlayerID("alice")
-	playerBob   = encountercore.PlayerID("bob")
-	playerWendy = encountercore.PlayerID("wendy")
+	playerAlice  = encountercore.PlayerID("alice")
+	playerBob    = encountercore.PlayerID("bob")
+	playerWendy  = encountercore.PlayerID("wendy")
+	playerCharli = encountercore.PlayerID("charli")
 
 	entityAlice  = encountercore.EntityID("char-alice")
 	entityBob    = encountercore.EntityID("char-bob")
 	entityWendy  = encountercore.EntityID("char-wendy")
 	entityGoblin = encountercore.EntityID("goblin-1")
+	entityCharli = encountercore.EntityID("char-charli")
 )
 
 func main() {
@@ -182,6 +189,14 @@ func run() error {
 	var encData *tkenc.Data
 
 	switch *fixture {
+	case fixtureWave2Monk:
+		chars = []*toolkitchar.Data{
+			buildCharliMonkData(),
+		}
+		encData, err = buildWave2MonkEncounterData(*encounterID, encMode)
+		if err != nil {
+			return fmt.Errorf("build encounter: %w", err)
+		}
 	case fixtureWave1Rogue:
 		chars = []*toolkitchar.Data{
 			buildAliceRogueL1Data(),
@@ -203,8 +218,8 @@ func run() error {
 			return fmt.Errorf("build encounter: %w", err)
 		}
 	default:
-		return fmt.Errorf("unknown fixture %q: supported values are %q and %q",
-			*fixture, fixtureDefault, fixtureWave1Rogue)
+		return fmt.Errorf("unknown fixture %q: supported values are %q, %q, and %q",
+			*fixture, fixtureDefault, fixtureWave1Rogue, fixtureWave2Monk)
 	}
 
 	// 1. Seed characters first so they exist when the harness or handler
@@ -527,9 +542,9 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 		MaxHP:       goblinData.MaxHitPoints,
 		AC:          goblinData.ArmorClass,
 		Speed:       6, // 30ft / 5ft per hex
-		MonsterRef:  "dnd5e:monsters:goblin",
+		MonsterRef:  monsterRefGoblin,
 		AttackBonus: 4, // matches goblin's NewScimitarAction
-		DamageDice:  "1d6+2",
+		DamageDice:  goblinBaseDamageDice,
 		DamageType:  damageTypeSlashing,
 		DataJSON:    goblinDataJSON,
 	}); err != nil {
@@ -539,6 +554,116 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 	// SetMode is a no-op for FreeRoam-from-fresh-create (the SDK's NewData
 	// already defaults to FreeRoam); only call it for TurnBased so the SDK
 	// rolls initiative and seeds ActiveIdx/Round.
+	if mode == encountercore.ModeTurnBased {
+		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
+			return nil, fmt.Errorf("set mode turn_based: %w", err)
+		}
+	}
+
+	return enc.ToData(), nil
+}
+
+// buildCharliMonkData returns a level-1 monk fixture for the wave-2-monk scenario.
+// Charli: DEX 16 (+3) / WIS 14 (+2) / CON 14 (+2), HP 10, AC 15, ProficiencyBonus 2.
+// No weapon equipped (unarmed strike via Martial Arts). No armor (Unarmored Defense active).
+// Conditions: MartialArts + UnarmoredDefense(Monk) persisted so they rehydrate on LoadFromData.
+func buildCharliMonkData() *toolkitchar.Data {
+	martialArtsCond := conditions.NewMartialArtsCondition(conditions.MartialArtsInput{
+		CharacterID: string(entityCharli),
+		MonkLevel:   1,
+	})
+	martialArtsJSON, err := martialArtsCond.ToJSON()
+	if err != nil {
+		panic(fmt.Errorf("charli martial arts ToJSON: %w", err))
+	}
+
+	unarmoredDefenseCond := conditions.NewUnarmoredDefenseCondition(conditions.UnarmoredDefenseInput{
+		CharacterID: string(entityCharli),
+		Type:        conditions.UnarmoredDefenseMonk,
+		Source:      "dnd5e:classes:monk",
+	})
+	unarmoredDefenseJSON, err := unarmoredDefenseCond.ToJSON()
+	if err != nil {
+		panic(fmt.Errorf("charli unarmored defense ToJSON: %w", err))
+	}
+
+	now := time.Now().UTC()
+	return &toolkitchar.Data{
+		ID:               string(entityCharli),
+		PlayerID:         string(playerCharli),
+		Name:             "Charli the Monk",
+		Level:            1,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Monk,
+		HitPoints:        10,
+		MaxHitPoints:     10,
+		ArmorClass:       15, // 10 + DEX(+3) + WIS(+2) via Unarmored Defense
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 10, // +0 — low STR forces Martial Arts DEX swap visible in test
+			abilities.DEX: 16, // +3
+			abilities.CON: 14, // +2
+			abilities.INT: 10,
+			abilities.WIS: 14, // +2 — AC = 10 + 3 + 2 = 15
+			abilities.CHA: 10,
+		},
+		// No weapon equipped: unarmed strike path triggers Martial Arts condition
+		Conditions: []json.RawMessage{martialArtsJSON, unarmoredDefenseJSON},
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+// buildWave2MonkEncounterData seeds the wave-2-monk encounter: charli (monk, unarmed) adjacent
+// to a standard goblin. No other players. Charli uses 1d4+DEX via Martial Arts.
+func buildWave2MonkEncounterData(encounterID string, mode encountercore.EncounterMode) (*tkenc.Data, error) {
+	transport := tkenc.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := tkenc.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+
+	enc := tkenc.New(encountercore.EncounterID(encounterID), broker)
+
+	// charli (monk, unarmed) — placed at origin, adjacent to goblin at Q:1.
+	// AttackBonus: DEX +3 + proficiency +2 = 5.
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    playerCharli,
+		EntityID:    entityCharli,
+		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          10,
+		MaxHP:       10,
+		AC:          15,
+		AttackBonus: 5,
+		DamageDice:  "1d4+3",
+		DamageType:  damageTypeBludgeoning,
+	}); err != nil {
+		return nil, fmt.Errorf("add charli: %w", err)
+	}
+
+	goblin := monster.NewGoblin(string(entityGoblin))
+	goblinData := goblin.ToData()
+	goblinDataJSON, err := json.Marshal(goblinData)
+	if err != nil {
+		return nil, fmt.Errorf("marshal goblin data: %w", err)
+	}
+
+	// Goblin adjacent to charli (Q:1 R:0 — euclidean distance 1.0 ≤ 1.5).
+	if err := enc.AddMonster(tkenc.MonsterInput{
+		ID:          entityGoblin,
+		Position:    encountercore.Hex{Q: 1, R: 0, S: -1},
+		HP:          goblinData.HitPoints,
+		MaxHP:       goblinData.MaxHitPoints,
+		AC:          goblinData.ArmorClass,
+		Speed:       6,
+		MonsterRef:  monsterRefGoblin,
+		AttackBonus: 4,
+		DamageDice:  goblinBaseDamageDice,
+		DamageType:  damageTypeSlashing,
+		DataJSON:    goblinDataJSON,
+	}); err != nil {
+		return nil, fmt.Errorf("add goblin: %w", err)
+	}
+
 	if mode == encountercore.ModeTurnBased {
 		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
 			return nil, fmt.Errorf("set mode turn_based: %w", err)
@@ -650,9 +775,9 @@ func buildWave1RogueEncounterData(encounterID string, mode encountercore.Encount
 		MaxHP:       goblinData.MaxHitPoints,
 		AC:          goblinData.ArmorClass,
 		Speed:       6,
-		MonsterRef:  "dnd5e:monsters:goblin",
+		MonsterRef:  monsterRefGoblin,
 		AttackBonus: 4,
-		DamageDice:  "1d6+2",
+		DamageDice:  goblinBaseDamageDice,
 		DamageType:  damageTypeSlashing,
 		DataJSON:    goblinDataJSON,
 	}); err != nil {

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-27
-confidence: high — Wave 2.11e entries verified against shipped code and passing integration tests
+updated: 2026-05-28
+confidence: high — Wave 2 Monk entries verified against passing integration tests
 ---
 
 # rpg-api: Where We Are
@@ -10,6 +10,18 @@ confidence: high — Wave 2.11e entries verified against shipped code and passin
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**Chapter 2 Wave 2 (monk) — devseed fixture + v2 unarmed-strike integration test (2026-05-28)** —
+`--fixture=wave-2-monk` seeds charli (L1 monk, DEX 16/WIS 14/CON 14, HP 10, AC 15, no weapon,
+MartialArts + UnarmoredDefense conditions persisted) + goblin adjacent into `enc:v2:dev-encounter`
+(closes #559). `TestMonkUnarmedIntegrationSuite` proves the full MartialArts chain via the real
+`TakeAction` RPC: unarmed strike uses DEX mod (+3) not STR (+0), 1d4 damage die applies, and
+the `dnd5e:abilities:dex` source appears in `DamageDealtEvent.Components` (closes #560).
+
+Root bug fixed: `buildEncounterCharacterRegistryFromResolved` was calling `reg.Add` (weapons)
+but never `reg.AddAbilityScores`. Without ability scores in the registry, `MartialArtsCondition`
+silently no-ops on `onDamageChain`. Fix adds `characterToGamectxAbilityScores` helper and two
+`AddAbilityScores` calls (attacker + target). No toolkit changes needed.
 
 **Chapter 2 Wave 1 (rogue) — devseed fixture + L1 SA integration test (2026-05-27)** —
 `--fixture=wave-1-rogue` seeds alice (L1 rogue, 1d6 SneakAttack, HP 10) + bob (L1 barbarian) +

--- a/internal/auth/mock/mock_discord.go
+++ b/internal/auth/mock/mock_discord.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	auth "github.com/KirkDiggler/rpg-api/internal/auth"
 	gomock "go.uber.org/mock/gomock"
+
+	auth "github.com/KirkDiggler/rpg-api/internal/auth"
 )
 
 // MockTokenValidator is a mock of TokenValidator interface.

--- a/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver.go
@@ -50,6 +50,7 @@ import (
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
@@ -318,14 +319,18 @@ func (r *Dnd5eCombatResolver) buildEncounterCharacterRegistryFromResolved(
 ) *gamectx.BasicCharacterRegistry {
 	reg := gamectx.NewBasicCharacterRegistry()
 
-	// Register the attacker's weapons if we have a rehydrated character.
+	// Register the attacker's weapons and ability scores if we have a rehydrated character.
+	// Ability scores are required by conditions like MartialArts that call
+	// registry.GetCharacterAbilityScores to determine DEX vs STR modifier.
 	if attackerChar != nil {
 		reg.Add(attackerChar.GetID(), characterToGamectxWeapons(attackerChar))
+		reg.AddAbilityScores(attackerChar.GetID(), characterToGamectxAbilityScores(attackerChar))
 	}
 
-	// Register the target's weapons if we have a rehydrated character.
+	// Register the target's weapons and ability scores if we have a rehydrated character.
 	if targetChar != nil {
 		reg.Add(targetChar.GetID(), characterToGamectxWeapons(targetChar))
+		reg.AddAbilityScores(targetChar.GetID(), characterToGamectxAbilityScores(targetChar))
 	}
 
 	if r.encounterData == nil {
@@ -353,6 +358,21 @@ func (r *Dnd5eCombatResolver) buildEncounterCharacterRegistryFromResolved(
 	}
 
 	return reg
+}
+
+// characterToGamectxAbilityScores converts a character's ability scores to the
+// gamectx.AbilityScores type so conditions like MartialArts can read DEX/STR
+// scores via registry.GetCharacterAbilityScores during the damage chain.
+func characterToGamectxAbilityScores(char *character.Character) *gamectx.AbilityScores {
+	scores := char.AbilityScores()
+	return &gamectx.AbilityScores{
+		Strength:     scores[abilities.STR],
+		Dexterity:    scores[abilities.DEX],
+		Constitution: scores[abilities.CON],
+		Intelligence: scores[abilities.INT],
+		Wisdom:       scores[abilities.WIS],
+		Charisma:     scores[abilities.CHA],
+	}
 }
 
 // characterToGamectxWeapons extracts the equipped weapon slots from a

--- a/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
@@ -1,0 +1,380 @@
+package encounter_test
+
+// integration_monk_unarmed_test.go — Wave 2 (Monk L1) sign-off integration tests.
+//
+// These tests verify that a charli (L1 monk, no weapon, Martial Arts + UnarmoredDefense
+// conditions persisted) unarmed-strikes via the real v2 TakeAction RPC and that:
+//
+//  1. The Martial Arts condition runs on the unarmed path (not silently no-oped).
+//  2. DEX modifier (+3) is used instead of STR (+0) in the damage components.
+//  3. DamageDealtEvent.Components carries "dnd5e:abilities:dex" as the ability source.
+//
+// # Root cause addressed
+//
+// buildEncounterCharacterRegistryFromResolved previously registered only weapon slots
+// (via reg.Add) but never called reg.AddAbilityScores. The MartialArts condition's
+// onDamageChain calls registry.GetCharacterAbilityScores(charID) and early-returns nil
+// when no scores are registered — silently yielding 1d4+STR. The fix (Wave 2) adds
+// reg.AddAbilityScores for resolved characters so the DEX swap and dice replacement run.
+//
+// # Deterministic roller strategy
+//
+// fixedRoller{val:15} (imported from integration_sneak_attack_test.go):
+//
+//	The unarmed stub weapon has no Finesse property, so combat.ResolveAttack uses STR
+//	for the attack roll: attackBonus = STR(+0) + proficiency(+2) = 2.
+//	d20 = min(15,20) = 15; attack total = 15+2 = 17 ≥ goblin AC 15 → always hit, no crit (not 20).
+//	Martial Arts replaces weapon dice: Roll(size=4) = min(15,4) = 4
+//	DEX mod = +3 (DEX 16) — ability component (Martial Arts DEX swap)
+//	STR mod = +0 (STR 10) — would be used WITHOUT Martial Arts DEX swap
+//	Expected total damage with MA: 4+3 = 7
+//	Expected total damage without MA (STR): 4+0 = 4
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	tkencevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	monkIntegEncID   = "enc-monk-integration"
+	monkPlayerCharli = "charli"
+	monkEntityCharli = "char-charli"
+	monkGoblinID     = "goblin-monk"
+
+	// monkDEXMod is charli's DEX modifier (DEX 16 → +3). Martial Arts replaces the
+	// ability component SourceRef with DEX and sets FlatBonus to dexMod. The
+	// weapon dice (1d4 via MartialArts condition's own random roller) are random,
+	// so HP-delta assertions use min/max bounds (1+3=4 to 4+3=7).
+	monkDEXMod = 3
+	// monkMaxDamage = max 1d4 (4) + DEX mod (3) = 7.
+	monkMaxDamage = 7
+)
+
+// MonkUnarmedIntegrationSuite tests the Wave 2 sign-off scenario: charli (L1 monk,
+// unarmed) strikes a goblin via TakeAction, proving Martial Arts applies DEX and 1d4.
+type MonkUnarmedIntegrationSuite struct {
+	suite.Suite
+	ctrl         *gomock.Controller
+	mockCharRepo *charactermock.MockRepository
+	charStore    *inMemoryCharStore
+	broker       *tkenc.Broker
+	repo         encountersv2.Repository
+	handler      *v2encounter.Handler
+	charliCtx    context.Context
+}
+
+func TestMonkUnarmedIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(MonkUnarmedIntegrationSuite))
+}
+
+func (s *MonkUnarmedIntegrationSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
+	s.charStore = newInMemoryCharStore()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	h, err := v2encounter.New(&v2encounter.HandlerConfig{
+		Broker: s.broker,
+		Repo:   s.repo,
+		Now:    func() time.Time { return fixedNow },
+		CombatResolverConfig: &v2encounter.Dnd5eCombatResolverConfig{
+			CharacterRepo: s.mockCharRepo,
+			Roller:        fixedRoller{val: 15},
+		},
+	})
+	s.Require().NoError(err)
+	s.handler = h
+
+	s.charliCtx = auth.WithPlayerID(context.Background(), monkPlayerCharli)
+}
+
+func (s *MonkUnarmedIntegrationSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// TestIntegration_MartialArts_UnarmedStrikeUsesDEX proves Martial Arts runs on the
+// unarmed path and applies the DEX modifier instead of STR.
+//
+// The Martial Arts condition uses its own random roller for 1d4 dice replacement
+// (not the handler's fixedRoller). HP delta is in range [1+3, 4+3] = [4, 7].
+// delta >= monkDEXMod (3) proves at minimum one DEX pip was added — combined with
+// the breakdown test which confirms "dnd5e:abilities:dex" source, this proves MA applied.
+func (s *MonkUnarmedIntegrationSuite) TestIntegration_MartialArts_UnarmedStrikeUsesDEX() {
+	charliData := s.buildCharliMonkData()
+	s.setupCharRepoMock(charliData)
+	s.seedMonkEncounter()
+	s.advanceToCharli()
+
+	hp0 := s.goblinHP()
+	_, err := s.handler.TakeAction(s.charliCtx, s.attackCharliVsGoblin())
+	s.Require().NoError(err, "unarmed strike must resolve without error")
+	hp1 := s.goblinHP()
+
+	delta := hp0 - hp1
+	s.Greater(delta, 0,
+		"unarmed strike must deal damage (delta=%d); attack with fixedRoller{15} should always hit", delta)
+	s.LessOrEqual(delta, monkMaxDamage,
+		"damage delta (%d) must not exceed monkMaxDamage (%d) = 1d4_max+DEX", delta, monkMaxDamage)
+	s.GreaterOrEqual(delta, monkDEXMod,
+		"damage delta (%d) must be >= DEX mod (%d); Martial Arts must apply DEX not STR (+0)",
+		delta, monkDEXMod)
+}
+
+// TestIntegration_MartialArts_DamageBreakdown_HasDEXAbilityComponent verifies that
+// the DamageDealtEvent published on the broker carries "dnd5e:abilities:dex" as the
+// ability source (not "dnd5e:abilities:str"), proving the Martial Arts condition
+// replaced the ability component source.
+func (s *MonkUnarmedIntegrationSuite) TestIntegration_MartialArts_DamageBreakdown_HasDEXAbilityComponent() {
+	charliData := s.buildCharliMonkData()
+	s.setupCharRepoMock(charliData)
+	s.seedMonkEncounter()
+	s.advanceToCharli()
+
+	sub, err := s.broker.Subscribe(encountercore.EncounterID(monkIntegEncID), encountercore.PlayerID(monkPlayerCharli))
+	s.Require().NoError(err, "broker subscribe must succeed")
+	defer sub.Close() //nolint:errcheck
+
+	_, err = s.handler.TakeAction(s.charliCtx, s.attackCharliVsGoblin())
+	s.Require().NoError(err, "attack must resolve without error")
+
+	var damageEvt *tkencevents.DamageDealtEvent
+	timeout := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drain
+			}
+			if d, ok := evt.(*tkencevents.DamageDealtEvent); ok {
+				damageEvt = d
+				break drain
+			}
+		case <-timeout:
+			break drain
+		}
+	}
+
+	s.Require().NotNil(damageEvt, "DamageDealtEvent must be published on the broker for charli's attack")
+	s.Require().NotEmpty(damageEvt.Components, "DamageDealtEvent.Components must be non-empty")
+
+	sources := make([]string, 0, len(damageEvt.Components))
+	for _, c := range damageEvt.Components {
+		sources = append(sources, c.Source)
+	}
+
+	s.Contains(sources, "dnd5e:abilities:dex",
+		"damage breakdown must include a DEX ability component (Martial Arts DEX swap); got %v", sources)
+	s.NotContains(sources, "dnd5e:abilities:str",
+		"STR ability component must not appear — Martial Arts must replace it with DEX; got %v", sources)
+}
+
+// TestIntegration_MartialArts_DoesNotCrashWithGamectx verifies that the unarmed
+// strike path runs without crashing from missing gamectx (RequireCharacters),
+// which would happen if AddAbilityScores were not called on the registry.
+func (s *MonkUnarmedIntegrationSuite) TestIntegration_MartialArts_DoesNotCrashWithGamectx() {
+	charliData := s.buildCharliMonkData()
+	s.setupCharRepoMock(charliData)
+	s.seedMonkEncounter()
+	s.advanceToCharli()
+
+	_, err := s.handler.TakeAction(s.charliCtx, s.attackCharliVsGoblin())
+	s.Require().NoError(err,
+		"unarmed strike with Martial Arts condition must not crash from missing ability scores in gamectx registry")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// buildCharliMonkData constructs character.Data for charli — a L1 monk with
+// DEX 16 > STR 10, no weapon equipped, and MartialArts + UnarmoredDefense conditions
+// persisted in the Conditions blob. DEX > STR ensures the Martial Arts DEX swap
+// is observable (STR mod = +0, DEX mod = +3).
+func (s *MonkUnarmedIntegrationSuite) buildCharliMonkData() *character.Data {
+	martialArtsCond := conditions.NewMartialArtsCondition(conditions.MartialArtsInput{
+		CharacterID: monkEntityCharli,
+		MonkLevel:   1,
+	})
+	martialArtsJSON, err := martialArtsCond.ToJSON()
+	s.Require().NoError(err, "marshal MartialArts condition")
+
+	unarmoredDefenseCond := conditions.NewUnarmoredDefenseCondition(conditions.UnarmoredDefenseInput{
+		CharacterID: monkEntityCharli,
+		Type:        conditions.UnarmoredDefenseMonk,
+		Source:      "dnd5e:classes:monk",
+	})
+	unarmoredDefenseJSON, err := unarmoredDefenseCond.ToJSON()
+	s.Require().NoError(err, "marshal UnarmoredDefense condition")
+
+	return &character.Data{
+		ID:               monkEntityCharli,
+		Name:             "Charli the Monk",
+		Level:            1,
+		ClassID:          "monk",
+		ProficiencyBonus: 2,
+		HitPoints:        10,
+		MaxHitPoints:     10,
+		ArmorClass:       15, // 10 + DEX(+3) + WIS(+2) — Unarmored Defense
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 10, // +0 — low STR makes DEX swap observable
+			abilities.DEX: 16, // +3
+			abilities.CON: 14, // +2
+			abilities.INT: 10,
+			abilities.WIS: 14, // +2
+			abilities.CHA: 10,
+		},
+		// No EquipmentSlots — no weapon equipped, unarmed path triggered
+		Conditions: []json.RawMessage{martialArtsJSON, unarmoredDefenseJSON},
+	}
+}
+
+// setupCharRepoMock registers mock expectations backed by inMemoryCharStore.
+// Charli's Get reads live state; Update writes back so subsequent Gets reflect
+// condition updates (e.g. UsedThisTurn round-trips).
+func (s *MonkUnarmedIntegrationSuite) setupCharRepoMock(charliData *character.Data) {
+	s.charStore.set(charliData)
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: monkEntityCharli}).
+		DoAndReturn(func(_ context.Context, _ characterrepo.GetInput) (*characterrepo.GetOutput, error) {
+			d := s.charStore.get(monkEntityCharli)
+			if d == nil {
+				return nil, fmt.Errorf("charli not found in charStore")
+			}
+			return &characterrepo.GetOutput{
+				Character: &entities.Character{Data: d},
+			}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			if input.Character != nil && input.Character.Data != nil {
+				s.charStore.update(input.Character.Data)
+			}
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		}).AnyTimes()
+
+	// Non-charli lookups fall back to stand-in.
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), gomock.Not(characterrepo.GetInput{ID: monkEntityCharli})).
+		Return(nil, fmt.Errorf("character not configured in monk integration test mock")).
+		AnyTimes()
+}
+
+// attackCharliVsGoblin returns a TakeActionRequest for charli attacking the goblin.
+func (s *MonkUnarmedIntegrationSuite) attackCharliVsGoblin() *encounterv2pb.TakeActionRequest {
+	return &encounterv2pb.TakeActionRequest{
+		EncounterId:   monkIntegEncID,
+		ActorEntityId: monkEntityCharli,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: monkGoblinID},
+		},
+	}
+}
+
+// goblinHP returns the goblin's current HP from the persisted encounter snapshot.
+func (s *MonkUnarmedIntegrationSuite) goblinHP() int {
+	data, err := s.repo.Get(context.Background(), monkIntegEncID)
+	s.Require().NoError(err, "repo.Get for goblin HP check")
+	md, ok := data.Monsters[encountercore.EntityID(monkGoblinID)]
+	s.Require().True(ok, "goblin must be in encounter data")
+	return md.HP
+}
+
+// seedMonkEncounter creates the wave-2-monk fixture encounter and saves it.
+//
+// Positions: charli at Q:0, goblin at Q:1 (adjacent, euclidean distance 1.0 ≤ 1.5).
+// Goblin has 100 HP so it survives multiple strikes during the test.
+func (s *MonkUnarmedIntegrationSuite) seedMonkEncounter() {
+	enc := tkenc.New(monkIntegEncID, s.broker)
+
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    encountercore.PlayerID(monkPlayerCharli),
+		EntityID:    encountercore.EntityID(monkEntityCharli),
+		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          10,
+		MaxHP:       10,
+		AC:          15,
+		AttackBonus: 5, // DEX +3 + proficiency +2
+		DamageDice:  "1d4+3",
+		DamageType:  "bludgeoning",
+	}))
+
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID:          encountercore.EntityID(monkGoblinID),
+		Position:    encountercore.Hex{Q: 1, R: 0, S: -1},
+		HP:          100,
+		MaxHP:       100,
+		AC:          15,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+	}))
+
+	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
+}
+
+// advanceToCharli cycles initiative until charli is the active actor.
+func (s *MonkUnarmedIntegrationSuite) advanceToCharli() {
+	for range 20 {
+		data, err := s.repo.Get(context.Background(), monkIntegEncID)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(data.Initiative, "initiative must be rolled")
+
+		if data.ActiveIdx < 0 || data.ActiveIdx >= len(data.Initiative) {
+			s.Fail("invalid ActiveIdx", data.ActiveIdx)
+		}
+		activeID := string(data.Initiative[data.ActiveIdx])
+
+		if activeID == monkEntityCharli {
+			return
+		}
+
+		if activeID == monkGoblinID {
+			enc, loadErr := tkenc.LoadFromData(data, s.broker)
+			s.Require().NoError(loadErr)
+			_, _, err = enc.EndTurn(encountercore.EntityID(activeID))
+			s.Require().NoError(err)
+			s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
+			continue
+		}
+
+		// Any other player's turn — end via handler with charli's context as fallback.
+		_, err = s.handler.EndTurn(s.charliCtx, &encounterv2pb.EndTurnRequest{
+			EncounterId: monkIntegEncID,
+			EntityId:    activeID,
+		})
+		s.Require().NoError(err, "EndTurn for actor %q must succeed", activeID)
+	}
+	s.Fail("advanceToCharli: charli did not become active within 20 initiative steps")
+}

--- a/internal/orchestrators/character/mock/mock_service.go
+++ b/internal/orchestrators/character/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 	gomock "go.uber.org/mock/gomock"
+
+	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/dice/mock/mock_service.go
+++ b/internal/orchestrators/dice/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 	gomock "go.uber.org/mock/gomock"
+
+	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/encounter/mock/mock_service.go
+++ b/internal/orchestrators/encounter/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounter "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 	gomock "go.uber.org/mock/gomock"
+
+	encounter "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/processors/event/mock/mock_processor.go
+++ b/internal/processors/event/mock/mock_processor.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	event "github.com/KirkDiggler/rpg-api/internal/processors/event"
 	gomock "go.uber.org/mock/gomock"
+
+	event "github.com/KirkDiggler/rpg-api/internal/processors/event"
 )
 
 // MockProcessor is a mock of Processor interface.

--- a/internal/publishers/encounter/mock/mock_publisher.go
+++ b/internal/publishers/encounter/mock/mock_publisher.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounter "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
 	gomock "go.uber.org/mock/gomock"
+
+	encounter "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
 )
 
 // MockPublisher is a mock of Publisher interface.

--- a/internal/repositories/character/mock/mock_repository.go
+++ b/internal/repositories/character/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	gomock "go.uber.org/mock/gomock"
+
+	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/character_draft/mock/mock_repository.go
+++ b/internal/repositories/character_draft/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 	gomock "go.uber.org/mock/gomock"
+
+	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dice_session/mock/mock_repository.go
+++ b/internal/repositories/dice_session/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 	gomock "go.uber.org/mock/gomock"
+
+	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dungeons/mock/mock_repository.go
+++ b/internal/repositories/dungeons/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dungeons "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
 	gomock "go.uber.org/mock/gomock"
+
+	dungeons "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/encounterlog/mock/mock_repository.go
+++ b/internal/repositories/encounterlog/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounterlog "github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog"
 	gomock "go.uber.org/mock/gomock"
+
+	encounterlog "github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/encounters/mock/mock_repository.go
+++ b/internal/repositories/encounters/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	encounters "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 	gomock "go.uber.org/mock/gomock"
+
+	encounters "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/services/sandboxroom/mock/mock_service.go
+++ b/internal/services/sandboxroom/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
 	gomock "go.uber.org/mock/gomock"
+
+	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
 )
 
 // MockService is a mock of Service interface.


### PR DESCRIPTION
## Summary

- Adds `--fixture=wave-2-monk` to devseed: charli (L1 monk, DEX 16/WIS 14/CON 14, HP 10, AC 15, no weapon) with `MartialArts` + `UnarmoredDefense` conditions persisted, goblin adjacent at Q:1 R:0 S:-1
- Adds `TestMonkUnarmedIntegrationSuite` in `internal/handlers/dnd5e/v2/encounter/` proving unarmed strike routes through MartialArts: DEX mod (+3) used instead of STR (+0), 1d4 die applied, `dnd5e:abilities:dex` source present in `DamageDealtEvent.Components`
- Fixes root bug: `buildEncounterCharacterRegistryFromResolved` called `reg.Add` (weapons) but never `reg.AddAbilityScores`. `MartialArtsCondition` got `nil` from `registry.GetCharacterAbilityScores` and silently no-op'd the DEX swap and 1d4 replacement. Fix adds `characterToGamectxAbilityScores` helper + `AddAbilityScores` calls for attacker and target — no toolkit changes needed.

Closes #559
Closes #560
Part of #558

## Test plan

- [ ] `go test ./internal/handlers/dnd5e/v2/encounter/... -run TestMonkUnarmedIntegration -v` — all 3 tests pass
- [ ] `go build ./cmd/devseed/...` — clean build
- [ ] `TestIntegration_MartialArts_DamageBreakdown_HasDEXAbilityComponent` — asserts `dnd5e:abilities:dex` in components (definitive DEX-path proof)
- [ ] `TestIntegration_MartialArts_UnarmedStrikeUsesDEX` — asserts HP delta in range [3,7] (DEX+1d4)
- [ ] `TestIntegration_MartialArts_DoesNotCrashWithGamectx` — smoke test, no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)