### PR TITLE
feat(encounter/v2): populate Entity.armor_class in snapshot (#562)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-28
+updated: 2026-05-29
 confidence: high — Wave 2 Monk entries verified against passing integration tests
 ---
 
@@ -10,6 +10,13 @@ confidence: high — Wave 2 Monk entries verified against passing integration te
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**Chapter 2 Wave 2 (monk) — Entity.armor_class populated in v2 snapshot (2026-05-29)** —
+`ProjectFor` now sets `Entity.armor_class` for both players (`PlayerData.AC`) and monsters
+(`MonsterData.AC`) when the value is non-zero. Charli's AC=15 (UnarmoredDefense) and the
+goblin's AC=15 flow through the snapshot wire so the playtest harness can render them (closes #562).
+Two new `ProjectSuite` tests: `TestProjectFor_PlayerEntityCarriesArmorClass` (charli AC=15)
+and an assertion on `TestProjectFor_TurnBased_EmitsModeTurnStateAndMonsters` (goblin AC=15).
 
 **Chapter 2 Wave 2 (monk) — devseed fixture + v2 unarmed-strike integration test (2026-05-28)** —
 `--fixture=wave-2-monk` seeds charli (L1 monk, DEX 16/WIS 14/CON 14, HP 10, AC 15, no weapon,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-api
 go 1.25.3
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260527223626-3a5e2bc47447
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260529032123-8974685f9fcb
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260527223626-3a5e2bc47447 h1:mUAa1bQ/5qdLbsvzsf+cWaxLJtLbn6g7/+ADFyg1oJY=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260527223626-3a5e2bc47447/go.mod h1:z4Ka1UqEslbSHcldcYvysxeer8uosHun7Dz9Iji2PFw=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260529032123-8974685f9fcb h1:2vthaC6JdiJhv0qp4ZFpQBp6CyfXlDzr6tMLWcNi/P8=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260529032123-8974685f9fcb/go.mod h1:z4Ka1UqEslbSHcldcYvysxeer8uosHun7Dz9Iji2PFw=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -107,7 +107,7 @@ func ProjectFor(
 		if visibleNow == nil || !visibleNow.Has(m.Position) {
 			continue
 		}
-		entities = append(entities, &encounterv2pb.Entity{
+		me := &encounterv2pb.Entity{
 			Id:       string(m.ID),
 			Position: HexToPosition(m.Position),
 			Type:     encounterv2pb.EntityType_ENTITY_TYPE_MONSTER,
@@ -120,7 +120,12 @@ func ProjectFor(
 					MonsterRef: monsterRefFor(m.MonsterRef),
 				},
 			},
-		})
+		}
+		if m.AC > 0 {
+			ac := int32(m.AC)
+			me.ArmorClass = &ac
+		}
+		entities = append(entities, me)
 	}
 
 	return &encounterv2pb.Encounter{
@@ -172,7 +177,7 @@ func buildTurnState(data *tkenc.Data) *encounterv2pb.TurnState {
 // rationale (we don't want to couple ProjectFor to the character orchestrator
 // for a thin enrichment).
 func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
-	return &encounterv2pb.Entity{
+	e := &encounterv2pb.Entity{
 		Id:       string(pd.EntityID),
 		Position: HexToPosition(pos),
 		Type:     encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER,
@@ -186,6 +191,11 @@ func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
 			},
 		},
 	}
+	if pd.AC > 0 {
+		ac := int32(pd.AC)
+		e.ArmorClass = &ac
+	}
+	return e
 }
 
 // monsterRefFor builds a proto Ref for a toolkit monster-ref string.

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -132,6 +132,10 @@ func (s *ProjectSuite) TestProjectFor_TurnBased_EmitsModeTurnStateAndMonsters() 
 	s.Require().Equal("dnd5e", ref.GetModule())
 	s.Require().Equal("monsters", ref.GetType())
 	s.Require().Equal("goblin", ref.GetId())
+
+	// ArmorClass is populated from MonsterData.AC (#562).
+	s.Require().NotNil(gob.ArmorClass, "monster entity must carry armor_class when MonsterData.AC > 0")
+	s.Require().Equal(int32(15), gob.GetArmorClass(), "armor_class must match MonsterData.AC")
 }
 
 func (s *ProjectSuite) TestProjectFor_TurnBased_SkipsMonsterOutsideLOS() {
@@ -365,6 +369,36 @@ func (s *ProjectSuite) TestProjectFor_PlayerEntitiesCarryTypeHpAndCharacterData(
 	bc := b.GetCharacter()
 	s.Require().NotNil(bc, "visible other-player must carry CharacterData oneof")
 	s.Require().Equal("player-bob", bc.GetPlayerId())
+}
+
+func (s *ProjectSuite) TestProjectFor_PlayerEntityCarriesArmorClass() {
+	// Charli is a L1 monk with AC=15 (UnarmoredDefense). The v2 Entity envelope
+	// must carry armor_class=15 so the playtest harness can render it (#562).
+	data := tkenc.NewData("enc-ac")
+	data.Mode = core.ModeTurnBased
+	data.Round = 1
+	data.ActiveIdx = 0
+	data.Initiative = []core.EntityID{"char-charli"}
+
+	charli := newPlayerData("player-charli", "char-charli", originHex, 3)
+	charli.HP = 10
+	charli.MaxHP = 10
+	charli.AC = 15
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-charli": charli}
+
+	pb, err := v2encounter.ProjectFor(data, "player-charli", s.broker, s.now)
+	s.Require().NoError(err)
+
+	var found *encounterv2pb.Entity
+	for _, e := range pb.GetSpace().GetEntities() {
+		if e.GetId() == "char-charli" {
+			found = e
+			break
+		}
+	}
+	s.Require().NotNil(found, "charli must be in the snapshot")
+	s.Require().NotNil(found.ArmorClass, "player entity must carry armor_class when PlayerData.AC > 0")
+	s.Require().Equal(int32(15), found.GetArmorClass(), "armor_class must equal PlayerData.AC")
 }
 
 func (s *ProjectSuite) TestProjectFor_MonsterRef_TooManyColonsTreatedAsMalformed() {


### PR DESCRIPTION
Closes #562
Part of #558

## What

`ProjectFor` now sets `Entity.armor_class` for both players (`PlayerData.AC`) and monsters (`MonsterData.AC`) when the value is non-zero.

- `playerEntity()` sets `ArmorClass` from `PlayerData.AC` (charli's UnarmoredDefense AC=15)
- monster entity emit sets `ArmorClass` from `MonsterData.AC` (goblin's AC=15)
- Bumps `rpg-api-protos/gen/go` to `8974685f9fcb` (the `generated` branch commit that added field 7 `armor_class` as optional int32)

## Tests

Two new `ProjectSuite` assertions:
- `TestProjectFor_PlayerEntityCarriesArmorClass` — charli with `PlayerData.AC=15` projects to `entity.armor_class=15`
- `TestProjectFor_TurnBased_EmitsModeTurnStateAndMonsters` — extended to assert goblin's `MonsterData.AC=15` projects to `entity.armor_class=15`

All 11 `ProjectSuite` tests pass.