### PR TITLE
feat(encounter/v2): orchestrator skeleton + carve Interact onto it — #582 step 1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,14 +40,19 @@ linters:
     depguard:
       rules:
         # Architecture invariant: the core action-verb handler files in the v2
-        # encounter package must never import rpg-toolkit rulebook internals
-        # (conditions, resources, classes, weapons, armor). All rule logic belongs
-        # in the toolkit; rpg-api is a thin shuttle. If you need one of these types
-        # in a handler file, you are about to add business logic — stop and push
+        # encounter package AND the v2 encounter orchestrator method files must
+        # never import rpg-toolkit rulebook internals (conditions, resources,
+        # classes, weapons, armor). All rule logic belongs in the toolkit; rpg-api
+        # is a thin shuttle. If you need one of these types in a handler or
+        # orchestrator file, you are about to add business logic — stop and push
         # the logic into the toolkit instead.
         #
-        # Scope: action-verb handler files only (activate_feature, take_action,
-        # end_turn, interact, submit_check, handler, create, get, project).
+        # Scope:
+        #   - action-verb handler files (activate_feature, take_action, end_turn,
+        #     interact, submit_check, handler, create, get)
+        #   - the v2 encounter orchestrator method files (orchestrator, load,
+        #     interact) under internal/orchestrators/encounter/v2 (rpg-api#582):
+        #     load → toolkit-verb → persist, by reference only.
         # Excludes: combat/movement resolver files (translate held entities → the
         # rulebook chain; legitimately import combat/character/monster/weapons),
         # hydrate_players.go (marshals the character blob for the SDK cascade),
@@ -68,6 +73,12 @@ linters:
             - "**/internal/handlers/dnd5e/v2/encounter/handler.go"
             - "**/internal/handlers/dnd5e/v2/encounter/create.go"
             - "**/internal/handlers/dnd5e/v2/encounter/get.go"
+            # v2 encounter orchestrator method files (#582). NOT the resolver
+            # adapters — those live in the handler package and legitimately
+            # import the rulebook as a translation seam.
+            - "**/internal/orchestrators/encounter/v2/orchestrator.go"
+            - "**/internal/orchestrators/encounter/v2/load.go"
+            - "**/internal/orchestrators/encounter/v2/interact.go"
           deny:
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
               desc: "game logic belongs in the toolkit — do not import dnd5e conditions in action handler files"

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -12,6 +12,7 @@ import (
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
@@ -49,6 +50,10 @@ type Handler struct {
 	// LoadFromData per RPC so the "modifier ID already exists" double-subscribe
 	// class is structurally impossible. Used by ActivateFeature.
 	runner *Runner
+	// orch is the v2 encounter orchestrator (rpg-api#582 carve-out). Verbs move
+	// onto it one at a time (Sequencing B); the handler method becomes a thin
+	// proto↔input map + sentinel→gRPC status mapping. Interact is carved first.
+	orch *encounterorch.Orchestrator
 }
 
 // New constructs a Handler. Returns error on missing required deps.
@@ -106,7 +111,7 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 		MovementResolverConfig: movementResolverConfig,
 	})
 
-	return &Handler{
+	h := &Handler{
 		broker:                 cfg.Broker,
 		encRepo:                cfg.Repo,
 		resolver:               resolver,
@@ -115,7 +120,29 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 		movementResolverConfig: movementResolverConfig,
 		now:                    now,
 		runner:                 runner,
-	}, nil
+	}
+
+	// v2 encounter orchestrator (#582). The handler supplies its existing
+	// per-request resolver builders so the orchestrator stays free of rulebook
+	// imports — the rulebook-importing Dnd5eCombatResolver / Dnd5eMovementResolver
+	// adapters are built here and handed in behind interface-typed builders.
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:              cfg.Broker,
+		EncounterRepo:       cfg.Repo,
+		CharacterRepo:       combatResolverConfig.CharacterRepo,
+		Resolver:            resolver,
+		BuildCombatResolver: h.buildCombatResolver,
+		BuildMovementResolver: func(data *encounter.Data) encounter.MovementResolver {
+			return h.buildMovementResolver(data)
+		},
+		Now: now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build encounter orchestrator: %w", err)
+	}
+	h.orch = orch
+
+	return h, nil
 }
 
 // buildCombatResolver returns the combat resolver for a given request.

--- a/internal/handlers/dnd5e/v2/encounter/handler_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler_test.go
@@ -410,9 +410,12 @@ func (s *HandlerSuite) TestInteract_DoorAlreadyOpen_FailedPrecondition() {
 	s.Require().Equal(codes.FailedPrecondition, st.Code())
 }
 
-func (s *HandlerSuite) TestInteract_PlayerNotInEncounter_FailedPrecondition() {
-	// Encounter has a door but no player-A. Toolkit OpenDoor refuses the
-	// player-not-in-encounter case as a state-dependent error.
+func (s *HandlerSuite) TestInteract_PlayerNotInEncounter_PermissionDenied() {
+	// Encounter has a door but no player-A. The #582 orchestrator carve added
+	// the upfront membership check to the shared load path, so Interact now maps
+	// player-not-in-encounter to PermissionDenied — consistent with MoveEntity,
+	// EndTurn, and the Runner (all of which already do this). Previously Interact
+	// was the outlier, falling through to the toolkit's FailedPrecondition.
 	enc := tkenc.New(context.Background(), "enc-no-player", s.broker)
 	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, false)
 	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
@@ -423,7 +426,7 @@ func (s *HandlerSuite) TestInteract_PlayerNotInEncounter_FailedPrecondition() {
 	})
 	s.Require().Error(err)
 	st, _ := status.FromError(err)
-	s.Require().Equal(codes.FailedPrecondition, st.Code())
+	s.Require().Equal(codes.PermissionDenied, st.Code())
 }
 
 func (s *HandlerSuite) TestInteract_OpenDoor_HappyPath() {

--- a/internal/handlers/dnd5e/v2/encounter/interact.go
+++ b/internal/handlers/dnd5e/v2/encounter/interact.go
@@ -9,36 +9,32 @@ import (
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
-	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// Interact handles the Interact RPC. Wave 2.7 wired the unlocked-door path
-// (toolkit OpenDoor verb dispatched directly). Wave 2.9 adds the locked-door
-// path: when the target door has Locked: true, the handler issues a
-// per-player skill-check prompt via the toolkit's AttemptUnlock verb and
-// returns the prompt to the caller as InputRequired{skill_check} on the
-// response. The caller then resolves the prompt by calling SubmitCheck with
-// a d20 roll.
+// Interact handles the Interact RPC. It validates the request envelope,
+// delegates door routing + dispatch to the v2 orchestrator, and translates the
+// orchestrator's result (and sentinel errors) back to proto.
 //
-// Future waves extend the dispatch to chests, levers, NPCs, and traps; the
-// optional interaction_kind field is plumbed through the proto for that
-// future routing but is unused today.
+// The orchestrator owns the load → classify door → AttemptUnlock/OpenDoor →
+// persist flow (#582 carve-out). This handler stays thin: proto↔input mapping
+// plus interactStatusError for the sentinel→gRPC code mapping.
 //
-// Behavior contract:
+// Behavior contract (preserved across the carve):
 //   - missing auth → Unauthenticated
 //   - empty encounter_id / target_entity_id → InvalidArgument
 //   - encounter not in repo → NotFound
 //   - target is not a known door in this encounter → NotFound
-//   - door is locked → AttemptUnlock issues a prompt; response carries
-//     InputRequired{skill_check}; persistence captures PendingPrompts so
-//     the prompt survives reconnect. Stream sees no event (caller-private).
+//   - door is locked → response carries InputRequired{skill_check}; the
+//     pending prompt is persisted so it survives reconnect; no broker event
+//     (caller-private)
 //   - door is unlocked → OpenDoor publishes per-viewer DoorOpened +
-//     GeometryRevealed; response is empty by proto design.
+//     GeometryRevealed; response is empty by proto design
 //   - toolkit OpenDoor / AttemptUnlock refuses (player not in encounter,
 //     door already open, prompt already pending, etc.) → FailedPrecondition
-//     per pat-v2-status-code-mapping.
+//     per pat-v2-status-code-mapping
 //   - save failure → Internal
 func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractRequest) (*encounterv2pb.InteractResponse, error) {
 	playerID := auth.GetPlayerID(ctx)
@@ -52,92 +48,62 @@ func (h *Handler) Interact(ctx context.Context, req *encounterv2pb.InteractReque
 		return nil, status.Error(codes.InvalidArgument, "target_entity_id is required")
 	}
 
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	out, err := h.orch.Interact(ctx, &encounterorch.InteractInput{
+		EncounterID:    req.GetEncounterId(),
+		PlayerID:       core.PlayerID(playerID),
+		TargetEntityID: core.EntityID(req.GetTargetEntityId()),
+	})
 	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
+		return nil, interactStatusError(err)
 	}
 
-	// Wave 2.7/2.9 dispatch: only door interactions are wired. Future waves
-	// add chests, levers, NPCs, traps via additional lookups + dispatch arms.
-	targetID := core.EntityID(req.GetTargetEntityId())
-	door, ok := data.Doors[targetID]
-	if !ok {
-		return nil, status.Error(codes.NotFound, "target entity is not a door, or door does not exist")
+	resp := &encounterv2pb.InteractResponse{}
+	if out.Prompt != nil {
+		resp.InputRequired = buildSkillCheckPrompt(*out.Prompt)
 	}
+	return resp, nil
+}
 
-	// #689: LoadFromData now takes ctx and owns the hydration cascade. The
-	// door verbs don't touch combatant state, so no player DataJSON is attached
-	// here — the cascade skips hydration (seats without DataJSON) and the door
-	// verbs operate on the Data snapshot directly.
-	enc, err := encounter.LoadFromData(ctx, data, h.broker,
-		encounter.WithCharacterResolver(h.resolver),
-		encounter.WithCombatResolver(h.buildCombatResolver(data)),
-		encounter.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
+// interactStatusError maps the orchestrator's Interact errors onto gRPC status
+// codes. Orchestrator sentinels carry the entity-layer classification; this
+// proto-layer mapper assigns the gRPC code per pat-v2-status-code-mapping.
+//
+//   - ErrEncounterNotFound / ErrTargetNotADoor → NotFound
+//   - ErrPlayerNotInEncounter → PermissionDenied
+//   - ErrDoorNotLocked (door state inconsistent with the just-read snapshot) →
+//     Internal — we routed on a Locked door but the toolkit reported unlocked
+//   - any other AttemptUnlock / OpenDoor refusal (player not in encounter at the
+//     verb level, door already open, prompt already pending) → FailedPrecondition
+//   - load / save / wrapped internal failures → Internal
+func interactStatusError(err error) error {
+	switch {
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrTargetNotADoor):
+		return status.Error(codes.NotFound, "target entity is not a door, or door does not exist")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounter.ErrPromptAlreadyPending):
+		return status.Error(codes.FailedPrecondition,
+			"resolve the pending prompt before issuing another action")
+	case errors.Is(err, encounter.ErrDoorNotLocked):
+		// Defensive: the orchestrator routed on door.Locked == true, so the
+		// toolkit reporting "not locked" means the persisted snapshot is
+		// inconsistent with the loaded encounter.
+		return status.Errorf(codes.Internal, "locked-door dispatch refused as not-locked: %v", err)
+	case errors.Is(err, encounterorch.ErrDoorVerbRefused):
+		// Player not in encounter / door not in encounter / door already open —
+		// state-dependent verb refusals map to FailedPrecondition.
+		return status.Errorf(codes.FailedPrecondition, "%v", err)
 	}
-
-	// Locked-door branch (Wave 2.9): issue a per-player skill-check prompt
-	// via the toolkit's AttemptUnlock verb. The prompt is persisted to
-	// data.PendingPrompts so the caller can resolve it later via SubmitCheck;
-	// no broker event is emitted (prompts are caller-private).
-	if door.Locked {
-		issued, unlockErr := enc.AttemptUnlock(core.PlayerID(playerID), targetID)
-		if unlockErr != nil {
-			switch {
-			case errors.Is(unlockErr, encounter.ErrPromptAlreadyPending):
-				return nil, status.Error(codes.FailedPrecondition,
-					"resolve the pending prompt before issuing another action")
-			case errors.Is(unlockErr, encounter.ErrDoorNotLocked):
-				// Defensive: we just checked door.Locked. If toolkit reports
-				// unlocked the persisted snapshot is inconsistent with the
-				// loaded encounter — surface as Internal.
-				return nil, status.Errorf(codes.Internal,
-					"locked-door dispatch refused as not-locked: %v", unlockErr)
-			default:
-				// Player not in encounter, door not in encounter, etc. — these
-				// are state-dependent and map to FailedPrecondition per
-				// pat-v2-status-code-mapping. AttemptUnlock wraps these with
-				// fmt.Errorf rather than sentinels, so the default arm covers
-				// the long tail.
-				return nil, status.Errorf(codes.FailedPrecondition, "attempt unlock: %v", unlockErr)
-			}
-		}
-
-		if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
-			return nil, status.Errorf(codes.Internal,
-				"save encounter %q after attempt unlock: %v", req.GetEncounterId(), err)
-		}
-
-		return &encounterv2pb.InteractResponse{
-			InputRequired: buildSkillCheckPrompt(issued),
-		}, nil
-	}
-
-	// Unlocked-door branch (Wave 2.7): dispatch directly to OpenDoor.
-	if err := enc.OpenDoor(core.PlayerID(playerID), targetID); err != nil {
-		// Toolkit OpenDoor errors are state-dependent (player not in
-		// encounter, door already open) — these are gRPC FailedPrecondition
-		// per pat-v2-status-code-mapping. The request is syntactically
-		// valid but the world state forbids the action.
-		return nil, status.Errorf(codes.FailedPrecondition, "open door: %v", err)
-	}
-
-	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
-		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	return &encounterv2pb.InteractResponse{}, nil
+	return status.Errorf(codes.Internal, "interact: %v", err)
 }
 
 // buildSkillCheckPrompt translates the toolkit's PromptIssued verb-return
 // into the proto wire shape InputRequired{skill_check}. The tool ref is
 // optional (empty when no tool proficiency applies); we surface it as a
 // nullable Ref so the client can render thieves'-tools-or-not without a
-// separate flag.
+// separate flag. Proto translation — stays handler-side.
 func buildSkillCheckPrompt(issued encounter.PromptIssued) *encounterv2pb.InputRequired {
 	prompt := &encounterv2pb.SkillCheckPrompt{
 		Dc:      int32(issued.DC), //nolint:gosec // DC is bounded by ruleset, never overflows int32

--- a/internal/orchestrators/encounter/v2/interact.go
+++ b/internal/orchestrators/encounter/v2/interact.go
@@ -1,0 +1,144 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ErrTargetNotADoor means the Interact target id is not a door in this
+// encounter. Handler maps to codes.NotFound. (Today only door interactions are
+// wired; future interaction kinds — chests, levers, NPCs, traps — add their own
+// lookups and classifications here.)
+var ErrTargetNotADoor = errors.New("target entity is not a door, or door does not exist")
+
+// ErrDoorVerbRefused wraps a state-dependent refusal from a toolkit door verb
+// (AttemptUnlock / OpenDoor) that is not one of the recognized sentinels —
+// e.g. player not in encounter at the verb level, door already open. The
+// toolkit returns these as plain fmt.Errorf rather than sentinels, so the
+// orchestrator wraps them in this sentinel and the handler maps it to
+// codes.FailedPrecondition per pat-v2-status-code-mapping. The recognized
+// sentinels (ErrDoorNotLocked, ErrPromptAlreadyPending) pass through unwrapped
+// so the handler can map them distinctly.
+var ErrDoorVerbRefused = errors.New("door interaction refused")
+
+// InteractInput carries the entity-typed Interact request. The handler builds
+// it from the proto request after envelope validation.
+type InteractInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player performing the interaction.
+	PlayerID core.PlayerID
+
+	// TargetEntityID is the entity being interacted with (today: a door).
+	TargetEntityID core.EntityID
+}
+
+// InteractOutput is the lean result of an Interact. World changes flow as
+// broker events (DoorOpened / HexRevealed), not in this output. The only
+// caller-private payload is the skill-check prompt issued when the target door
+// is locked.
+type InteractOutput struct {
+	// Prompt carries the toolkit's PromptIssued when the target door was locked
+	// and AttemptUnlock issued a per-player skill-check prompt. The handler
+	// translates it to the proto InputRequired{skill_check} wire shape.
+	Prompt *tkenc.PromptIssued
+}
+
+// Interact routes a door interaction: load the encounter, classify the target
+// door (locked vs unlocked), dispatch the matching toolkit verb (AttemptUnlock
+// for locked, OpenDoor for unlocked), and persist.
+//
+// Door routing is the orchestrator's job by design, not a toolkit rule: the SDK
+// does NOT gate OpenDoor on Locked (see encounter.DoorData docs — "Locked is the
+// orchestrator's flag; orchestrators check Locked and route to AttemptUnlock").
+// So reading door.Locked here is orchestration, not rules logic.
+//
+// Door state is read through the encounter's own synced snapshot (enc.ToData()),
+// not a parallel *Data fetched alongside load — there is no public door accessor
+// on *Encounter today (a toolkit gap worth a getter, but not blocking: ToData()
+// is the sanctioned "ask the encounter for its state" surface and is the same
+// snapshot persisted on Save).
+func (o *Orchestrator) Interact(ctx context.Context, in *InteractInput) (*InteractOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: InteractInput is required")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		// Door interactions act on a target, not the player's own entity, so no
+		// entity-ownership check. Membership is still verified by load.
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Classify the target via the encounter's synced snapshot. Only door
+	// interactions are wired today; a non-door target is ErrTargetNotADoor.
+	data := enc.ToData()
+	door, ok := data.Doors[in.TargetEntityID]
+	if !ok {
+		return nil, ErrTargetNotADoor
+	}
+
+	// Locked-door branch: issue a per-player skill-check prompt. The prompt is
+	// persisted on the encounter snapshot so the caller can resolve it later via
+	// SubmitCheck; no broker event is emitted (prompts are caller-private).
+	if door.Locked {
+		issued, unlockErr := enc.AttemptUnlock(in.PlayerID, in.TargetEntityID)
+		if unlockErr != nil {
+			return nil, wrapDoorVerbErr("attempt unlock", unlockErr)
+		}
+		if err := o.persist(ctx, enc, in.EncounterID); err != nil {
+			return nil, err
+		}
+		return &InteractOutput{Prompt: &issued}, nil
+	}
+
+	// Unlocked-door branch: dispatch directly to OpenDoor (publishes per-viewer
+	// DoorOpened + GeometryRevealed events to the broker).
+	if err := enc.OpenDoor(in.PlayerID, in.TargetEntityID); err != nil {
+		return nil, wrapDoorVerbErr("open door", err)
+	}
+	if err := o.persist(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+	return &InteractOutput{}, nil
+}
+
+// wrapDoorVerbErr classifies a toolkit door-verb error for the handler's status
+// mapping. Recognized sentinels (ErrDoorNotLocked, ErrPromptAlreadyPending) are
+// preserved (still wrapped with op context) so errors.Is keeps matching them in
+// the handler. Everything else — the toolkit's plain fmt.Errorf state refusals —
+// is additionally joined with ErrDoorVerbRefused so the handler maps it to
+// FailedPrecondition without string matching.
+func wrapDoorVerbErr(op string, err error) error {
+	if errors.Is(err, tkenc.ErrDoorNotLocked) || errors.Is(err, tkenc.ErrPromptAlreadyPending) {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return fmt.Errorf("%s: %w: %w", op, ErrDoorVerbRefused, err)
+}
+
+// persist writes the encounter's synced snapshot back to the repo, checking the
+// ToData write-back cascade for serialization errors first. A non-nil SyncErr
+// means a held entity failed to re-serialize into its DataJSON, so the snapshot
+// would carry stale state — surface it rather than persisting silently.
+//
+// For the door verbs no combatants are hydrated (no DataJSON attached), so the
+// cascade is a no-op and SyncErr is nil; the check is correctness hygiene shared
+// by every verb that lands on this orchestrator.
+func (o *Orchestrator) persist(ctx context.Context, enc *tkenc.Encounter, encID string) error {
+	out := enc.ToData()
+	if syncErr := enc.SyncErr(); syncErr != nil {
+		return fmt.Errorf("sync encounter state %q: %w", encID, syncErr)
+	}
+	if err := o.encRepo.Save(ctx, out); err != nil {
+		return fmt.Errorf("save encounter %q: %w", encID, err)
+	}
+	return nil
+}

--- a/internal/orchestrators/encounter/v2/interact_test.go
+++ b/internal/orchestrators/encounter/v2/interact_test.go
@@ -1,0 +1,192 @@
+package encounter_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+type InteractSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *InteractSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		// No combat / movement resolver behavior is exercised by the door verbs,
+		// but the orchestrator requires the builders to be present. Return the
+		// toolkit zero-value interfaces (nil) — Interact never invokes them.
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// stubCharacterResolver satisfies tkenc.CharacterResolver with zero modifiers;
+// the door verbs never call it, but Config.Resolver is required.
+type stubCharacterResolver struct{}
+
+func (stubCharacterResolver) AbilityModifier(_ core.PlayerID, _ string) (int, bool) { return 0, true }
+func (stubCharacterResolver) ToolProficiencyBonus(_ core.PlayerID, _ string) (int, bool) {
+	return 0, true
+}
+
+// seedUnlockedDoor persists an encounter with player-A adjacent to an unlocked
+// door so OpenDoor can publish a per-viewer slice (the viewer must see the
+// door's hex).
+func (s *InteractSuite) seedUnlockedDoor(encID, doorID string) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   "player-A",
+		EntityID:   "char-A",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 4,
+	}))
+	enc.AddDoor(core.EntityID(doorID), core.Hex{Q: 1, R: 0, S: -1}, false)
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+}
+
+// seedLockedDoor persists an encounter with player-A adjacent to a locked door.
+func (s *InteractSuite) seedLockedDoor(encID, doorID string, dc int, ability, tool string) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   "player-A",
+		EntityID:   "char-A",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 4,
+	}))
+	enc.AddDoor(core.EntityID(doorID), core.Hex{Q: 1, R: 0, S: -1}, false)
+	data := enc.ToData()
+	door := data.Doors[core.EntityID(doorID)]
+	door.Locked = true
+	door.LockDC = dc
+	door.LockAbility = ability
+	door.LockTool = tool
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+}
+
+func (s *InteractSuite) interact(encID, target string) (*encounterorch.InteractOutput, error) {
+	return s.orch.Interact(s.ctx, &encounterorch.InteractInput{
+		EncounterID:    encID,
+		PlayerID:       "player-A",
+		TargetEntityID: core.EntityID(target),
+	})
+}
+
+// --- load preconditions ---
+
+func (s *InteractSuite) TestInteract_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.interact("nope", "door-east")
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *InteractSuite) TestInteract_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-no-player", s.broker)
+	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, false)
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.interact("enc-no-player", "door-east")
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+// --- door classification ---
+
+func (s *InteractSuite) TestInteract_TargetNotADoor_ErrTargetNotADoor() {
+	s.seedUnlockedDoor("enc-no-door", "door-east")
+	_, err := s.interact("enc-no-door", "not-a-door")
+	s.Require().ErrorIs(err, encounterorch.ErrTargetNotADoor)
+}
+
+// --- unlocked-door happy path ---
+
+func (s *InteractSuite) TestInteract_OpenDoor_OpensAndPersists() {
+	s.seedUnlockedDoor("enc-open", "door-east")
+
+	out, err := s.interact("enc-open", "door-east")
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+	s.Require().Nil(out.Prompt, "unlocked door must not issue a prompt")
+
+	loaded, err := s.repo.Get(s.ctx, "enc-open")
+	s.Require().NoError(err)
+	door, ok := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(ok, "door must remain in persisted Doors map")
+	s.Require().True(door.Open, "door must be persisted as Open")
+}
+
+func (s *InteractSuite) TestInteract_DoorAlreadyOpen_ErrDoorVerbRefused() {
+	enc := tkenc.New(s.ctx, "enc-already-open", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	enc.AddDoor("door-east", core.Hex{Q: 1, R: 0, S: -1}, true) // already open
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.interact("enc-already-open", "door-east")
+	s.Require().ErrorIs(err, encounterorch.ErrDoorVerbRefused)
+}
+
+// --- locked-door path ---
+
+func (s *InteractSuite) TestInteract_LockedDoor_IssuesPromptAndPersists() {
+	s.seedLockedDoor("enc-locked", "door-east", 15, "DEX", "dnd5e:item:thieves-tools")
+
+	out, err := s.interact("enc-locked", "door-east")
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Prompt, "locked door must issue a skill-check prompt")
+	s.Require().Equal(15, out.Prompt.DC)
+	s.Require().Equal("DEX", out.Prompt.Ability)
+	s.Require().Equal("dnd5e:item:thieves-tools", out.Prompt.Tool)
+
+	// Pending prompt persisted so SubmitCheck can resolve it; door stays closed.
+	loaded, err := s.repo.Get(s.ctx, "enc-locked")
+	s.Require().NoError(err)
+	s.Require().Contains(loaded.PendingPrompts, core.PlayerID("player-A"))
+	door := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(door.Locked)
+	s.Require().False(door.Open)
+}
+
+func (s *InteractSuite) TestInteract_LockedDoor_PromptCollision_ErrPromptAlreadyPending() {
+	s.seedLockedDoor("enc-collide", "door-east", 15, "DEX", "")
+
+	_, err := s.interact("enc-collide", "door-east")
+	s.Require().NoError(err)
+
+	// Second call with an outstanding prompt must be refused with the toolkit's
+	// ErrPromptAlreadyPending sentinel passed through (the handler maps it
+	// distinctly from generic verb refusals).
+	_, err = s.interact("enc-collide", "door-east")
+	s.Require().ErrorIs(err, tkenc.ErrPromptAlreadyPending)
+	s.Require().False(errors.Is(err, encounterorch.ErrDoorVerbRefused),
+		"recognized sentinels must NOT also be wrapped as generic verb refusals")
+}
+
+func TestInteractSuite(t *testing.T) {
+	suite.Run(t, new(InteractSuite))
+}

--- a/internal/orchestrators/encounter/v2/load.go
+++ b/internal/orchestrators/encounter/v2/load.go
@@ -1,0 +1,87 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// Orchestrator-level sentinel errors. These are entity-layer classifications;
+// the thin handler maps them onto gRPC status codes (proto-layer concern). The
+// orchestrator never imports proto, so it must surface these as typed sentinels
+// rather than status.Error.
+var (
+	// ErrEncounterNotFound means the encounter id has no stored snapshot.
+	// Handler maps to codes.NotFound.
+	ErrEncounterNotFound = errors.New("encounter not found")
+
+	// ErrPlayerNotInEncounter means the authenticated player is not a member of
+	// the encounter. Handler maps to codes.PermissionDenied.
+	ErrPlayerNotInEncounter = errors.New("player is not in this encounter")
+
+	// ErrEntityOwnershipMismatch means the player asked to act with an entity
+	// they do not control. Handler maps to codes.PermissionDenied.
+	ErrEntityOwnershipMismatch = errors.New("entity does not match player's controlled entity")
+)
+
+// loadInput carries the per-request load context.
+type loadInput struct {
+	// EncounterID identifies the encounter snapshot to load.
+	EncounterID string
+
+	// PlayerID is the authenticated player making the request. Membership is
+	// always verified against this id.
+	PlayerID core.PlayerID
+
+	// EntityID is the entity the player claims to control. When non-empty, load
+	// verifies the encounter maps PlayerID → EntityID and returns
+	// ErrEntityOwnershipMismatch otherwise. Empty skips the ownership check
+	// (read-path / door verbs that act on a target rather than the actor).
+	EntityID string
+}
+
+// load is the single load core: Get the snapshot → verify membership (and
+// optional entity ownership) from the snapshot BEFORE rehydration → LoadFromData
+// onto the broker bus with the resolvers wired uniformly.
+//
+// It returns ONLY the encounter (2 returns, no side *Data): the encounter is
+// the synced state — verbs read entities and orchestration state through it and
+// persist via enc.ToData(). Returning a parallel *Data snapshot would invite
+// drift between it and the held entities.
+//
+// Auth checks read data.Players directly and run before LoadFromData so the
+// auth-fail path does not pay rehydration cost.
+func (o *Orchestrator) load(ctx context.Context, in loadInput) (*tkenc.Encounter, error) {
+	data, err := o.encRepo.Get(ctx, in.EncounterID)
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, ErrEncounterNotFound
+		}
+		return nil, fmt.Errorf("load encounter %q: %w", in.EncounterID, err)
+	}
+
+	pd, ok := data.Players[in.PlayerID]
+	if !ok {
+		return nil, ErrPlayerNotInEncounter
+	}
+	if in.EntityID != "" && string(pd.EntityID) != in.EntityID {
+		return nil, ErrEntityOwnershipMismatch
+	}
+
+	// Resolvers are wired uniformly on every load, mirroring the handler today.
+	// The dice roller is carried inside the resolver configs (the builders), not
+	// passed as a separate WithRoller option — keeping a single roller source per
+	// the "one representation" rule rather than a parallel encounter-level roller.
+	enc, err := tkenc.LoadFromData(ctx, data, o.broker,
+		tkenc.WithCharacterResolver(o.resolver),
+		tkenc.WithCombatResolver(o.buildCombatResolver(data)),
+		tkenc.WithMovementResolver(o.buildMovementResolver(data)))
+	if err != nil {
+		return nil, fmt.Errorf("load encounter from data %q: %w", in.EncounterID, err)
+	}
+	return enc, nil
+}

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -1,0 +1,139 @@
+// Package encounter is the v1alpha2 encounter orchestrator: the single
+// load → toolkit-verb → persist core for the v2 encounter vertical.
+//
+// It is the clean replacement for the handler-package Runner + the inline
+// verb bodies (rpg-api#582). The orchestrator speaks entity / toolkit types
+// only — it NEVER imports proto (pb.*). The thin v2 encounter handler converts
+// proto ↔ these Input/Output types and maps the orchestrator's sentinel errors
+// onto gRPC status codes; the orchestrator owns load, the toolkit verb call,
+// and persistence.
+//
+// Boundary: NO rules logic lives here. The orchestrator routes by reference and
+// orchestrates load/verb/save; all game mechanics live in the rpg-toolkit
+// encounter SDK and the dnd5e rulebook (reached only through the combat /
+// movement resolver adapters). If something here starts to feel rule-ish (a
+// tier table, an AC computation, a "can this fire" decision), it belongs in the
+// toolkit or a resolver adapter — surface it, do not inline it.
+package encounter
+
+import (
+	"errors"
+	"time"
+
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+)
+
+// CombatResolver is the toolkit's combat resolver interface. The orchestrator
+// wires an implementation onto every LoadFromData so attack-resolving verbs can
+// dispatch through it. Aliased here so the orchestrator package references a
+// single name regardless of which implementation is supplied.
+type CombatResolver = tkenc.CombatResolver
+
+// CharacterResolver is the toolkit's character resolver interface (ability
+// modifier / tool-proficiency lookups for skill checks). Aliased for the same
+// reason as CombatResolver.
+type CharacterResolver = tkenc.CharacterResolver
+
+// CombatResolverBuilder builds a per-request CombatResolver from the encounter
+// data. The handler supplies this so the orchestrator stays free of rulebook
+// imports: the concrete Dnd5eCombatResolver (which legitimately imports the
+// dnd5e rulebook as a translation adapter) is constructed handler-side and
+// handed in as a builder. When a fixed resolver override is present (tests),
+// the builder returns it directly.
+type CombatResolverBuilder func(data *tkenc.Data) CombatResolver
+
+// MovementResolverBuilder builds a per-request movement resolver from the
+// encounter data. Same rationale as CombatResolverBuilder — the concrete
+// Dnd5eMovementResolver is a rulebook-importing adapter built handler-side.
+//
+// The return type is the toolkit MovementResolver interface so the orchestrator
+// never imports the dnd5e rulebook movement adapter.
+type MovementResolverBuilder func(data *tkenc.Data) tkenc.MovementResolver
+
+// Config holds the dependencies for an Orchestrator.
+type Config struct {
+	// Broker is the encounter event broker. Required.
+	Broker *tkenc.Broker
+
+	// EncounterRepo persists encounter snapshots. Required.
+	EncounterRepo encountersv2.Repository
+
+	// CharacterRepo provides player character lookup for the hydration cascade
+	// (attach/persist of transient PlayerData.DataJSON on combat-capable verbs).
+	// Optional — when nil, combat-capable verbs fall back to the resolver
+	// stand-in path. The door verbs (Interact) do not use it.
+	CharacterRepo characterrepo.Repository
+
+	// Resolver bridges the toolkit's CharacterResolver to the character store
+	// for skill-check totals. Required (the handler supplies a stub default).
+	Resolver CharacterResolver
+
+	// BuildCombatResolver builds the per-request combat resolver. Required.
+	BuildCombatResolver CombatResolverBuilder
+
+	// BuildMovementResolver builds the per-request movement resolver. Required.
+	BuildMovementResolver MovementResolverBuilder
+
+	// Now supplies the current time. Optional — defaults to time.Now.
+	//
+	// Not used by the door verbs (Interact); reserved for the projection /
+	// snapshot read path carved in later steps of #582.
+	Now func() time.Time
+}
+
+// Orchestrator is the v2 encounter load → verb → persist core. Construct via
+// New. One method per encounter RPC; each does exactly one load + one
+// toolkit-verb dispatch + one persist (the single-load guarantee that makes the
+// #684 double-subscribe class structurally impossible).
+type Orchestrator struct {
+	broker  *tkenc.Broker
+	encRepo encountersv2.Repository
+	// charRepo and now are wired now but unused by the door verbs (Interact).
+	// They are required by the combat-capable verbs (attach/persist of transient
+	// PlayerData.DataJSON) and the projection/snapshot read path carved in later
+	// steps of #582 — held here so the Config surface and ctor are stable as
+	// those verbs land, rather than re-threading per verb.
+	charRepo              characterrepo.Repository
+	resolver              CharacterResolver
+	buildCombatResolver   CombatResolverBuilder
+	buildMovementResolver MovementResolverBuilder
+	now                   func() time.Time
+}
+
+// New constructs an Orchestrator from cfg. Returns an error (never a nil
+// Orchestrator) when a required dependency is missing.
+func New(cfg *Config) (*Orchestrator, error) {
+	if cfg == nil {
+		return nil, errors.New("encounter orchestrator: Config is required")
+	}
+	if cfg.Broker == nil {
+		return nil, errors.New("encounter orchestrator: Config.Broker is required")
+	}
+	if cfg.EncounterRepo == nil {
+		return nil, errors.New("encounter orchestrator: Config.EncounterRepo is required")
+	}
+	if cfg.Resolver == nil {
+		return nil, errors.New("encounter orchestrator: Config.Resolver is required")
+	}
+	if cfg.BuildCombatResolver == nil {
+		return nil, errors.New("encounter orchestrator: Config.BuildCombatResolver is required")
+	}
+	if cfg.BuildMovementResolver == nil {
+		return nil, errors.New("encounter orchestrator: Config.BuildMovementResolver is required")
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Orchestrator{
+		broker:                cfg.Broker,
+		encRepo:               cfg.EncounterRepo,
+		charRepo:              cfg.CharacterRepo,
+		resolver:              cfg.Resolver,
+		buildCombatResolver:   cfg.BuildCombatResolver,
+		buildMovementResolver: cfg.BuildMovementResolver,
+		now:                   now,
+	}, nil
+}


### PR DESCRIPTION
## Chunk 2, step 1 of the encounter orchestrator carve-out (Part of #582)

First step of the #582 carve-out (full carve, Sequencing B): stand up the dedicated `internal/orchestrators/encounter/v2` package and move the **first verb — Interact** — onto it, thinning the handler to proto↔input mapping + sentinel→gRPC status mapping. Per the aligned plan (`ideas/encounter/v1alpha2/plans/11-582-encounter-orchestrator.md`), the EndTurn pause-for-reaction wire-serialization is **deferred** (EndTurn is the last verb, a later step).

### Orchestrator skeleton
- `Orchestrator` struct + `Config` + `New` ctor (validates required deps; never returns a nil orchestrator).
- Private **`load(ctx, loadInput) (*tkenc.Encounter, error)` — 2 returns, NO side `*Data`**: `Get` (NotFound map) → membership + optional entity-ownership check from the snapshot **before** `LoadFromData` → `LoadFromData` with the combat/movement resolvers wired uniformly (same as the handler does today). Verbs read state through the encounter; the drift-prone parallel `*Data` is gone.
- The rulebook-importing `Dnd5eCombatResolver` / `Dnd5eMovementResolver` adapters stay in the handler package; the orchestrator receives them behind interface-typed builders (`CombatResolverBuilder` / `MovementResolverBuilder`) so it **never imports the rulebook**.

### Interact carve
- `Orchestrator.Interact` = `load → classify door (Locked vs unlocked) → AttemptUnlock / OpenDoor → persist` (with `SyncErr` check). Door routing is the orchestrator's job by SDK design (`encounter.DoorData` docs: "Locked is the orchestrator's flag"), not a rule — read through `enc.ToData()`. Returns the toolkit `PromptIssued` in a lean Output; no proto in the orchestrator.
- Entity-layer sentinels (`ErrEncounterNotFound`, `ErrPlayerNotInEncounter`, `ErrTargetNotADoor`, `ErrDoorVerbRefused`) + preservation of the toolkit's `ErrDoorNotLocked` / `ErrPromptAlreadyPending`; the handler's `interactStatusError` maps them to gRPC codes.
- Handler `interact.go` inline body **deleted**; `buildSkillCheckPrompt` / `parseToolkitRef` (proto translation) stay handler-side.

### One intentional behavior change
Player-not-in-encounter on Interact now maps to **PermissionDenied** (via the shared `load` membership check) instead of falling through to the toolkit's FailedPrecondition. This aligns Interact with `MoveEntity` / `EndTurn` / the Runner, which all already do the upfront membership check — Interact was the outlier. Test updated + renamed to document it.

### depguard
The orchestrator method files (`orchestrator.go` / `load.go` / `interact.go`) are added to the rulebook-deny set; the resolver adapters are deliberately **NOT** (legit translation seam). Verified the guard fires on a rulebook import in the orchestrator package.

### Verification
- `go build ./...` clean; full `go test ./...` green.
- New orchestrator-level suite (load preconditions, door classification, open / locked→prompt / collision / already-open refusal) + existing handler Interact tests pass.
- v2 orchestrator + v2 encounter handler packages lint clean (0 issues). The repo-wide `make ci-check` flags pre-existing lint debt in unrelated v1alpha1/legacy files and the known #580/#583 local-mockgen import-grouping drift — neither introduced here nor enforced by the GitHub CI workflow (which runs `make generate` + tests).

### Playtest-verifiable
Door open + locked-door-attempt path is unchanged on the wire — verifiable end-to-end (open a door / attempt a locked door, both browsers see the events / the skill-check prompt).

Part of #582