### PR TITLE
feat(encounter/v2): carve SetReactionReady onto the orchestrator (#582 step 3)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,8 +51,8 @@ linters:
         #   - action-verb handler files (activate_feature, take_action, end_turn,
         #     interact, submit_check, handler, create, get)
         #   - the v2 encounter orchestrator method files (orchestrator, load,
-        #     interact, submit_check, submit_check_reaction) under
-        #     internal/orchestrators/encounter/v2 (rpg-api#582):
+        #     interact, submit_check, submit_check_reaction, set_reaction_ready)
+        #     under internal/orchestrators/encounter/v2 (rpg-api#582):
         #     load → toolkit-verb → persist, by reference only.
         # Excludes: combat/movement resolver files (translate held entities → the
         # rulebook chain; legitimately import combat/character/monster/weapons),
@@ -85,6 +85,7 @@ linters:
             - "**/internal/orchestrators/encounter/v2/interact.go"
             - "**/internal/orchestrators/encounter/v2/submit_check.go"
             - "**/internal/orchestrators/encounter/v2/submit_check_reaction.go"
+            - "**/internal/orchestrators/encounter/v2/set_reaction_ready.go"
           deny:
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
               desc: "game logic belongs in the toolkit — do not import dnd5e conditions in action handler files"

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -53,7 +53,11 @@ What's here as of Wave 2.11e:
   unmarshals the persisted `AttackContextJSON` back into `combat.AttackContext`
   and feeds it into `CompleteTakeAction` with the chosen modifiers.
 - `SetReactionReady` (`set_reaction_ready.go`) — RPC for per-character
-  per-condition readiness toggle.
+  per-condition readiness toggle. Carved onto the v2 orchestrator
+  (`internal/orchestrators/encounter/v2/set_reaction_ready.go`, #582 step 3):
+  the handler is now proto↔input + sentinel→status mapping; the orchestrator
+  owns load → `enc.SetReactionReady` → persist. Joins `Interact` (#582 step 1)
+  and `SubmitCheck` (#582 step 2) on the orchestrator's single-`load` core.
 - `EndTurn` (`end_turn.go`) — handles `IsNPCPausedForReaction(err)`;
   `serializePendingPhasedAttacks` marshals the live `*PhasedAttackContext`
   into `AttackContextJSON` before snapshot (honors the encounter SDK's

--- a/internal/handlers/dnd5e/v2/encounter/set_reaction_ready.go
+++ b/internal/handlers/dnd5e/v2/encounter/set_reaction_ready.go
@@ -1,6 +1,6 @@
 package encounter
 
-// Wave 2.11d — SetReactionReady RPC handler.
+// SetReactionReady RPC handler.
 //
 // Toggles per-character readiness for a specific reaction. Players opt in
 // to spell-cost reactions (Shield) by setting ready=true; conditions only
@@ -10,6 +10,10 @@ package encounter
 // Free-cost reactions (OA) are seeded ready=true at AddPlayer time
 // (encounter SDK Wave 2.11c); players use this RPC to override the default
 // (e.g. "hold OA this turn").
+//
+// The v2 orchestrator owns the load → SetReactionReady verb → persist flow
+// (#582 step 3). This handler stays thin: proto↔input mapping plus
+// setReactionReadyStatusError for the sentinel→gRPC code mapping.
 
 import (
 	"context"
@@ -20,16 +24,15 @@ import (
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
-	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
-	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// SetReactionReady handles the SetReactionReady RPC: validates the request,
-// updates the encounter's reaction-readiness map for the named character,
-// and persists the snapshot.
+// SetReactionReady handles the SetReactionReady RPC: validates the request
+// envelope, delegates the readiness toggle to the v2 orchestrator, and maps
+// the orchestrator's sentinel errors back to gRPC status codes.
 //
-// Behavior contract:
+// Behavior contract (preserved across the carve):
 //   - missing auth → Unauthenticated
 //   - empty encounter_id / character_id / reaction_ref → InvalidArgument
 //   - encounter not in repo → NotFound
@@ -63,48 +66,42 @@ func (h *Handler) SetReactionReady(
 			"reaction_ref must have module, type, and id set")
 	}
 
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	_, err := h.orch.SetReactionReady(ctx, &encounterorch.SetReactionReadyInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+		EntityID:    core.EntityID(req.GetCharacterId()),
+		ReactionRef: refProtoToString(req.GetReactionRef()),
+		Ready:       req.GetReady(),
+	})
 	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal,
-			"load encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	pd, ok := data.Players[core.PlayerID(playerID)]
-	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
-	}
-	if string(pd.EntityID) != req.GetCharacterId() {
-		return nil, status.Error(codes.PermissionDenied,
-			"character_id does not match player's controlled entity")
-	}
-
-	// #689: readiness toggle doesn't touch combatant state; no player DataJSON
-	// attached, so the cascade skips hydration. ctx threaded for the new
-	// LoadFromData signature.
-	enc, err := tkenc.LoadFromData(ctx, data, h.broker,
-		tkenc.WithCharacterResolver(h.resolver),
-		tkenc.WithCombatResolver(h.buildCombatResolver(data)),
-		tkenc.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
-	}
-
-	refStr := refProtoToString(req.GetReactionRef())
-	if err := enc.SetReactionReady(core.EntityID(req.GetCharacterId()), refStr, req.GetReady()); err != nil {
-		// The SDK rejects unknown entities — surface as state-dependent.
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"set reaction ready: %v", err)
-	}
-
-	if err := h.encRepo.Save(ctx, enc.ToData()); err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"save encounter %q after set-reaction-ready: %v", req.GetEncounterId(), err)
+		return nil, setReactionReadyStatusError(err)
 	}
 
 	return &encounterv2pb.SetReactionReadyResponse{}, nil
+}
+
+// setReactionReadyStatusError maps the orchestrator's SetReactionReady errors
+// onto gRPC status codes per pat-v2-status-code-mapping. Orchestrator load
+// sentinels carry the auth classification; the ErrSetReactionReadyRefused
+// wrapper carries the state-dependent verb refusal.
+//
+//   - ErrEncounterNotFound → NotFound
+//   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
+//   - ErrSetReactionReadyRefused (SDK rejects the entity) → FailedPrecondition
+//   - load / save / unclassified failures → Internal
+func setReactionReadyStatusError(err error) error {
+	switch {
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounterorch.ErrEntityOwnershipMismatch):
+		return status.Error(codes.PermissionDenied,
+			"character_id does not match player's controlled entity")
+	case errors.Is(err, encounterorch.ErrSetReactionReadyRefused):
+		return status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+	return status.Errorf(codes.Internal, "set reaction ready: %v", err)
 }
 
 // refProtoToString joins a proto Ref into the canonical "module:type:id"

--- a/internal/orchestrators/encounter/v2/set_reaction_ready.go
+++ b/internal/orchestrators/encounter/v2/set_reaction_ready.go
@@ -8,12 +8,15 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// ErrSetReactionReadyRefused wraps a state-dependent refusal from the toolkit's
-// SetReactionReady verb — today the only case is "entity not in encounter" (the
-// SDK validates the charID against player + monster seats). The toolkit returns
-// these as plain fmt.Errorf rather than a sentinel, so the orchestrator joins
-// them with this sentinel and the handler maps it to codes.FailedPrecondition
-// per pat-v2-status-code-mapping (mirrors ErrDoorVerbRefused on Interact).
+// ErrSetReactionReadyRefused wraps a refusal from the toolkit's
+// SetReactionReady verb. The verb rejects an empty charID, an empty reactionRef,
+// or an entity not in the encounter (the SDK validates the charID against player
+// + monster seats); in normal operation the handler pre-validates the envelope,
+// so the entity-not-in-encounter case is the one that reaches here through the
+// RPC path. The toolkit returns all of these as plain errors rather than a
+// sentinel, so the orchestrator joins them with this sentinel and the handler
+// maps it to codes.FailedPrecondition per pat-v2-status-code-mapping (mirrors
+// ErrDoorVerbRefused on Interact).
 var ErrSetReactionReadyRefused = errors.New("set reaction ready refused")
 
 // SetReactionReadyInput carries the entity-typed SetReactionReady request. The

--- a/internal/orchestrators/encounter/v2/set_reaction_ready.go
+++ b/internal/orchestrators/encounter/v2/set_reaction_ready.go
@@ -1,0 +1,93 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ErrSetReactionReadyRefused wraps a state-dependent refusal from the toolkit's
+// SetReactionReady verb — today the only case is "entity not in encounter" (the
+// SDK validates the charID against player + monster seats). The toolkit returns
+// these as plain fmt.Errorf rather than a sentinel, so the orchestrator joins
+// them with this sentinel and the handler maps it to codes.FailedPrecondition
+// per pat-v2-status-code-mapping (mirrors ErrDoorVerbRefused on Interact).
+var ErrSetReactionReadyRefused = errors.New("set reaction ready refused")
+
+// SetReactionReadyInput carries the entity-typed SetReactionReady request. The
+// handler builds it from the proto request after envelope validation, joining
+// the proto Ref into the canonical "module:type:id" ReactionRef the toolkit's
+// readiness map keys on (proto translation — stays handler-side).
+type SetReactionReadyInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player toggling readiness.
+	PlayerID core.PlayerID
+
+	// EntityID is the entity the player controls. load verifies the encounter
+	// maps PlayerID -> EntityID and returns ErrEntityOwnershipMismatch otherwise
+	// (a player may only toggle readiness on their own controlled entity). This
+	// is also the charID handed to enc.SetReactionReady.
+	EntityID core.EntityID
+
+	// ReactionRef is the canonical "module:type:id" ref string for the reaction
+	// (e.g. "dnd5e:conditions:shield"). The handler assembles it from the proto
+	// Ref; the orchestrator passes it through to the toolkit as the readiness-map
+	// key by reference, never inspecting which ref it is.
+	ReactionRef string
+
+	// Ready is the readiness value to set: true opts the entity in to the
+	// reaction's trigger window, false opts it out.
+	Ready bool
+}
+
+// SetReactionReadyOutput is the lean result of a readiness toggle. The write
+// has no caller-private payload — clients refresh their readiness panel from
+// the next encounter snapshot — so the output is intentionally empty, kept as a
+// type for the Input/Output convention and future expansion.
+type SetReactionReadyOutput struct{}
+
+// SetReactionReady toggles per-entity reaction readiness: load the encounter
+// (verifying membership + entity ownership), invoke the toolkit's
+// SetReactionReady verb (which owns the readiness map and entity validation),
+// and persist.
+//
+// No rules logic here: the orchestrator never decides which reactions exist or
+// what readiness means — it routes the caller's ref + flag to the toolkit's
+// readiness-map setter by reference and persists the snapshot. The toolkit owns
+// the only rule-ish piece (validating the entity belongs to the encounter).
+func (o *Orchestrator) SetReactionReady(
+	ctx context.Context,
+	in *SetReactionReadyInput,
+) (*SetReactionReadyOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: SetReactionReadyInput is required")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		EntityID:    string(in.EntityID),
+		// Readiness toggle doesn't touch combatant state, so no #689 cascade.
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if readyErr := enc.SetReactionReady(in.EntityID, in.ReactionRef, in.Ready); readyErr != nil {
+		// The toolkit returns plain fmt.Errorf for its refusals (entity not in
+		// encounter, empty charID/ref — the latter pre-validated handler-side).
+		// Join with the sentinel so the handler maps to FailedPrecondition
+		// without string matching.
+		return nil, fmt.Errorf("%w: %w", ErrSetReactionReadyRefused, readyErr)
+	}
+
+	if err := o.persist(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+
+	return &SetReactionReadyOutput{}, nil
+}

--- a/internal/orchestrators/encounter/v2/set_reaction_ready_test.go
+++ b/internal/orchestrators/encounter/v2/set_reaction_ready_test.go
@@ -1,0 +1,157 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// shieldReactionRef is the canonical readiness-map key the handler assembles
+// from the proto Ref for the Shield reaction.
+const shieldReactionRef = "dnd5e:conditions:shield"
+
+type SetReactionReadySuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *SetReactionReadySuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		// The readiness toggle never invokes the combat / movement resolvers, but
+		// the orchestrator requires the builders to be present.
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedPlayer persists an encounter with player-A controlling char-A.
+func (s *SetReactionReadySuite) seedPlayer(encID string) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   "player-A",
+		EntityID:   "char-A",
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+}
+
+func (s *SetReactionReadySuite) setReady(encID, entity, ref string, ready bool) (*encounterorch.SetReactionReadyOutput, error) {
+	return s.orch.SetReactionReady(s.ctx, &encounterorch.SetReactionReadyInput{
+		EncounterID: encID,
+		PlayerID:    "player-A",
+		EntityID:    core.EntityID(entity),
+		ReactionRef: ref,
+		Ready:       ready,
+	})
+}
+
+// --- nil input ---
+
+func (s *SetReactionReadySuite) TestSetReactionReady_NilInput_Error() {
+	_, err := s.orch.SetReactionReady(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+// --- load preconditions ---
+
+func (s *SetReactionReadySuite) TestSetReactionReady_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.setReady("nope", "char-A", shieldReactionRef, true)
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *SetReactionReadySuite) TestSetReactionReady_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-no-player", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other", EntityID: "other-char", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.setReady("enc-no-player", "char-A", shieldReactionRef, true)
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+func (s *SetReactionReadySuite) TestSetReactionReady_EntityMismatch_ErrEntityOwnershipMismatch() {
+	s.seedPlayer("enc-mismatch")
+	_, err := s.setReady("enc-mismatch", "char-someone-else", shieldReactionRef, true)
+	s.Require().ErrorIs(err, encounterorch.ErrEntityOwnershipMismatch)
+}
+
+// --- verb refusal wrapped in the sentinel ---
+//
+// The toolkit returns plain errors (not sentinels) for its SetReactionReady
+// refusals; the orchestrator joins them with ErrSetReactionReadyRefused so the
+// handler maps to FailedPrecondition without string matching. The
+// entity-not-in-encounter case isn't reachable through the public surface (the
+// load ownership check passes only when EntityID is the player's seat, and the
+// toolkit re-validates that same charID), so we drive the empty-ref refusal —
+// normally pre-validated handler-side — straight at the orchestrator to prove
+// the wrapping.
+func (s *SetReactionReadySuite) TestSetReactionReady_EmptyRef_ErrSetReactionReadyRefused() {
+	s.seedPlayer("enc-empty-ref")
+	_, err := s.setReady("enc-empty-ref", "char-A", "", true)
+	s.Require().ErrorIs(err, encounterorch.ErrSetReactionReadyRefused)
+}
+
+// --- happy path: toggle on, persisted ---
+
+func (s *SetReactionReadySuite) TestSetReactionReady_True_PersistsReadyFlag() {
+	s.seedPlayer("enc-ready-on")
+
+	out, err := s.setReady("enc-ready-on", "char-A", shieldReactionRef, true)
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+
+	loaded, err := s.repo.Get(s.ctx, "enc-ready-on")
+	s.Require().NoError(err)
+	s.Require().Contains(loaded.ReactionReadiness, core.EntityID("char-A"),
+		"readiness map must carry the entity after a toggle")
+	s.Require().True(loaded.ReactionReadiness[core.EntityID("char-A")][shieldReactionRef],
+		"ready=true must persist as true")
+}
+
+// --- toggle off: clears the flag, persisted ---
+
+func (s *SetReactionReadySuite) TestSetReactionReady_False_PersistsClearedFlag() {
+	s.seedPlayer("enc-ready-off")
+
+	// Toggle on, then off — the off write must persist as false.
+	_, err := s.setReady("enc-ready-off", "char-A", shieldReactionRef, true)
+	s.Require().NoError(err)
+	_, err = s.setReady("enc-ready-off", "char-A", shieldReactionRef, false)
+	s.Require().NoError(err)
+
+	loaded, err := s.repo.Get(s.ctx, "enc-ready-off")
+	s.Require().NoError(err)
+	s.Require().False(loaded.ReactionReadiness[core.EntityID("char-A")][shieldReactionRef],
+		"ready=false must persist as false")
+}
+
+func TestSetReactionReadySuite(t *testing.T) {
+	suite.Run(t, new(SetReactionReadySuite))
+}


### PR DESCRIPTION
**Part of #582** (chunk 2, step 3: SetReactionReady).

Step 3 of the Sequencing-B carve: move **SetReactionReady** (the per-entity reaction-readiness write) onto the v2 encounter orchestrator, following the merged Interact (#585) and SubmitCheck (#587) pattern. The method = shared `load()` → `enc.SetReactionReady` → `persist` (SyncErr-checked); the handler thins to proto↔input mapping + a sentinel→gRPC status mapper. The inline load/verb/save body is deleted.

### Orchestrator (`internal/orchestrators/encounter/v2/set_reaction_ready.go`)
- `SetReactionReadyInput{EncounterID, PlayerID, EntityID, ReactionRef, Ready}` / `SetReactionReadyOutput{}` (empty — the write has no caller-private payload; clients refresh from the next snapshot).
- `Orchestrator.SetReactionReady`: `load` (membership + entity-ownership check; `EntityID` is the player's own controlled entity, so the ownership check applies) → `enc.SetReactionReady(charID, ref, ready)` → `persist`.
- The toolkit returns plain errors for its verb refusals (entity not in encounter), so the orchestrator joins them with **`ErrSetReactionReadyRefused`** and the handler maps that to `FailedPrecondition` without string matching — mirroring `ErrDoorVerbRefused` on Interact.
- No rules logic: the orchestrator routes the caller's ref + flag to the toolkit's readiness-map setter by reference and persists; it never inspects which ref it is.

### Handler (`internal/handlers/dnd5e/v2/encounter/set_reaction_ready.go`)
- Thinned to: auth/envelope validation → `refProtoToString` (proto Ref → `module:type:id`, stays handler-side) → `h.orch.SetReactionReady(...)` → `setReactionReadyStatusError`.
- **Behavior contract preserved** across the carve: auth ordering and all status codes (Unauthenticated / InvalidArgument / NotFound / PermissionDenied / FailedPrecondition / Internal) are unchanged.

### depguard
- Added `set_reaction_ready.go` to the guarded `files:` set in `.golangci.yml` (the orchestrator method file, not the resolver adapters), same as steps 1-2. Verified the guard fires: injecting a `rulebooks/dnd5e/conditions` import produces the expected `no-rulebook-internals-in-action-handlers` deny.

### Tests
- `set_reaction_ready_test.go`: nil input, load preconditions (missing encounter / player-not-in / entity mismatch), verb-refusal sentinel wrapping, and the on/off readiness write asserted against the persisted `ReactionReadiness` map.

### Docs
- `docs/quality.md`: updated the SetReactionReady bullet to reflect the carve onto the orchestrator (alongside Interact #582 step 1 and SubmitCheck #582 step 2 on the single-`load` core).

### Verification
- `go build ./...` clean.
- `go test -race` over the CI scope (non-gen/mock/cmd) green — 27 packages ok.
- depguard guard fires on the new orchestrator file (verified).

Note: the repo's whole-repo `golangci-lint` has 70 pre-existing debts on `main` (v1alpha1 + the legacy `orchestrators/encounter/orchestrator.go`); this PR adds zero. The GitHub `test.yml` CI gates on tests, not lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)