### PR TITLE
feat(encounter/v2): carve SubmitCheck onto the orchestrator (#582 step 2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,11 +51,15 @@ linters:
         #   - action-verb handler files (activate_feature, take_action, end_turn,
         #     interact, submit_check, handler, create, get)
         #   - the v2 encounter orchestrator method files (orchestrator, load,
-        #     interact) under internal/orchestrators/encounter/v2 (rpg-api#582):
+        #     interact, submit_check, submit_check_reaction) under
+        #     internal/orchestrators/encounter/v2 (rpg-api#582):
         #     load → toolkit-verb → persist, by reference only.
         # Excludes: combat/movement resolver files (translate held entities → the
         # rulebook chain; legitimately import combat/character/monster/weapons),
         # hydrate_players.go (marshals the character blob for the SDK cascade),
+        # reaction_resume.go (the SubmitCheck take_reaction adapter seam: decodes
+        # the opaque combat.AttackContext blob + carries the Shield +5 AC
+        # magnitude — kept handler-side so the orchestrator stays rulebook-free),
         # tests. reaction_conditions.go is gone: OA now rides the toolkit's #689
         # hydration cascade, so rpg-api no longer constructs conditions.New* and
         # that depguard exclusion is retired.
@@ -79,6 +83,8 @@ linters:
             - "**/internal/orchestrators/encounter/v2/orchestrator.go"
             - "**/internal/orchestrators/encounter/v2/load.go"
             - "**/internal/orchestrators/encounter/v2/interact.go"
+            - "**/internal/orchestrators/encounter/v2/submit_check.go"
+            - "**/internal/orchestrators/encounter/v2/submit_check_reaction.go"
           deny:
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
               desc: "game logic belongs in the toolkit — do not import dnd5e conditions in action handler files"

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -151,6 +151,7 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 		ReactionResume: encounterorch.ReactionResume{
 			DecodeAttackContext:    decodeReactionAttackContext,
 			BuildReactionModifiers: buildReactionModifiers,
+			IsOneShotReaction:      isOneShotReaction,
 		},
 		Now: now,
 	})

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -126,14 +126,31 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 	// per-request resolver builders so the orchestrator stays free of rulebook
 	// imports — the rulebook-importing Dnd5eCombatResolver / Dnd5eMovementResolver
 	// adapters are built here and handed in behind interface-typed builders.
+	// The #689 hydration cascade and the reaction-resume rulebook decode/
+	// modifier-build are supplied as funcs so the orchestrator stays free of the
+	// rulebooks/dnd5e/{character,combat} imports — the marshaling + rule
+	// magnitudes (Shield +5 AC) live in this handler package's adapter seam
+	// (hydrate_players.go, reaction_resume.go).
+	charRepo := combatResolverConfig.CharacterRepo
 	orch, err := encounterorch.New(&encounterorch.Config{
 		Broker:              cfg.Broker,
 		EncounterRepo:       cfg.Repo,
-		CharacterRepo:       combatResolverConfig.CharacterRepo,
 		Resolver:            resolver,
 		BuildCombatResolver: h.buildCombatResolver,
 		BuildMovementResolver: func(data *encounter.Data) encounter.MovementResolver {
 			return h.buildMovementResolver(data)
+		},
+		CharacterData: encounterorch.CharacterDataCascade{
+			Attach: func(ctx context.Context, data *encounter.Data) error {
+				return attachPlayerCharacterData(ctx, data, charRepo)
+			},
+			Persist: func(ctx context.Context, data *encounter.Data) error {
+				return persistPlayerCharacterData(ctx, data, charRepo)
+			},
+		},
+		ReactionResume: encounterorch.ReactionResume{
+			DecodeAttackContext:    decodeReactionAttackContext,
+			BuildReactionModifiers: buildReactionModifiers,
 		},
 		Now: now,
 	})

--- a/internal/handlers/dnd5e/v2/encounter/reaction_resume.go
+++ b/internal/handlers/dnd5e/v2/encounter/reaction_resume.go
@@ -73,3 +73,13 @@ func buildReactionModifiers(prompt *tkenc.PendingReactionPrompt, take bool) []tk
 	}
 	return nil
 }
+
+// isOneShotReaction decides whether a taken reaction consumes its readiness (the
+// reactor must re-ready before the next window) vs. stays ready. This is a
+// rulebook decision — Shield is a spell that costs a reaction + slot, so a taken
+// Shield is one-shot; an opportunity attack is a free reaction that stays ready.
+// Kept handler-side so the orchestrator stays free of per-condition ref
+// knowledge (the orchestrator only performs the toolkit readiness-reset call).
+func isOneShotReaction(conditionRef string) bool {
+	return conditionRef == reactionShieldRef
+}

--- a/internal/handlers/dnd5e/v2/encounter/reaction_resume.go
+++ b/internal/handlers/dnd5e/v2/encounter/reaction_resume.go
@@ -1,0 +1,75 @@
+package encounter
+
+// reaction_resume.go — the rulebook-touching adapter seam for the SubmitCheck
+// take_reaction branch.
+//
+// The v2 orchestrator runs phase-2 reaction completion (CompleteTakeAction) but
+// stays free of the dnd5e combat rulebook import. The two rule-ish pieces it
+// needs are supplied here as funcs and wired into encounterorch.Config:
+//
+//   - decodeReactionAttackContext: unmarshals the persisted opaque
+//     AttackContextJSON back into the toolkit's PhasedAttackContext, whose
+//     Rulebook slot holds the resolver's native *combat.AttackContext.
+//   - buildReactionModifiers: maps a pending prompt + take/skip choice to the
+//     ReactionModifier set, carrying the rule-ish Shield +5 AC magnitude.
+//
+// This file is intentionally OUTSIDE the depguard no-rulebook-internals set: it
+// is a translation adapter (like the combat / movement resolvers), not an
+// orchestrator method. It imports rulebooks/dnd5e/combat to interpret the opaque
+// attack-context blob the resolver wrote in phase 1.
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// shieldACBonus is the AC bonus the Shield spell applies in phase 2 when taken.
+// Mirrors the rulebook's Shield magnitude (combat does not export a named const;
+// see combat/attack_phases.go "typically +5 for Shield"). Lives in this adapter
+// seam, NOT in the orchestrator — it is a rule magnitude.
+const shieldACBonus = 5
+
+// reactionShieldRef is the canonical Shield spell condition ref used to select
+// the Shield modifier band.
+const reactionShieldRef = "dnd5e:spells:shield"
+
+// decodeReactionAttackContext unmarshals the persisted opaque AttackContextJSON
+// (written by the phased combat resolver in phase 1) into the toolkit's
+// PhasedAttackContext. The Rulebook slot carries the resolver's native
+// *combat.AttackContext, which CompleteTakeAction passes back to
+// ApplyAttackOutcome. AttackerID / TargetID are mirrored so the SDK can route
+// phase 2 without inspecting the opaque payload.
+func decodeReactionAttackContext(raw []byte) (*tkenc.PhasedAttackContext, error) {
+	rulebookCtx := &combat.AttackContext{}
+	if err := json.Unmarshal(raw, rulebookCtx); err != nil {
+		return nil, fmt.Errorf("unmarshal attack context: %w", err)
+	}
+	return &tkenc.PhasedAttackContext{
+		Rulebook:   rulebookCtx,
+		AttackerID: core.EntityID(rulebookCtx.AttackerID),
+		TargetID:   core.EntityID(rulebookCtx.TargetID),
+	}, nil
+}
+
+// buildReactionModifiers maps a pending reaction prompt + take/skip choice to
+// the ReactionModifier slice for phase 2. When take is false (skip), or the
+// prompt's condition is not a modifier-style reaction, it returns no modifiers.
+//
+// Today only Shield contributes a modifier (OA is a separate attack, not a
+// modifier on the in-flight attack). When the second modifier-style reaction
+// lands, add a case here.
+func buildReactionModifiers(prompt *tkenc.PendingReactionPrompt, take bool) []tkenc.ReactionModifier {
+	if !take || prompt == nil {
+		return nil
+	}
+	if prompt.ConditionRef == reactionShieldRef {
+		return []tkenc.ReactionModifier{
+			{ConditionRef: prompt.ConditionRef, ACBonus: shieldACBonus},
+		}
+	}
+	return nil
+}

--- a/internal/handlers/dnd5e/v2/encounter/submit_check.go
+++ b/internal/handlers/dnd5e/v2/encounter/submit_check.go
@@ -9,48 +9,49 @@ import (
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
-	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
-	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// d20 roll bounds — defense-in-depth alongside the toolkit's
-// ErrInvalidRoll, so we surface InvalidArgument before reaching the verb.
+// d20 roll bounds — defense-in-depth alongside the toolkit's ErrInvalidRoll, so
+// we surface InvalidArgument before reaching the verb.
 const (
 	minD20Roll = 1
 	maxD20Roll = 20
 )
 
-// SubmitCheck handles the SubmitCheck RPC: it resolves the caller's currently
-// pending InputRequired prompt against a supplied d20 roll. The toolkit owns
-// modifier resolution (via the wired CharacterResolver) and any side-effect
-// dispatch on success — for Wave 2.9 the only wired action is "open" on a
-// locked door, which the toolkit dispatches to OpenDoor internally; that
-// publishes DoorOpened + GeometryRevealed through the broker the same way
-// Wave 2.7 did.
+// SubmitCheck handles the SubmitCheck RPC. It validates the request envelope,
+// delegates skill-check resolution (or the take_reaction branch) to the v2
+// orchestrator, and translates the result (and sentinel errors) back to proto.
 //
-// Behavior contract:
+// The orchestrator owns the load → SubmitCheck verb → persist flow (#582
+// carve-out). The toolkit owns modifier resolution (via the wired
+// CharacterResolver) and any success side-effect dispatch — for the locked-door
+// case the wired action is "open", which the toolkit dispatches to OpenDoor
+// internally (publishing DoorOpened + GeometryRevealed through the broker). This
+// handler stays thin: proto↔input mapping plus submitCheckStatusError.
+//
+// Behavior contract (preserved across the carve):
 //   - missing auth → Unauthenticated
 //   - empty encounter_id / entity_id → InvalidArgument
-//   - roll outside [1, 20] → InvalidArgument (defense in depth before
-//     the toolkit also checks; surfaces a clearer error to the client)
+//   - take_reaction set → routes to the reaction branch (the roll is ignored;
+//     reaction prompts don't carry a d20 roll)
+//   - roll outside [1, 20] → InvalidArgument (defense in depth before the
+//     toolkit also checks; clearer error to the client)
 //   - encounter not in repo → NotFound
-//   - caller is not a member of the encounter → PermissionDenied
-//   - entity_id does not match caller's controlled entity →
-//     PermissionDenied (mirrors MoveEntity / EndTurn / TakeAction)
+//   - caller not a member / entity_id mismatch → PermissionDenied
 //   - no pending prompt → FailedPrecondition
-//   - prompt is not a skill check → FailedPrecondition (other prompt
-//     kinds resolve via different verbs in future waves)
-//   - prompt's TriggeredAction is not wired in this toolkit version →
-//     Unimplemented
-//   - encounter has no character resolver → Internal (the orchestrator
+//   - prompt is not a skill check → FailedPrecondition
+//   - prompt's TriggeredAction not wired → Unimplemented
+//   - encounter has no character resolver → Internal (orchestrator
 //     misconfigured itself; the resolver is wired by HandlerConfig)
-//   - save failure → Internal
+//   - roll rejected by toolkit (range disagreement) → InvalidArgument
+//   - dispatch / save failure → Internal
 //
-// On success the response carries the resolved total (roll + ability
-// modifier + tool-proficiency bonus) and a boolean indicating whether
-// total >= prompt DC. World effects flow as broker events on the existing
-// StreamEncounter session — the response itself does not include them.
+// On success the response carries the resolved total (roll + ability modifier +
+// tool-proficiency bonus) and a boolean for total ≥ DC. World effects flow as
+// broker events on the existing StreamEncounter session.
 func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitCheckRequest) (*encounterv2pb.SubmitCheckResponse, error) {
 	playerID := auth.GetPlayerID(ctx)
 	if playerID == "" {
@@ -62,9 +63,9 @@ func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitChec
 	if req.GetEntityId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "entity_id is required")
 	}
-	// Wave 2.11d: take_reaction is the reaction-prompt response semantic.
-	// When set, route to the phased completion path; the roll field is
-	// ignored (reaction prompts don't carry a d20 roll).
+	// take_reaction is the reaction-prompt response semantic. When set, route to
+	// the reaction branch; the roll field is ignored (reaction prompts don't
+	// carry a d20 roll).
 	if req.TakeReaction != nil {
 		return h.submitReactionCheck(ctx, req, playerID)
 	}
@@ -74,88 +75,65 @@ func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitChec
 			req.GetRoll(), minD20Roll, maxD20Roll)
 	}
 
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	out, err := h.orch.SubmitCheck(ctx, &encounterorch.SubmitCheckInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+		EntityID:    req.GetEntityId(),
+		Roll:        int(req.GetRoll()),
+	})
 	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal,
-			"load encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	// Authorization: the caller must be a member of this encounter and the
-	// supplied entity_id must match their controlled entity. Mirrors the
-	// pattern used by MoveEntity / EndTurn / TakeAction so a caller cannot
-	// resolve a prompt that doesn't belong to them (defense in depth — the
-	// toolkit already keys PendingPrompts by playerID, so a non-member would
-	// hit ErrNoPendingPrompt anyway, but PermissionDenied is the clearer
-	// signal and prevents leaking encounter membership through the FailedPrecondition
-	// vs PermissionDenied distinction).
-	pd, ok := data.Players[core.PlayerID(playerID)]
-	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
-	}
-	if string(pd.EntityID) != req.GetEntityId() {
-		return nil, status.Error(codes.PermissionDenied,
-			"entity_id does not match player's controlled entity")
-	}
-
-	// #689: skill-check resolution doesn't touch combatant state; no player
-	// DataJSON is attached, so the cascade skips hydration. ctx threaded for
-	// the new LoadFromData signature.
-	enc, err := tkenc.LoadFromData(ctx, data, h.broker,
-		tkenc.WithCharacterResolver(h.resolver),
-		tkenc.WithCombatResolver(h.buildCombatResolver(data)),
-		tkenc.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"load from data %q: %v", req.GetEncounterId(), err)
-	}
-
-	result, submitErr := enc.SubmitCheck(core.PlayerID(playerID), int(req.GetRoll()))
-	if submitErr != nil {
-		switch {
-		case errors.Is(submitErr, tkenc.ErrNoPendingPrompt):
-			return nil, status.Error(codes.FailedPrecondition,
-				"no pending prompt to resolve for caller")
-		case errors.Is(submitErr, tkenc.ErrPromptKindMismatch):
-			return nil, status.Error(codes.FailedPrecondition,
-				"pending prompt is not a skill check")
-		case errors.Is(submitErr, tkenc.ErrInvalidRoll):
-			// Defense in depth: handler-side bounds check above should have
-			// caught this. If it didn't, the toolkit's range disagrees with
-			// ours — still InvalidArgument from the client's perspective.
-			return nil, status.Errorf(codes.InvalidArgument,
-				"roll rejected by toolkit: %v", submitErr)
-		case errors.Is(submitErr, tkenc.ErrUnsupportedPromptAction):
-			return nil, status.Errorf(codes.Unimplemented,
-				"prompt action not supported in this server version: %v", submitErr)
-		case errors.Is(submitErr, tkenc.ErrNoCharacterResolver):
-			// The handler always wires a resolver (StubCharacterResolver as
-			// default). Reaching this means the orchestrator rebuilt the
-			// encounter without going through HandlerConfig — surface as
-			// Internal.
-			return nil, status.Errorf(codes.Internal,
-				"encounter has no character resolver wired: %v", submitErr)
-		default:
-			// Resolution-proceeded-but-dispatch-failed cases (downstream
-			// OpenDoor failures) wrap with fmt.Errorf rather than sentinels.
-			// The check itself succeeded (Success=true is reported in result)
-			// but the side effect failed; the prompt has been cleared by the
-			// toolkit. Surface as Internal so the client knows the world
-			// state may be inconsistent.
-			return nil, status.Errorf(codes.Internal,
-				"submit check dispatch: %v", submitErr)
-		}
-	}
-
-	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"save encounter %q after submit check: %v", req.GetEncounterId(), err)
+		return nil, submitCheckStatusError(err)
 	}
 
 	return &encounterv2pb.SubmitCheckResponse{
-		Success: result.Success,
-		Total:   int32(result.Total), //nolint:gosec // total is roll(1-20)+small mods, fits int32
+		Success: out.Success,
+		Total:   int32(out.Total), //nolint:gosec // total is roll(1-20)+small mods, fits int32
 	}, nil
+}
+
+// submitCheckStatusError maps the orchestrator's SubmitCheck errors onto gRPC
+// status codes per pat-v2-status-code-mapping. Orchestrator load sentinels and
+// the toolkit verb sentinels (surfaced unwrapped by the orchestrator) carry the
+// classification; this proto-layer mapper assigns the code.
+//
+//   - ErrEncounterNotFound → NotFound
+//   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
+//   - ErrNoPendingPrompt / ErrPromptKindMismatch → FailedPrecondition
+//   - ErrInvalidRoll → InvalidArgument (range disagreement vs the handler bound)
+//   - ErrUnsupportedPromptAction → Unimplemented
+//   - ErrNoCharacterResolver / ErrSubmitCheckDispatch / load+save failures →
+//     Internal
+func submitCheckStatusError(err error) error {
+	switch {
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounterorch.ErrEntityOwnershipMismatch):
+		return status.Error(codes.PermissionDenied,
+			"entity_id does not match player's controlled entity")
+	case errors.Is(err, encounter.ErrNoPendingPrompt):
+		return status.Error(codes.FailedPrecondition,
+			"no pending prompt to resolve for caller")
+	case errors.Is(err, encounter.ErrPromptKindMismatch):
+		return status.Error(codes.FailedPrecondition,
+			"pending prompt is not a skill check")
+	case errors.Is(err, encounter.ErrInvalidRoll):
+		// Defense in depth: the handler-side bounds check should have caught
+		// this. Reaching it means the toolkit's range disagrees with ours —
+		// still InvalidArgument from the client's perspective.
+		return status.Errorf(codes.InvalidArgument, "roll rejected by toolkit: %v", err)
+	case errors.Is(err, encounter.ErrUnsupportedPromptAction):
+		return status.Errorf(codes.Unimplemented,
+			"prompt action not supported in this server version: %v", err)
+	case errors.Is(err, encounter.ErrNoCharacterResolver):
+		// The handler always wires a resolver (StubCharacterResolver default).
+		// Reaching this means the orchestrator rebuilt the encounter without the
+		// resolver — surface as Internal.
+		return status.Errorf(codes.Internal,
+			"encounter has no character resolver wired: %v", err)
+	}
+	// ErrSubmitCheckDispatch (resolution succeeded, side effect failed) + load /
+	// save / unclassified failures.
+	return status.Errorf(codes.Internal, "submit check: %v", err)
 }

--- a/internal/handlers/dnd5e/v2/encounter/submit_check_reaction.go
+++ b/internal/handlers/dnd5e/v2/encounter/submit_check_reaction.go
@@ -1,175 +1,84 @@
 package encounter
 
-// Wave 2.11d — SubmitCheck{take_reaction} branch.
+// submit_check_reaction.go — the SubmitCheck{take_reaction} branch.
 //
-// When the caller's pending prompt is a ReactionPrompt (set by TakeAction's
-// phased path), SubmitCheck routes here instead of the skill-check verb.
-// Builds ReactionModifiers from the take/skip choice, calls
-// Encounter.CompleteTakeAction to run phase 2, clears the pending prompt,
-// and persists the snapshot.
+// When the caller's pending prompt is a reaction prompt (set by TakeAction's
+// phased path / an NPCAct pause), SubmitCheck routes here. This handler is thin:
+// validate the take/skip choice, delegate the phase-2 reaction completion to the
+// v2 orchestrator (#582 carve-out), and map the result + sentinel errors back to
+// proto. The rule-ish pieces (the opaque AttackContext decode, the per-condition
+// ReactionModifier magnitudes such as Shield +5 AC) live in the injected
+// ReactionResume funcs wired in handler.New — see reaction_resume.go.
+//
+// INTERNAL single-RPC: this resolves a reaction prompt already persisted on the
+// snapshot; there is no cross-RPC wire-pause here (that is the deferred EndTurn
+// concern).
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
-	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
-	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 )
 
-// shieldACBonus is the AC bonus the Shield spell applies in phase 2 when
-// taken. Mirrors combat.ShieldACBonus from the rulebook to keep the
-// orchestrator's modifier construction self-contained.
-const shieldACBonus = 5
-
-// canonical condition refs for which Wave 2.11d builds reaction modifiers.
-const (
-	shieldRef = "dnd5e:spells:shield"
-)
-
-// submitReactionCheck handles the SubmitCheck{take_reaction} branch.
-//
-// Looks up the caller's pending reaction prompt; if take_reaction is true,
-// builds the corresponding ReactionModifier set; if false, runs phase 2
-// with no modifiers (skip). Either way, the prompt is cleared and the
-// snapshot persists.
+// submitReactionCheck handles the SubmitCheck{take_reaction} branch. The roll
+// is ignored on this path. On success the response carries Success=true (phase 2
+// ran) and Total = the reactor's choice (1 = took, 0 = skipped) for client
+// telemetry; the attack outcome flows as broker events.
 func (h *Handler) submitReactionCheck(
 	ctx context.Context,
 	req *encounterv2pb.SubmitCheckRequest,
 	playerID string,
 ) (*encounterv2pb.SubmitCheckResponse, error) {
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	out, err := h.orch.SubmitReactionCheck(ctx, &encounterorch.SubmitReactionCheckInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+		EntityID:    req.GetEntityId(),
+		Take:        req.GetTakeReaction(),
+	})
 	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal,
-			"load encounter %q: %v", req.GetEncounterId(), err)
+		return nil, submitReactionCheckStatusError(err)
 	}
 
-	pd, ok := data.Players[core.PlayerID(playerID)]
-	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
-	}
-	if string(pd.EntityID) != req.GetEntityId() {
-		return nil, status.Error(codes.PermissionDenied,
-			"entity_id does not match player's controlled entity")
-	}
-
-	prompt, ok := data.PendingReactionPrompts[core.PlayerID(playerID)]
-	if !ok || prompt == nil {
-		return nil, status.Error(codes.FailedPrecondition,
-			"no pending reaction prompt to resolve for caller")
-	}
-
-	// #689: attach player character blobs (transient) so the hydration cascade
-	// holds the combatants for the phase-2 resume.
-	if attachErr := attachPlayerCharacterData(ctx, data, h.combatResolverConfig.CharacterRepo); attachErr != nil {
-		return nil, status.Errorf(codes.Internal, "attach character data %q: %v", req.GetEncounterId(), attachErr)
-	}
-
-	enc, err := tkenc.LoadFromData(ctx, data, h.broker,
-		tkenc.WithCharacterResolver(h.resolver),
-		tkenc.WithCombatResolver(h.buildCombatResolver(data)),
-		tkenc.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
-	}
-
-	// Unmarshal the persisted AttackContext back into the rulebook shape.
-	rulebookCtx := &combat.AttackContext{}
-	if err := json.Unmarshal(prompt.AttackContextJSON, rulebookCtx); err != nil {
-		return nil, status.Errorf(codes.Internal, "unmarshal attack context: %v", err)
-	}
-	phasedCtx := &tkenc.PhasedAttackContext{
-		Rulebook:   rulebookCtx,
-		AttackerID: core.EntityID(rulebookCtx.AttackerID),
-		TargetID:   core.EntityID(rulebookCtx.TargetID),
-	}
-
-	// Build modifiers from take/skip choice. Today only Shield is supported
-	// as a player-take reaction; OA is also a possible future ref but for
-	// 2.11d Wave OA auto-fires (NPC reactor inline) — player OA prompts
-	// land in this same code path once #650's OA-as-condition variant
-	// targets player reactors that can choose to skip. The switch is
-	// extensible for those follow-ups.
-	var modifiers []tkenc.ReactionModifier
-	if req.TakeReaction != nil && *req.TakeReaction {
-		modifiers = buildReactionModifiers(prompt)
-	}
-
-	// Run phase 2 with the chosen modifiers (or none if skipped).
-	if err := enc.CompleteTakeAction(phasedCtx, modifiers); err != nil {
-		return nil, status.Errorf(codes.Internal, "complete take action: %v", err)
-	}
-
-	// One-shot Shield: when the player takes a Shield reaction, clear the
-	// readiness flag so the wizard must re-ready before the next attack.
-	// Free reactions (OA) stay ready until explicitly toggled off.
-	if req.TakeReaction != nil && *req.TakeReaction && prompt.ConditionRef == shieldRef {
-		if setErr := enc.SetReactionReady(prompt.ReactorEntityID, prompt.ConditionRef, false); setErr != nil {
-			// Non-fatal — readiness state is best-effort housekeeping.
-			// The reaction already fired; logging-and-continuing is safer.
-			_ = setErr
-		}
-	}
-
-	enc.ClearPendingReactionPrompt(core.PlayerID(playerID))
-
-	out := enc.ToData()
-	if syncErr := enc.SyncErr(); syncErr != nil {
-		return nil, status.Errorf(codes.Internal, "sync encounter state %q: %v", req.GetEncounterId(), syncErr)
-	}
-	if persistErr := persistPlayerCharacterData(ctx, out, h.combatResolverConfig.CharacterRepo); persistErr != nil {
-		return nil, status.Errorf(codes.Internal, "persist character data %q: %v", req.GetEncounterId(), persistErr)
-	}
-	if err := h.encRepo.Save(ctx, out); err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"save encounter %q after reaction: %v", req.GetEncounterId(), err)
-	}
-
-	// Reaction responses don't carry a roll/total in the Wave 2.11d shape;
-	// the response Success indicates "phase 2 ran" and Total carries the
-	// reactor's choice (1 = took, 0 = skipped) for client telemetry.
 	return &encounterv2pb.SubmitCheckResponse{
 		Success: true,
-		Total:   reactionResponseTotal(req.TakeReaction),
+		Total:   reactionResponseTotal(out.TookReaction),
 	}, nil
 }
 
-// buildReactionModifiers translates a pending prompt into the rulebook
-// ReactionModifier slice for phase 2. Centralizes the per-condition modifier
-// shape so future reactions add a case here.
+// submitReactionCheckStatusError maps the orchestrator's SubmitReactionCheck
+// errors onto gRPC status codes per pat-v2-status-code-mapping.
 //
-// Today only Shield contributes a modifier (OA is a separate attack, not a
-// modifier on the in-flight attack). When the second modifier-style reaction
-// lands, convert this back to a switch.
-func buildReactionModifiers(prompt *tkenc.PendingReactionPrompt) []tkenc.ReactionModifier {
-	if prompt.ConditionRef == shieldRef {
-		return []tkenc.ReactionModifier{
-			{ConditionRef: prompt.ConditionRef, ACBonus: shieldACBonus},
-		}
+//   - ErrEncounterNotFound → NotFound
+//   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
+//   - ErrNoPendingReactionPrompt → FailedPrecondition
+//   - decode / CompleteTakeAction / cascade / save failures → Internal
+func submitReactionCheckStatusError(err error) error {
+	switch {
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounterorch.ErrEntityOwnershipMismatch):
+		return status.Error(codes.PermissionDenied,
+			"entity_id does not match player's controlled entity")
+	case errors.Is(err, encounterorch.ErrNoPendingReactionPrompt):
+		return status.Error(codes.FailedPrecondition,
+			"no pending reaction prompt to resolve for caller")
 	}
-	return nil
+	return status.Errorf(codes.Internal, "submit reaction check: %v", err)
 }
 
-// reactionResponseTotal maps a take/skip choice to a small int the client
-// can read for telemetry. take=1, skip=0. Helper exists so the take_reaction
-// nil-check is not duplicated at the callsite.
-func reactionResponseTotal(takeReaction *bool) int32 {
-	if takeReaction != nil && *takeReaction {
+// reactionResponseTotal maps a take/skip choice to a small int the client can
+// read for telemetry. take=1, skip=0.
+func reactionResponseTotal(took bool) int32 {
+	if took {
 		return 1
 	}
 	return 0
 }
-
-// compile-time check for fmt usage so unused-import doesn't trip if a
-// future change drops one of the formatted error sites.
-var _ = fmt.Sprintf

--- a/internal/orchestrators/encounter/v2/load.go
+++ b/internal/orchestrators/encounter/v2/load.go
@@ -42,6 +42,14 @@ type loadInput struct {
 	// ErrEntityOwnershipMismatch otherwise. Empty skips the ownership check
 	// (read-path / door verbs that act on a target rather than the actor).
 	EntityID string
+
+	// WithCharacterData requests the #689 hydration cascade: load attaches the
+	// transient PlayerData.DataJSON (via the injected CharacterData.Attach)
+	// BEFORE LoadFromData, so the held *character.Character is hydrated for each
+	// seat. Combat-capable verbs (the reaction-resume path) set this; the
+	// skill-check and door verbs leave it false (skill checks don't touch
+	// combatant state). No-op when no Attach func is wired.
+	WithCharacterData bool
 }
 
 // load is the single load core: Get the snapshot → verify membership (and
@@ -70,6 +78,17 @@ func (o *Orchestrator) load(ctx context.Context, in loadInput) (*tkenc.Encounter
 	}
 	if in.EntityID != "" && string(pd.EntityID) != in.EntityID {
 		return nil, ErrEntityOwnershipMismatch
+	}
+
+	// #689 hydration cascade: combat-capable verbs attach the transient
+	// PlayerData.DataJSON from the character store before LoadFromData rehydrates
+	// the held combatants. Runs after auth (no rehydration cost on the auth-fail
+	// path) and before LoadFromData (which consumes the DataJSON). No-op when no
+	// Attach func is wired (tests / non-combat verbs).
+	if in.WithCharacterData && o.characterData.Attach != nil {
+		if attachErr := o.characterData.Attach(ctx, data); attachErr != nil {
+			return nil, fmt.Errorf("attach character data %q: %w", in.EncounterID, attachErr)
+		}
 	}
 
 	// Resolvers are wired uniformly on every load, mirroring the handler today.

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -91,6 +91,14 @@ type ReactionResume struct {
 	// returns no modifiers. The rule-ish per-condition modifier magnitudes
 	// (Shield = +5 AC) live here, handler-side.
 	BuildReactionModifiers func(prompt *tkenc.PendingReactionPrompt, take bool) []tkenc.ReactionModifier
+
+	// IsOneShotReaction decides whether a taken reaction consumes its readiness
+	// (so the reactor must re-ready before the next window) vs. stays ready
+	// (free reactions like an opportunity attack). This is a rulebook decision —
+	// which reactions are one-shot — so it lives handler-side. The orchestrator
+	// only performs the readiness reset (a toolkit-flag bookkeeping call) when
+	// this returns true, keeping it free of any per-condition ref knowledge.
+	IsOneShotReaction func(conditionRef string) bool
 }
 
 // Config holds the dependencies for an Orchestrator.

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -17,10 +17,10 @@
 package encounter
 
 import (
+	"context"
 	"errors"
 	"time"
 
-	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 )
@@ -52,6 +52,47 @@ type CombatResolverBuilder func(data *tkenc.Data) CombatResolver
 // never imports the dnd5e rulebook movement adapter.
 type MovementResolverBuilder func(data *tkenc.Data) tkenc.MovementResolver
 
+// CharacterDataCascade attaches/persists the transient PlayerData.DataJSON for
+// the #689 hydration cascade on combat-capable verbs. The orchestrator calls
+// AttachCharacterData (before LoadFromData) and PersistCharacterData (after
+// ToData, before Save). The concrete implementations marshal the dnd5e
+// character blob, so they are supplied handler-side as funcs — the orchestrator
+// stays free of the rulebooks/dnd5e/character import (rule-ish serialization is
+// the handler/adapter's job, not the orchestrator's).
+//
+// Both funcs are no-ops when the handler has no character store wired (tests):
+// the door verbs never set loadInput.WithCharacterData, so the cascade is never
+// invoked on those paths.
+type CharacterDataCascade struct {
+	// Attach sets transient PlayerData.DataJSON on data from the character store,
+	// before LoadFromData hydrates the held *character.Character per seat.
+	Attach func(ctx context.Context, data *tkenc.Data) error
+
+	// Persist flushes each player's post-verb DataJSON back to the character
+	// store (the authoritative source) and clears it so it does not persist onto
+	// the encounter snapshot.
+	Persist func(ctx context.Context, data *tkenc.Data) error
+}
+
+// ReactionResume carries the rulebook-touching pieces of the SubmitCheck
+// take_reaction branch as injected funcs, so the orchestrator runs phase-2
+// reaction completion without importing the dnd5e combat rulebook. Both the
+// AttackContext decode (combat.AttackContext is the resolver's native opaque
+// shape) and the take/skip -> ReactionModifier mapping (which carries the
+// rule-ish Shield +5 AC magnitude) are supplied handler-side.
+type ReactionResume struct {
+	// DecodeAttackContext unmarshals the persisted opaque AttackContextJSON back
+	// into the toolkit's PhasedAttackContext (Rulebook = the resolver's native
+	// *combat.AttackContext). Returns an error on a corrupt blob.
+	DecodeAttackContext func(raw []byte) (*tkenc.PhasedAttackContext, error)
+
+	// BuildReactionModifiers maps a pending reaction prompt + take/skip choice
+	// to the ReactionModifier set for phase 2. When take is false (skip), it
+	// returns no modifiers. The rule-ish per-condition modifier magnitudes
+	// (Shield = +5 AC) live here, handler-side.
+	BuildReactionModifiers func(prompt *tkenc.PendingReactionPrompt, take bool) []tkenc.ReactionModifier
+}
+
 // Config holds the dependencies for an Orchestrator.
 type Config struct {
 	// Broker is the encounter event broker. Required.
@@ -59,12 +100,6 @@ type Config struct {
 
 	// EncounterRepo persists encounter snapshots. Required.
 	EncounterRepo encountersv2.Repository
-
-	// CharacterRepo provides player character lookup for the hydration cascade
-	// (attach/persist of transient PlayerData.DataJSON on combat-capable verbs).
-	// Optional — when nil, combat-capable verbs fall back to the resolver
-	// stand-in path. The door verbs (Interact) do not use it.
-	CharacterRepo characterrepo.Repository
 
 	// Resolver bridges the toolkit's CharacterResolver to the character store
 	// for skill-check totals. Required (the handler supplies a stub default).
@@ -75,6 +110,18 @@ type Config struct {
 
 	// BuildMovementResolver builds the per-request movement resolver. Required.
 	BuildMovementResolver MovementResolverBuilder
+
+	// CharacterData attaches/persists the transient #689 cascade DataJSON on
+	// combat-capable verbs. Optional — when the funcs are nil, combat-capable
+	// verbs run without the cascade (the resolver stand-in path), which keeps
+	// tests that don't wire a character store green. The door verbs (Interact)
+	// never invoke it.
+	CharacterData CharacterDataCascade
+
+	// ReactionResume carries the rulebook-touching funcs for the SubmitCheck
+	// take_reaction branch (AttackContext decode + modifier-building). Required
+	// for SubmitReactionCheck; the skill-check and door verbs do not use it.
+	ReactionResume ReactionResume
 
 	// Now supplies the current time. Optional — defaults to time.Now.
 	//
@@ -90,16 +137,18 @@ type Config struct {
 type Orchestrator struct {
 	broker  *tkenc.Broker
 	encRepo encountersv2.Repository
-	// charRepo and now are wired now but unused by the door verbs (Interact).
-	// They are required by the combat-capable verbs (attach/persist of transient
-	// PlayerData.DataJSON) and the projection/snapshot read path carved in later
-	// steps of #582 — held here so the Config surface and ctor are stable as
-	// those verbs land, rather than re-threading per verb.
-	charRepo              characterrepo.Repository
+	// now is wired now but unused by the door verbs (Interact); reserved for the
+	// projection / snapshot read path carved in later steps of #582.
 	resolver              CharacterResolver
 	buildCombatResolver   CombatResolverBuilder
 	buildMovementResolver MovementResolverBuilder
-	now                   func() time.Time
+	// characterData carries the #689 hydration cascade (attach/persist of
+	// transient PlayerData.DataJSON) for combat-capable verbs. The injected funcs
+	// hold the character store handler-side, so the orchestrator needs no direct
+	// character-repo handle of its own.
+	characterData  CharacterDataCascade
+	reactionResume ReactionResume
+	now            func() time.Time
 }
 
 // New constructs an Orchestrator from cfg. Returns an error (never a nil
@@ -130,10 +179,11 @@ func New(cfg *Config) (*Orchestrator, error) {
 	return &Orchestrator{
 		broker:                cfg.Broker,
 		encRepo:               cfg.EncounterRepo,
-		charRepo:              cfg.CharacterRepo,
 		resolver:              cfg.Resolver,
 		buildCombatResolver:   cfg.BuildCombatResolver,
 		buildMovementResolver: cfg.BuildMovementResolver,
+		characterData:         cfg.CharacterData,
+		reactionResume:        cfg.ReactionResume,
 		now:                   now,
 	}, nil
 }

--- a/internal/orchestrators/encounter/v2/submit_check.go
+++ b/internal/orchestrators/encounter/v2/submit_check.go
@@ -1,0 +1,117 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// SubmitCheckInput carries the entity-typed SubmitCheck request. The handler
+// builds it from the proto request after envelope validation (auth, empty-id,
+// d20-range). The roll is the caller-supplied d20 value; modifier resolution is
+// the toolkit's job via the wired CharacterResolver.
+type SubmitCheckInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player resolving their pending prompt.
+	PlayerID core.PlayerID
+
+	// EntityID is the entity the player controls. load verifies the encounter
+	// maps PlayerID -> EntityID and returns ErrEntityOwnershipMismatch otherwise
+	// (a caller may not resolve a prompt that is not theirs).
+	EntityID string
+
+	// Roll is the caller-supplied d20 value. The handler bounds it to [1,20]
+	// before reaching here; the toolkit re-checks via ErrInvalidRoll.
+	Roll int
+}
+
+// SubmitCheckOutput is the lean result of a skill-check resolution. World
+// effects (a successful unlock dispatches OpenDoor inside the toolkit, which
+// publishes DoorOpened + GeometryRevealed) flow as broker events, not in this
+// output.
+type SubmitCheckOutput struct {
+	// Success is whether the resolved total met or beat the prompt DC.
+	Success bool
+
+	// Total is the resolved total (roll + ability modifier + tool-proficiency
+	// bonus) the toolkit computed via the wired CharacterResolver.
+	Total int
+}
+
+// Skill-check resolution sentinels. The toolkit returns these as typed
+// sentinels (or plain fmt.Errorf for the dispatch-failed default); the
+// orchestrator surfaces them unwrapped where the handler maps them distinctly,
+// and wraps the unclassified dispatch failures behind ErrSubmitCheckDispatch.
+var (
+	// ErrSubmitCheckDispatch wraps a resolution-succeeded-but-side-effect-failed
+	// error from enc.SubmitCheck (e.g. the downstream OpenDoor dispatch failed).
+	// The toolkit returns these as plain fmt.Errorf rather than a sentinel; the
+	// orchestrator joins them with this sentinel so the handler maps them to
+	// codes.Internal without string matching. The recognized toolkit sentinels
+	// (ErrNoPendingPrompt / ErrPromptKindMismatch / ErrInvalidRoll /
+	// ErrUnsupportedPromptAction / ErrNoCharacterResolver) pass through unwrapped.
+	ErrSubmitCheckDispatch = errors.New("submit check dispatch failed")
+)
+
+// SubmitCheck resolves the caller's pending skill-check prompt against a
+// supplied d20 roll: load the encounter (verifying membership + entity
+// ownership), dispatch the toolkit's SubmitCheck verb (which owns modifier
+// resolution and any success side-effect dispatch), and persist.
+//
+// The toolkit owns ALL rules here: it reads the pending prompt, applies the
+// wired CharacterResolver's ability/tool modifiers to the roll, compares to the
+// prompt DC, and on success dispatches the prompt's TriggeredAction (today only
+// "open" on a locked door -> OpenDoor, which publishes per-viewer events). The
+// orchestrator does no skill math and no door routing — it loads, invokes the
+// verb, and persists.
+func (o *Orchestrator) SubmitCheck(ctx context.Context, in *SubmitCheckInput) (*SubmitCheckOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: SubmitCheckInput is required")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		EntityID:    in.EntityID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result, submitErr := enc.SubmitCheck(in.PlayerID, in.Roll)
+	if submitErr != nil {
+		return nil, wrapSubmitCheckErr(submitErr)
+	}
+
+	if err := o.persist(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+
+	return &SubmitCheckOutput{
+		Success: result.Success,
+		Total:   result.Total,
+	}, nil
+}
+
+// wrapSubmitCheckErr classifies a toolkit SubmitCheck error for the handler's
+// status mapping. Recognized sentinels are preserved (errors.Is keeps matching
+// them in the handler). The unclassified "resolution proceeded but the side
+// effect failed" cases — which the toolkit returns as plain fmt.Errorf — are
+// joined with ErrSubmitCheckDispatch so the handler maps them to Internal
+// without string matching.
+func wrapSubmitCheckErr(err error) error {
+	switch {
+	case errors.Is(err, tkenc.ErrNoPendingPrompt),
+		errors.Is(err, tkenc.ErrPromptKindMismatch),
+		errors.Is(err, tkenc.ErrInvalidRoll),
+		errors.Is(err, tkenc.ErrUnsupportedPromptAction),
+		errors.Is(err, tkenc.ErrNoCharacterResolver):
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrSubmitCheckDispatch, err)
+}

--- a/internal/orchestrators/encounter/v2/submit_check_reaction.go
+++ b/internal/orchestrators/encounter/v2/submit_check_reaction.go
@@ -44,13 +44,6 @@ type SubmitReactionCheckOutput struct {
 	TookReaction bool
 }
 
-// shieldRef is the canonical Shield spell condition ref. Used only to apply the
-// one-shot Shield readiness reset after a taken Shield reaction — this is
-// orchestration of readiness state (a flag the toolkit exposes), NOT a rules
-// computation: the AC magnitude lives in the injected BuildReactionModifiers,
-// handler-side.
-const shieldRef = "dnd5e:spells:shield"
-
 // SubmitReactionCheck resolves the caller's pending reaction prompt: load the
 // encounter with the #689 cascade, decode the persisted phase-1 attack context,
 // run the toolkit's CompleteTakeAction (phase 2) with the take/skip modifiers,
@@ -74,7 +67,9 @@ func (o *Orchestrator) SubmitReactionCheck(
 	if in == nil {
 		return nil, errors.New("encounter orchestrator: SubmitReactionCheckInput is required")
 	}
-	if o.reactionResume.DecodeAttackContext == nil || o.reactionResume.BuildReactionModifiers == nil {
+	if o.reactionResume.DecodeAttackContext == nil ||
+		o.reactionResume.BuildReactionModifiers == nil ||
+		o.reactionResume.IsOneShotReaction == nil {
 		return nil, errors.New("encounter orchestrator: ReactionResume funcs are required for SubmitReactionCheck")
 	}
 
@@ -106,12 +101,13 @@ func (o *Orchestrator) SubmitReactionCheck(
 		return nil, fmt.Errorf("complete take action %q: %w", in.EncounterID, err)
 	}
 
-	// One-shot Shield: when the player takes a Shield reaction, clear the
-	// readiness flag so the caster must re-ready before the next attack. Free
-	// reactions (OA) stay ready until explicitly toggled off. This is readiness
-	// bookkeeping (a toolkit-exposed flag), not a rules computation. Non-fatal —
-	// the reaction already fired.
-	if in.Take && prompt.ConditionRef == shieldRef {
+	// One-shot reactions: when the player takes a one-shot reaction (e.g. Shield),
+	// clear the readiness flag so the reactor must re-ready before the next
+	// window. Free reactions (OA) stay ready until explicitly toggled off. The
+	// rulebook decision — which refs are one-shot — is the injected predicate's;
+	// the orchestrator only performs the readiness reset (toolkit-flag
+	// bookkeeping). Non-fatal — the reaction already fired.
+	if in.Take && o.reactionResume.IsOneShotReaction(prompt.ConditionRef) {
 		_ = enc.SetReactionReady(prompt.ReactorEntityID, prompt.ConditionRef, false)
 	}
 

--- a/internal/orchestrators/encounter/v2/submit_check_reaction.go
+++ b/internal/orchestrators/encounter/v2/submit_check_reaction.go
@@ -1,0 +1,147 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ErrNoPendingReactionPrompt means the caller has no pending reaction prompt to
+// resolve. Handler maps to codes.FailedPrecondition.
+var ErrNoPendingReactionPrompt = errors.New("no pending reaction prompt for player")
+
+// SubmitReactionCheckInput carries the entity-typed SubmitCheck{take_reaction}
+// request. The handler builds it from the proto request after envelope
+// validation. There is no d20 roll on this branch — a reaction prompt is a
+// take/skip choice, not a check.
+type SubmitReactionCheckInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player resolving their reaction prompt.
+	PlayerID core.PlayerID
+
+	// EntityID is the entity the player controls. load verifies the encounter
+	// maps PlayerID -> EntityID and returns ErrEntityOwnershipMismatch otherwise.
+	EntityID string
+
+	// Take is the caller's take/skip choice. When true, the orchestrator builds
+	// the prompt's ReactionModifiers (via the injected BuildReactionModifiers)
+	// and runs phase 2 with them; when false, phase 2 runs with no modifiers.
+	Take bool
+}
+
+// SubmitReactionCheckOutput is the lean result of a reaction resolution. The
+// phase-2 attack outcome flows as broker events (AttackResolved / DamageDealt);
+// this output only signals that phase 2 ran and echoes the take/skip choice for
+// client telemetry.
+type SubmitReactionCheckOutput struct {
+	// TookReaction echoes the caller's take/skip choice (the handler maps it to
+	// the wire Total: 1 = took, 0 = skipped).
+	TookReaction bool
+}
+
+// shieldRef is the canonical Shield spell condition ref. Used only to apply the
+// one-shot Shield readiness reset after a taken Shield reaction — this is
+// orchestration of readiness state (a flag the toolkit exposes), NOT a rules
+// computation: the AC magnitude lives in the injected BuildReactionModifiers,
+// handler-side.
+const shieldRef = "dnd5e:spells:shield"
+
+// SubmitReactionCheck resolves the caller's pending reaction prompt: load the
+// encounter with the #689 cascade, decode the persisted phase-1 attack context,
+// run the toolkit's CompleteTakeAction (phase 2) with the take/skip modifiers,
+// clear the prompt, and persist (flushing player character data back to the
+// store).
+//
+// The toolkit owns the phase-2 attack resolution (re-evaluating the hit with
+// the reactor's modifiers and publishing AttackResolved / DamageDealt). The
+// orchestrator loads, decodes the opaque context via the injected decoder,
+// builds modifiers via the injected builder, invokes the verb, and persists —
+// the rule-ish pieces (the AttackContext shape, the Shield +5 magnitude) live
+// in the injected funcs, handler-side, not here.
+//
+// INTERNAL single-RPC: this resolves a prompt that is already persisted on the
+// snapshot (set by a prior TakeAction phase-1 / NPCAct pause). There is NO
+// cross-RPC wire-pause built here — that is the deferred EndTurn concern.
+func (o *Orchestrator) SubmitReactionCheck(
+	ctx context.Context,
+	in *SubmitReactionCheckInput,
+) (*SubmitReactionCheckOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: SubmitReactionCheckInput is required")
+	}
+	if o.reactionResume.DecodeAttackContext == nil || o.reactionResume.BuildReactionModifiers == nil {
+		return nil, errors.New("encounter orchestrator: ReactionResume funcs are required for SubmitReactionCheck")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID:       in.EncounterID,
+		PlayerID:          in.PlayerID,
+		EntityID:          in.EntityID,
+		WithCharacterData: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the pending reaction prompt through the encounter's synced snapshot —
+	// the same "ask the encounter for its state" surface Interact uses for doors.
+	prompt, ok := enc.ToData().PendingReactionPrompts[in.PlayerID]
+	if !ok || prompt == nil {
+		return nil, ErrNoPendingReactionPrompt
+	}
+
+	phasedCtx, err := o.reactionResume.DecodeAttackContext(prompt.AttackContextJSON)
+	if err != nil {
+		return nil, fmt.Errorf("decode attack context %q: %w", in.EncounterID, err)
+	}
+
+	modifiers := o.reactionResume.BuildReactionModifiers(prompt, in.Take)
+
+	if err := enc.CompleteTakeAction(phasedCtx, modifiers); err != nil {
+		return nil, fmt.Errorf("complete take action %q: %w", in.EncounterID, err)
+	}
+
+	// One-shot Shield: when the player takes a Shield reaction, clear the
+	// readiness flag so the caster must re-ready before the next attack. Free
+	// reactions (OA) stay ready until explicitly toggled off. This is readiness
+	// bookkeeping (a toolkit-exposed flag), not a rules computation. Non-fatal —
+	// the reaction already fired.
+	if in.Take && prompt.ConditionRef == shieldRef {
+		_ = enc.SetReactionReady(prompt.ReactorEntityID, prompt.ConditionRef, false)
+	}
+
+	enc.ClearPendingReactionPrompt(in.PlayerID)
+
+	if err := o.persistWithCharacterData(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+
+	return &SubmitReactionCheckOutput{TookReaction: in.Take}, nil
+}
+
+// persistWithCharacterData is the combat-capable persist path: ToData +
+// SyncErr check (shared by persist) + flush the cascaded player character
+// DataJSON back to the authoritative character store BEFORE saving the
+// encounter snapshot (so the next RPC re-attaches fresh state and the snapshot
+// does not carry a soon-stale char blob). No-op flush when no Persist func is
+// wired.
+func (o *Orchestrator) persistWithCharacterData(ctx context.Context, enc *tkenc.Encounter, encID string) error {
+	out := enc.ToData()
+	if syncErr := enc.SyncErr(); syncErr != nil {
+		return fmt.Errorf("sync encounter state %q: %w", encID, syncErr)
+	}
+	if o.characterData.Persist != nil {
+		if err := o.characterData.Persist(ctx, out); err != nil {
+			return fmt.Errorf("persist character data %q: %w", encID, err)
+		}
+	}
+	if err := o.encRepo.Save(ctx, out); err != nil {
+		return fmt.Errorf("save encounter %q: %w", encID, err)
+	}
+	return nil
+}

--- a/internal/orchestrators/encounter/v2/submit_check_test.go
+++ b/internal/orchestrators/encounter/v2/submit_check_test.go
@@ -47,6 +47,7 @@ func (s *SubmitCheckSuite) SetupTest() {
 			BuildReactionModifiers: func(_ *tkenc.PendingReactionPrompt, _ bool) []tkenc.ReactionModifier {
 				return nil
 			},
+			IsOneShotReaction: func(_ string) bool { return false },
 		},
 		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
 	})

--- a/internal/orchestrators/encounter/v2/submit_check_test.go
+++ b/internal/orchestrators/encounter/v2/submit_check_test.go
@@ -1,0 +1,249 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+type SubmitCheckSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *SubmitCheckSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		// Reaction funcs supplied so SubmitReactionCheck reaches the load path in
+		// the reaction tests below (decode/build are only invoked once a prompt
+		// is present, which the deterministic tests below do not reach).
+		ReactionResume: encounterorch.ReactionResume{
+			DecodeAttackContext: func(_ []byte) (*tkenc.PhasedAttackContext, error) {
+				return &tkenc.PhasedAttackContext{}, nil
+			},
+			BuildReactionModifiers: func(_ *tkenc.PendingReactionPrompt, _ bool) []tkenc.ReactionModifier {
+				return nil
+			},
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedLockedDoor persists an encounter with player-A (controlling char-A)
+// adjacent to a locked door, then issues the per-player skill-check prompt via
+// Interact so SubmitCheck has a pending prompt to resolve.
+func (s *SubmitCheckSuite) seedLockedDoorWithPrompt(encID, doorID string, dc int) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   "player-A",
+		EntityID:   "char-A",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 4,
+	}))
+	enc.AddDoor(core.EntityID(doorID), core.Hex{Q: 1, R: 0, S: -1}, false)
+	data := enc.ToData()
+	door := data.Doors[core.EntityID(doorID)]
+	door.Locked = true
+	door.LockDC = dc
+	door.LockAbility = "DEX"
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+
+	// Issue the prompt via Interact (the carved orchestrator door path).
+	_, err := s.orch.Interact(s.ctx, &encounterorch.InteractInput{
+		EncounterID:    encID,
+		PlayerID:       "player-A",
+		TargetEntityID: core.EntityID(doorID),
+	})
+	s.Require().NoError(err)
+}
+
+func (s *SubmitCheckSuite) submitCheck(encID, entity string, roll int) (*encounterorch.SubmitCheckOutput, error) {
+	return s.orch.SubmitCheck(s.ctx, &encounterorch.SubmitCheckInput{
+		EncounterID: encID,
+		PlayerID:    "player-A",
+		EntityID:    entity,
+		Roll:        roll,
+	})
+}
+
+// --- nil input ---
+
+func (s *SubmitCheckSuite) TestSubmitCheck_NilInput_Error() {
+	_, err := s.orch.SubmitCheck(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+// --- load preconditions ---
+
+func (s *SubmitCheckSuite) TestSubmitCheck_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.submitCheck("nope", "char-A", 10)
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *SubmitCheckSuite) TestSubmitCheck_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-no-player", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other", EntityID: "other-char", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.submitCheck("enc-no-player", "char-A", 10)
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+func (s *SubmitCheckSuite) TestSubmitCheck_EntityMismatch_ErrEntityOwnershipMismatch() {
+	s.seedLockedDoorWithPrompt("enc-mismatch", "door-east", 10)
+	_, err := s.submitCheck("enc-mismatch", "char-someone-else", 10)
+	s.Require().ErrorIs(err, encounterorch.ErrEntityOwnershipMismatch)
+}
+
+// --- no pending prompt ---
+
+func (s *SubmitCheckSuite) TestSubmitCheck_NoPendingPrompt_ErrNoPendingPrompt() {
+	enc := tkenc.New(s.ctx, "enc-no-prompt", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.submitCheck("enc-no-prompt", "char-A", 15)
+	s.Require().ErrorIs(err, tkenc.ErrNoPendingPrompt)
+}
+
+// --- success path: total >= DC unlocks + opens the door, prompt cleared ---
+
+func (s *SubmitCheckSuite) TestSubmitCheck_Success_OpensDoorPromptCleared() {
+	s.seedLockedDoorWithPrompt("enc-success", "door-east", 10)
+
+	// Roll 20 vs DC 10 with zero-modifier stub resolver — success.
+	out, err := s.submitCheck("enc-success", "char-A", 20)
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+	s.Require().Equal(20, out.Total)
+
+	loaded, err := s.repo.Get(s.ctx, "enc-success")
+	s.Require().NoError(err)
+	door := loaded.Doors[core.EntityID("door-east")]
+	s.Require().True(door.Open, "successful unlock opens the door")
+	s.Require().False(door.Locked, "successful unlock clears Locked")
+	s.Require().Empty(loaded.PendingPrompts, "prompt cleared after success")
+}
+
+// --- failure path: total < DC leaves the door locked, prompt cleared ---
+
+func (s *SubmitCheckSuite) TestSubmitCheck_Failure_DoorStaysLockedPromptCleared() {
+	s.seedLockedDoorWithPrompt("enc-fail", "door-east", 30)
+
+	// Roll 1 vs DC 30 — failure.
+	out, err := s.submitCheck("enc-fail", "char-A", 1)
+	s.Require().NoError(err)
+	s.Require().False(out.Success)
+	s.Require().Equal(1, out.Total)
+
+	loaded, err := s.repo.Get(s.ctx, "enc-fail")
+	s.Require().NoError(err)
+	door := loaded.Doors[core.EntityID("door-east")]
+	s.Require().False(door.Open, "failed unlock leaves door closed")
+	s.Require().True(door.Locked, "failed unlock leaves door locked")
+	s.Require().Empty(loaded.PendingPrompts, "prompt cleared even on failure")
+}
+
+// --- reaction branch: load preconditions + no-prompt sentinel ---
+//
+// The take_reaction CompleteTakeAction happy path needs a paused two-phase
+// attack, which the toolkit cannot resume cross-RPC at v0.17.0 (documented gap:
+// ApplyAttackOutcome lacks a held-entity accessor). These tests cover the
+// deterministically-reachable reaction surface: load auth + the
+// no-pending-reaction-prompt sentinel.
+
+func (s *SubmitCheckSuite) reactionCheck(encID, entity string, take bool) (*encounterorch.SubmitReactionCheckOutput, error) {
+	return s.orch.SubmitReactionCheck(s.ctx, &encounterorch.SubmitReactionCheckInput{
+		EncounterID: encID,
+		PlayerID:    "player-A",
+		EntityID:    entity,
+		Take:        take,
+	})
+}
+
+func (s *SubmitCheckSuite) TestSubmitReactionCheck_NilInput_Error() {
+	_, err := s.orch.SubmitReactionCheck(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+func (s *SubmitCheckSuite) TestSubmitReactionCheck_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.reactionCheck("nope", "char-A", true)
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *SubmitCheckSuite) TestSubmitReactionCheck_EntityMismatch_ErrEntityOwnershipMismatch() {
+	enc := tkenc.New(s.ctx, "enc-react-mismatch", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.reactionCheck("enc-react-mismatch", "char-someone-else", true)
+	s.Require().ErrorIs(err, encounterorch.ErrEntityOwnershipMismatch)
+}
+
+func (s *SubmitCheckSuite) TestSubmitReactionCheck_NoPendingPrompt_ErrNoPendingReactionPrompt() {
+	enc := tkenc.New(s.ctx, "enc-react-no-prompt", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-A", EntityID: "char-A", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.reactionCheck("enc-react-no-prompt", "char-A", true)
+	s.Require().ErrorIs(err, encounterorch.ErrNoPendingReactionPrompt)
+}
+
+func (s *SubmitCheckSuite) TestSubmitReactionCheck_MissingFuncs_Error() {
+	// An orchestrator without the ReactionResume funcs must refuse the reaction
+	// branch up front rather than nil-panic.
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+	})
+	s.Require().NoError(err)
+
+	_, err = orch.SubmitReactionCheck(s.ctx, &encounterorch.SubmitReactionCheckInput{
+		EncounterID: "enc-x", PlayerID: "player-A", EntityID: "char-A", Take: true,
+	})
+	s.Require().Error(err)
+}
+
+func TestSubmitCheckSuite(t *testing.T) {
+	suite.Run(t, new(SubmitCheckSuite))
+}


### PR DESCRIPTION
**Part of #582** (chunk 2, step 2: SubmitCheck).

Step 2 of the Sequencing-B carve: move **SubmitCheck** (skill-check) and its **take_reaction** branch onto the v2 encounter orchestrator, following the merged Interact pattern (#585). Each method = shared `load()` → toolkit verb → persist; the handlers thin to proto↔input mapping + sentinel→gRPC status mapping. Inline bodies deleted.

### Orchestrator (`internal/orchestrators/encounter/v2`)
- **`submit_check.go`** — `SubmitCheckInput/Output` + `Orchestrator.SubmitCheck`. `load(EntityID ownership)` → `enc.SubmitCheck(roll)` → `persist`. The toolkit owns all skill math + the success side-effect dispatch (OpenDoor on unlock); the orchestrator does no skill math and no door routing. Recognized toolkit sentinels pass through unwrapped; unclassified dispatch failures join `ErrSubmitCheckDispatch`.
- **`submit_check_reaction.go`** — `SubmitReactionCheckInput/Output` + `Orchestrator.SubmitReactionCheck`. `load(WithCharacterData #689 cascade)` → decode opaque attack ctx → `CompleteTakeAction` (phase 2) → one-shot Shield readiness reset → `ClearPendingReactionPrompt` → `persistWithCharacterData`. **INTERNAL single-RPC**: resolves an already-persisted prompt; **no cross-RPC wire-pause** (that is the deferred EndTurn concern).
- **`load.go`** — optional `WithCharacterData` attach hook (combat-capable verbs only; no-op for skill-check / door verbs).
- **`orchestrator.go`** — `CharacterDataCascade` + `ReactionResume` injected funcs so the orchestrator stays rulebook-free; dropped the now-dead `charRepo`/`CharacterRepo` placeholder (the cascade flows through the injected funcs — one representation).

### Handlers (`internal/handlers/dnd5e/v2/encounter`)
- **`submit_check.go` / `submit_check_reaction.go`** — inline bodies deleted; both now thin (proto↔input + status-error).
- **`reaction_resume.go`** (new) — adapter seam holding the rule-ish pieces (opaque `combat.AttackContext` decode + the Shield +5 AC modifier magnitude), kept handler-side and **OUT** of the depguard set, like the combat/movement resolvers.

### depguard
`submit_check.go` + `submit_check_reaction.go` orchestrator files added to the guarded `files:` set; **verified the guard fires** on a rulebook import in either file. No resolver adapters added to the set.

### Tests
Orchestrator suite (load preconditions, no-pending-prompt, success/failure skill-check resolution — opens / leaves-locked the door + prompt clearing, reaction load preconditions + no-prompt sentinel + missing-funcs guard) + existing handler SubmitCheck / shield tests green. `go build ./...` + full suite green.

### Lane note (flagged)
The Shield +5 AC magnitude (`reaction_resume.go: shieldACBonus`) is a rule magnitude living in rpg-api — a **pre-existing toolkit gap** (`combat` exports no named const; there is no SDK helper to build a `ReactionModifier` from a prompt). Carried faithfully and isolated to the adapter seam (handler-side, behind the injected func); flagged here for a toolkit follow-up.

### CI / verification notes
- CI (`test.yml`) gates on `go test` — green.
- `make pre-commit` / `make ci-check` report **pre-existing** repo-wide debt only: the #580 mockgen import-ordering drift (all 13 mock files, none touched by this PR) and legacy v1alpha1 lint debt (files byte-identical to parent commit). My touched files are lint-clean (0 issues) and all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)