### PR TITLE
feat(encounter/v2): carve TakeAction onto the orchestrator (#582 step 5)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,7 @@ linters:
         #     interact, submit_check, handler, create, get)
         #   - the v2 encounter orchestrator method files (orchestrator, load,
         #     interact, submit_check, submit_check_reaction, set_reaction_ready,
-        #     activate_feature) under internal/orchestrators/encounter/v2
+        #     activate_feature, take_action) under internal/orchestrators/encounter/v2
         #     (rpg-api#582): load → toolkit-verb → persist, by reference only.
         # Excludes: combat/movement resolver files (translate held entities → the
         # rulebook chain; legitimately import combat/character/monster/weapons),
@@ -87,6 +87,7 @@ linters:
             - "**/internal/orchestrators/encounter/v2/submit_check_reaction.go"
             - "**/internal/orchestrators/encounter/v2/set_reaction_ready.go"
             - "**/internal/orchestrators/encounter/v2/activate_feature.go"
+            - "**/internal/orchestrators/encounter/v2/take_action.go"
           deny:
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
               desc: "game logic belongs in the toolkit — do not import dnd5e conditions in action handler files"

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -46,8 +46,20 @@ What's here as of Wave 2.11e:
   `tkenc.MovementResolver`; delegates to `combat.MoveEntity` per hex step.
   Builds spatial room + combatant registry + gamectx per step so OA chain
   fires correctly (see `encounter.md` MovementResolver wiring section).
-- `TakeAction` (`take_action.go`) — drives `Encounter.TakeActionPhased`;
-  persists `PendingReactionPrompts` when phase 1 surfaces a player reactor.
+- `TakeAction` (`take_action.go`) — RPC for player-initiated combat actions
+  (Wave 2.8: only the "attack" action ref). Carved onto the v2 orchestrator
+  (`internal/orchestrators/encounter/v2/take_action.go`, #582 step 5): the
+  handler is now proto↔input + sentinel→status mapping; the orchestrator owns
+  load (with the #689 hydration cascade so the resolver reads the held
+  attacker/defender — the #684 double-subscribe cure) → `enc.TakeActionPhased`
+  → persist, and persists `PendingReactionPrompts` + publishes
+  `InputRequiredDelivered` (save-before-publish, #538 A) when phase 1 surfaces a
+  player reactor. The single rulebook-touching piece — marshaling the resolver's
+  native `*combat.AttackContext` into the opaque `AttackContextJSON` — is the
+  injected `ReactionResume.MarshalAttackContext` (the phase-1 counterpart to the
+  SubmitCheck-side decode), kept in `reaction_resume.go` so the orchestrator
+  stays rulebook-free. Joins `Interact`/`SubmitCheck`/`SetReactionReady`/
+  `ActivateFeature` on the orchestrator's single-`load` core.
 - `SubmitCheck` (`submit_check.go` + `submit_check_reaction.go`) — dispatches
   to the reaction branch when the caller's pending prompt is a reaction;
   unmarshals the persisted `AttackContextJSON` back into `combat.AttackContext`

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -157,8 +157,8 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 				// events already went out from inside NPCAct; subscribers
 				// reloading from repo will find no matching prompt and drop
 				// silently — acceptable behavior under single-reactor
-				// semantics. See take_action.go's persistPendingReactions for
-				// the design rationale + Wave 2.11e follow-up
+				// semantics. See the v2 orchestrator's TakeAction
+				// persistPendingReactions for the design rationale + Wave 2.11e follow-up
 				// https://github.com/KirkDiggler/rpg-api/issues/540 for the
 				// proper aggregate-then-complete fix.
 				enforceSingleReactor(enc)

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -137,6 +137,7 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 			},
 		},
 		ReactionResume: encounterorch.ReactionResume{
+			MarshalAttackContext:   marshalReactionAttackContext,
 			DecodeAttackContext:    decodeReactionAttackContext,
 			BuildReactionModifiers: buildReactionModifiers,
 			IsOneShotReaction:      isOneShotReaction,

--- a/internal/handlers/dnd5e/v2/encounter/reaction_resume.go
+++ b/internal/handlers/dnd5e/v2/encounter/reaction_resume.go
@@ -1,12 +1,16 @@
 package encounter
 
-// reaction_resume.go — the rulebook-touching adapter seam for the SubmitCheck
-// take_reaction branch.
+// reaction_resume.go — the rulebook-touching adapter seam for the two-phase
+// attack (TakeAction phase-1 pause + SubmitCheck take_reaction phase-2 resume).
 //
-// The v2 orchestrator runs phase-2 reaction completion (CompleteTakeAction) but
-// stays free of the dnd5e combat rulebook import. The two rule-ish pieces it
-// needs are supplied here as funcs and wired into encounterorch.Config:
+// The v2 orchestrator runs both halves but stays free of the dnd5e combat
+// rulebook import. The rule-ish pieces it needs are supplied here as funcs and
+// wired into encounterorch.Config:
 //
+//   - marshalReactionAttackContext: serializes the in-flight phase-1
+//     PhasedAttackContext (Rulebook slot = the resolver's native
+//     *combat.AttackContext) into the opaque AttackContextJSON persisted on the
+//     pending prompt. The phase-1 counterpart to decodeReactionAttackContext.
 //   - decodeReactionAttackContext: unmarshals the persisted opaque
 //     AttackContextJSON back into the toolkit's PhasedAttackContext, whose
 //     Rulebook slot holds the resolver's native *combat.AttackContext.
@@ -36,6 +40,28 @@ const shieldACBonus = 5
 // reactionShieldRef is the canonical Shield spell condition ref used to select
 // the Shield modifier band.
 const reactionShieldRef = "dnd5e:spells:shield"
+
+// marshalReactionAttackContext serializes the in-flight phase-1
+// PhasedAttackContext returned by TakeActionPhased into the opaque
+// AttackContextJSON the orchestrator persists on the pending reaction prompt.
+// The Rulebook slot holds the resolver's native *combat.AttackContext (made pure
+// data in Wave 2.11d so it round-trips through JSON); this adapter type-asserts
+// it so the orchestrator never touches the rulebook shape. The phase-1
+// counterpart to decodeReactionAttackContext.
+func marshalReactionAttackContext(ctx *tkenc.PhasedAttackContext) ([]byte, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("nil attack context")
+	}
+	rulebookCtx, ok := ctx.Rulebook.(*combat.AttackContext)
+	if !ok {
+		return nil, fmt.Errorf("AttackContext.Rulebook is %T, expected *combat.AttackContext", ctx.Rulebook)
+	}
+	raw, err := json.Marshal(rulebookCtx)
+	if err != nil {
+		return nil, fmt.Errorf("marshal attack context: %w", err)
+	}
+	return raw, nil
+}
 
 // decodeReactionAttackContext unmarshals the persisted opaque AttackContextJSON
 // (written by the phased combat resolver in phase 1) into the toolkit's

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -1,38 +1,51 @@
 package encounter
 
+// take_action.go — TakeAction handler.
+//
+// The handler is a thin envelope over the v2 orchestrator's TakeAction method
+// (#582 step 5, retiring the inline load → verb → persist body). It owns exactly
+// two things:
+//  1. Validate the request envelope (auth, encounter_id, actor_entity_id,
+//     action_ref, target shape) and convert proto → orchestrator Input.
+//  2. Delegate the load → TakeActionPhased verb → persist (+ reaction-prompt
+//     persist/publish) cycle to the orchestrator, mapping its toolkit sentinel
+//     errors onto gRPC status codes.
+//
+// NO rule logic lives here. The toolkit's Encounter.TakeActionPhased owns all
+// rule meaning (mode/turn/combatant gating, the attack hit + damage chain — Rage
+// +2 + physical resistance, Sneak Attack, the reaction-trigger pause). rpg-api
+// passes the action ref + target through by reference and persists the result.
+//
+// Wave 2.8 only wires the "attack" action ref; other refs the toolkit refuses
+// with ErrUnsupportedAction (→ Unimplemented). Only entity-id targeting is wired
+// (position / area / self oneofs are reserved for future waves and rejected here
+// with InvalidArgument because the request shape is wrong, not the world state).
+
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
-	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
-	tkevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 )
 
 // TakeAction dispatches a player-initiated action against the encounter's
-// turn-based combat verbs. Wave 2.8 only wires the "attack" action ref;
-// other refs return Unimplemented.
+// turn-based combat verbs. The handler validates the envelope, converts the
+// proto request to the orchestrator Input, delegates the load → TakeActionPhased
+// → persist cycle to the v2 orchestrator, and maps the toolkit's sentinel errors
+// onto gRPC status codes.
 //
-// The handler is a thin shim over the toolkit's Encounter.TakeAction verb:
-// load → load-from-data → call verb → save. Mode-gating, turn-violation,
-// non-combatant, and unknown-target errors are all surfaced by the toolkit
-// as sentinel errors (encounter.ErrNotTurnBased, ErrNotYourTurn,
-// ErrUnsupportedAction, ErrNonCombatant, ErrUnknownTarget); the handler
-// maps each onto the corresponding gRPC status code.
-//
-// Outcome events (AttackResolvedEvent + DamageDealtEvent on hit) are
-// published per-viewer through the broker by the toolkit verb itself; the
-// handler does not need to translate or echo them in the response. Empty
-// TakeActionResponse is the design — the events deliver state changes.
+// Outcome events (AttackResolved / DamageDealt on hit) are published per-viewer
+// through the broker by the toolkit verb itself; when a player reaction pauses
+// the attack, the orchestrator persists the pending prompt and publishes
+// InputRequiredDelivered to the reactor's stream. The empty TakeActionResponse
+// is the design — the events deliver state changes.
 func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionRequest) (*encounterv2pb.TakeActionResponse, error) {
 	playerID := auth.GetPlayerID(ctx)
 	if playerID == "" {
@@ -60,209 +73,54 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 		return nil, status.Error(codes.InvalidArgument, "target.entity_id is required (only entity-id targeting is supported in this wave)")
 	}
 
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
+	_, err := h.orch.TakeAction(ctx, &encounterorch.TakeActionInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+		ActorID:     core.EntityID(req.GetActorEntityId()),
+		ActionRef: tkenc.ActionRef{
+			Module: req.GetActionRef().GetModule(),
+			Type:   req.GetActionRef().GetType(),
+			ID:     req.GetActionRef().GetId(),
+		},
+		TargetEntityID: core.EntityID(entityID),
+	})
 	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	// Caller must be in the encounter and the actor entity must be the
-	// caller's controlled entity. Read directly from data BEFORE LoadFromData
-	// so we don't pay rehydration cost on the auth-fail path.
-	pd, ok := data.Players[core.PlayerID(playerID)]
-	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
-	}
-	if string(pd.EntityID) != req.GetActorEntityId() {
-		return nil, status.Error(codes.PermissionDenied, "actor_entity_id does not match player's controlled entity")
-	}
-
-	// #689: attach player character blobs (transient) so the hydration cascade
-	// holds the attacker/defender; the combat resolver reads the held entities
-	// (no per-attack re-load — the #684 double-subscribe cure).
-	if attachErr := attachPlayerCharacterData(ctx, data, h.combatResolverConfig.CharacterRepo); attachErr != nil {
-		return nil, status.Errorf(codes.Internal, "attach character data %q: %v", req.GetEncounterId(), attachErr)
-	}
-
-	enc, err := tkenc.LoadFromData(ctx, data, h.broker,
-		tkenc.WithCharacterResolver(h.resolver),
-		tkenc.WithCombatResolver(h.buildCombatResolver(data)),
-		tkenc.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
-	}
-
-	actionRef := tkenc.ActionRef{
-		Module: req.GetActionRef().GetModule(),
-		Type:   req.GetActionRef().GetType(),
-		ID:     req.GetActionRef().GetId(),
-	}
-	target := tkenc.ActionTarget{EntityID: core.EntityID(entityID)}
-
-	// Wave 2.11d: use the phased verb so reaction prompts can surface to
-	// player reactors. Resolved=true → no readied reactions matched, behaves
-	// as the legacy single-phase path. Reactions populated → persist the
-	// in-flight phase-1 state as a pending prompt + push prompt event onto
-	// the reactor's per-viewer stream.
-	outcome, takeErr := enc.TakeActionPhased(core.PlayerID(playerID), actionRef, target)
-	if takeErr != nil {
-		return nil, takeActionStatusError(takeErr)
-	}
-
-	// Wave 2.11d closeout (#538 A): split persist from publish so the save
-	// lands BEFORE InputRequiredDelivered fires. The stream translator
-	// reloads PendingReactionPrompts from the repo when it receives the
-	// event; if we published first, a fast subscriber could see the
-	// pre-prompt snapshot and drop the event as "no matching prompt."
-	var promptsToPublish []core.PlayerID
-	if outcome != nil && len(outcome.Reactions) > 0 {
-		pids, err := h.persistPendingReactions(enc, outcome)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "persist pending reactions: %v", err)
-		}
-		promptsToPublish = pids
-	}
-
-	out := enc.ToData()
-	// #689: ToData cascades held-entity state (e.g. SneakAttack.UsedThisTurn,
-	// RagingCondition.DidAttackThisTurn) back into PlayerData/MonsterData.DataJSON.
-	// Surface a sync failure rather than persisting a stale snapshot.
-	if syncErr := enc.SyncErr(); syncErr != nil {
-		return nil, status.Errorf(codes.Internal, "sync encounter state %q: %v", req.GetEncounterId(), syncErr)
-	}
-	// Flush the cascaded player state back to the authoritative character store
-	// so the next RPC sees it (cross-RPC once-per-turn / rage activity tracking).
-	if err := persistPlayerCharacterData(ctx, out, h.combatResolverConfig.CharacterRepo); err != nil {
-		return nil, status.Errorf(codes.Internal, "persist character data %q: %v", req.GetEncounterId(), err)
-	}
-	if err := h.encRepo.Save(ctx, out); err != nil {
-		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	// Save committed — now safe to publish prompt events. Stream subscribers
-	// that reload from repo will see the persisted prompts.
-	for _, pid := range promptsToPublish {
-		if err := enc.PublishInputRequiredDelivered(pid, tkevents.PromptKindReaction); err != nil {
-			return nil, status.Errorf(codes.Internal, "publish reaction prompt event: %v", err)
-		}
+		return nil, takeActionStatusError(err)
 	}
 
 	return &encounterv2pb.TakeActionResponse{}, nil
 }
 
-// persistPendingReactions records the first eligible player-reaction trigger
-// from the phased outcome as a PendingReactionPrompt on the encounter Data.
-// Returns the list of reactor PlayerIDs whose prompts were persisted (0 or
-// 1 entries — see single-reactor enforcement note below); the caller
-// publishes InputRequiredDelivered for each AFTER the snapshot save commits
-// (Wave 2.11d closeout #538 A: save-before-publish ordering).
+// takeActionStatusError maps the orchestrator's TakeAction errors onto gRPC
+// status codes per pat-v2-status-code-mapping. The orchestrator's load sentinels
+// carry the auth classification; the toolkit verb sentinels (surfaced unwrapped)
+// carry the mode / turn / combatant / target / terminal-state classifications.
 //
-// The PhasedAttackContext (opaque to the SDK; *combat.AttackContext under
-// the hood) is JSON-marshaled and stored on the prompt so SubmitCheck +
-// CompleteTakeAction can rehydrate it on the resume path. This is the
-// load-bearing reason combat.AttackContext was refactored to be pure data
-// in Wave 2.11d (no eventBus/roller fields).
-//
-// Single-reactor enforcement (Wave 2.11d closeout #538 C, Option 1):
-// CompleteTakeAction is destructive — it publishes the AttackResolvedEvent +
-// applies damage once per call. Persisting multiple reactor prompts on the
-// same paused attack risks double-resolution when the second SubmitCheck
-// arrives (each would call CompleteTakeAction with its own modifier list,
-// double-applying damage). For Wave 2.11d's shipped scope (Shield is the
-// only post-hit modifier; OA is fan-out as separate attacks, not modifier
-// stacking) this is correct: the only realistic multi-reactor case in
-// 2.11d would be two wizards both having Shield ready against the same
-// attack, which is a 1-target-per-attack scenario (only the attack target
-// can Shield-self).
-//
-// TODO(wave-2.11e): multi-reactor aggregation for stacked post-hit
-// modifiers (Shield + Counterspell + Lucky reroll). Replace the first-
-// trigger pick with: persist all eligible triggers + gate
-// CompleteTakeAction on all-reactors-responded (or deadline). See
-// https://github.com/KirkDiggler/rpg-api/issues/540 for the design.
-func (h *Handler) persistPendingReactions(
-	enc *tkenc.Encounter,
-	outcome *tkenc.TakeActionOutcome,
-) ([]core.PlayerID, error) {
-	if outcome.AttackContext == nil {
-		return nil, errors.New("phased outcome has reactions but no attack context")
-	}
-	rulebookCtx, ok := outcome.AttackContext.Rulebook.(*combat.AttackContext)
-	if !ok {
-		return nil, fmt.Errorf("AttackContext.Rulebook is %T, expected *combat.AttackContext", outcome.AttackContext.Rulebook)
-	}
-	ctxJSON, err := json.Marshal(rulebookCtx)
-	if err != nil {
-		return nil, fmt.Errorf("marshal attack context: %w", err)
-	}
-
-	// Single-reactor enforcement: pick the first trigger whose reactor we
-	// can resolve to a player. Subsequent triggers are dropped (see TODO
-	// above for the Wave 2.11e aggregation design).
-	for _, trig := range outcome.Reactions {
-		reactorPlayerID, ok := h.reactorPlayerID(enc, trig.ReactorID)
-		if !ok {
-			// SDK contract: only player reactors are surfaced (NPC triggers
-			// auto-resolve inside TakeActionPhased). Missing playerID means
-			// data inconsistency; skip and try the next trigger.
-			continue
-		}
-
-		enc.SetPendingReactionPrompt(reactorPlayerID, &tkenc.PendingReactionPrompt{
-			ReactorEntityID:   trig.ReactorID,
-			ConditionRef:      trig.ConditionRef,
-			TriggerKind:       trig.TriggerKind,
-			SourceEntity:      trig.SourceEntity,
-			AttackContextJSON: ctxJSON,
-		})
-		return []core.PlayerID{reactorPlayerID}, nil
-	}
-
-	// No eligible player-reactor trigger found.
-	return []core.PlayerID{}, nil
-}
-
-// reactorPlayerID resolves the controlling player ID for a reactor entity.
-// Returns false when the entity is not a player-controlled entity (e.g.
-// monster — should never happen on a surfaced reaction since NPC triggers
-// auto-resolve inside TakeActionPhased, but checked defensively).
-func (h *Handler) reactorPlayerID(enc *tkenc.Encounter, reactorID core.EntityID) (core.PlayerID, bool) {
-	for pid, pd := range enc.ToData().Players {
-		if pd.EntityID == reactorID {
-			return pid, true
-		}
-	}
-	return "", false
-}
-
-// takeActionStatusError maps toolkit TakeAction sentinel errors onto gRPC
-// status codes per pat-v2-status-code-mapping (FailedPrecondition for
-// state-dependent failures, Unimplemented for unsupported actions,
-// InvalidArgument for unknown targets that are syntactically valid but
-// don't exist in the encounter — though the toolkit overloads
-// ErrUnknownTarget to also mean state-dependent missing-monster, so we
-// map it to FailedPrecondition).
-//
-// Wave 2.10: ErrEncounterEnded is the terminal-state sentinel returned
-// when verbs are called against an encounter whose mode is ModeEnded.
-// State-dependent → FailedPrecondition.
+//   - ErrEncounterNotFound → NotFound
+//   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
+//   - ErrUnsupportedAction → Unimplemented (only "attack" is wired this wave)
+//   - ErrEncounterEnded / ErrNotTurnBased / ErrNotYourTurn / ErrNonCombatant /
+//     ErrUnknownTarget / ErrNoCombatants → FailedPrecondition (state-dependent;
+//     the toolkit overloads ErrUnknownTarget to also mean missing-monster, so it
+//     maps to FailedPrecondition rather than InvalidArgument)
+//   - load / save / unclassified failures → Internal
 func takeActionStatusError(err error) error {
 	switch {
-	case errors.Is(err, tkenc.ErrEncounterEnded):
-		return status.Error(codes.FailedPrecondition, err.Error())
-	case errors.Is(err, tkenc.ErrNotTurnBased):
-		return status.Error(codes.FailedPrecondition, err.Error())
-	case errors.Is(err, tkenc.ErrNotYourTurn):
-		return status.Error(codes.FailedPrecondition, err.Error())
-	case errors.Is(err, tkenc.ErrNonCombatant):
-		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounterorch.ErrEntityOwnershipMismatch):
+		return status.Error(codes.PermissionDenied,
+			"actor_entity_id does not match player's controlled entity")
 	case errors.Is(err, tkenc.ErrUnsupportedAction):
 		return status.Error(codes.Unimplemented, err.Error())
-	case errors.Is(err, tkenc.ErrUnknownTarget):
-		return status.Error(codes.FailedPrecondition, err.Error())
-	case errors.Is(err, tkenc.ErrNoCombatants):
+	case errors.Is(err, tkenc.ErrEncounterEnded),
+		errors.Is(err, tkenc.ErrNotTurnBased),
+		errors.Is(err, tkenc.ErrNotYourTurn),
+		errors.Is(err, tkenc.ErrNonCombatant),
+		errors.Is(err, tkenc.ErrUnknownTarget),
+		errors.Is(err, tkenc.ErrNoCombatants):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return status.Errorf(codes.Internal, "take action: %v", err)

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -74,13 +74,22 @@ type CharacterDataCascade struct {
 	Persist func(ctx context.Context, data *tkenc.Data) error
 }
 
-// ReactionResume carries the rulebook-touching pieces of the SubmitCheck
-// take_reaction branch as injected funcs, so the orchestrator runs phase-2
-// reaction completion without importing the dnd5e combat rulebook. Both the
-// AttackContext decode (combat.AttackContext is the resolver's native opaque
-// shape) and the take/skip -> ReactionModifier mapping (which carries the
-// rule-ish Shield +5 AC magnitude) are supplied handler-side.
+// ReactionResume carries the rulebook-touching pieces of the two-phase attack
+// (TakeAction phase-1 pause + SubmitCheck take_reaction phase-2 resume) as
+// injected funcs, so the orchestrator runs both halves without importing the
+// dnd5e combat rulebook. The AttackContext marshal/decode (combat.AttackContext
+// is the resolver's native opaque shape) and the take/skip -> ReactionModifier
+// mapping (which carries the rule-ish Shield +5 AC magnitude) are supplied
+// handler-side.
 type ReactionResume struct {
+	// MarshalAttackContext serializes the in-flight PhasedAttackContext returned
+	// by TakeActionPhased (Rulebook = the resolver's native *combat.AttackContext)
+	// into the opaque AttackContextJSON persisted on the pending reaction prompt.
+	// The phase-1 counterpart to DecodeAttackContext; both live handler-side so
+	// the orchestrator never type-asserts the rulebook payload. Required for
+	// TakeAction (only used when a player reaction pauses the attack).
+	MarshalAttackContext func(ctx *tkenc.PhasedAttackContext) ([]byte, error)
+
 	// DecodeAttackContext unmarshals the persisted opaque AttackContextJSON back
 	// into the toolkit's PhasedAttackContext (Rulebook = the resolver's native
 	// *combat.AttackContext). Returns an error on a corrupt blob.

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -86,8 +86,9 @@ type ReactionResume struct {
 	// by TakeActionPhased (Rulebook = the resolver's native *combat.AttackContext)
 	// into the opaque AttackContextJSON persisted on the pending reaction prompt.
 	// The phase-1 counterpart to DecodeAttackContext; both live handler-side so
-	// the orchestrator never type-asserts the rulebook payload. Required for
-	// TakeAction (only used when a player reaction pauses the attack).
+	// the orchestrator never type-asserts the rulebook payload. Required only on
+	// the TakeAction reaction-pause path (when a player reaction pauses the
+	// attack); checked lazily there, so non-phased callers need not wire it.
 	MarshalAttackContext func(ctx *tkenc.PhasedAttackContext) ([]byte, error)
 
 	// DecodeAttackContext unmarshals the persisted opaque AttackContextJSON back

--- a/internal/orchestrators/encounter/v2/take_action.go
+++ b/internal/orchestrators/encounter/v2/take_action.go
@@ -78,9 +78,6 @@ func (o *Orchestrator) TakeAction(ctx context.Context, in *TakeActionInput) (*Ta
 	if in == nil {
 		return nil, errors.New("encounter orchestrator: TakeActionInput is required")
 	}
-	if o.reactionResume.MarshalAttackContext == nil {
-		return nil, errors.New("encounter orchestrator: ReactionResume.MarshalAttackContext is required for TakeAction")
-	}
 
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
@@ -162,6 +159,13 @@ func (o *Orchestrator) persistPendingReactions(
 ) ([]core.PlayerID, error) {
 	if outcome.AttackContext == nil {
 		return nil, errors.New("phased outcome has reactions but no attack context")
+	}
+	// The marshal seam is only needed on this pause path, so it is required
+	// lazily here (not up-front in TakeAction) — non-phased callers that can
+	// never produce reactions need not wire it. A clear error if we reach the
+	// pause path without it beats a nil dereference.
+	if o.reactionResume.MarshalAttackContext == nil {
+		return nil, errors.New("encounter orchestrator: ReactionResume.MarshalAttackContext is required to persist a reaction prompt")
 	}
 	ctxJSON, err := o.reactionResume.MarshalAttackContext(outcome.AttackContext)
 	if err != nil {

--- a/internal/orchestrators/encounter/v2/take_action.go
+++ b/internal/orchestrators/encounter/v2/take_action.go
@@ -1,0 +1,210 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	tkevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+// TakeActionInput carries the entity-typed TakeAction request. The handler
+// builds it from the proto request after envelope validation (auth, empty-id,
+// target-shape) and after loading + serializing the actor's character data
+// (attached via the #689 cascade by load, not passed here).
+type TakeActionInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player taking the action. Membership +
+	// entity ownership are verified by load.
+	PlayerID core.PlayerID
+
+	// ActorID is the entity the player controls and is acting with. load
+	// verifies the encounter maps PlayerID -> ActorID and returns
+	// ErrEntityOwnershipMismatch otherwise (a player may only act with their own
+	// controlled entity). It is also the actor handed to the toolkit verb.
+	ActorID core.EntityID
+
+	// ActionRef is the canonical action reference (module / type / id) the
+	// toolkit verb routes on (Wave 2.8: only id "attack" is wired; other refs
+	// the toolkit refuses with ErrUnsupportedAction). The orchestrator passes it
+	// through by reference, never inspecting which action it is.
+	ActionRef tkenc.ActionRef
+
+	// TargetEntityID is the entity-id target of the action (Wave 2.8: only
+	// entity-id targeting is wired; position / area / self oneofs are reserved
+	// for future waves and validated handler-side). The orchestrator passes it
+	// through to the toolkit verb.
+	TargetEntityID core.EntityID
+}
+
+// TakeActionOutput is the lean result of a TakeAction. Outcome events
+// (AttackResolved / DamageDealt on an inline resolution) flow to clients as
+// broker events, not in this output. When a player reaction pauses the attack,
+// the orchestrator persists the in-flight phase-1 state as a pending prompt and
+// publishes InputRequiredDelivered to the reactor's stream; the empty output is
+// intentional in both cases.
+type TakeActionOutput struct{}
+
+// TakeAction dispatches a player-initiated action against the encounter's
+// turn-based combat verbs: load the encounter with the #689 hydration cascade
+// (so the combat resolver reads the held attacker/defender — the #684
+// double-subscribe cure), invoke the toolkit's two-phase TakeActionPhased verb,
+// and persist.
+//
+// The toolkit owns ALL rules here: it gates mode / turn / combatant / target,
+// runs the combat resolver's hit + damage chain (Rage's +2 damage component and
+// physical resistance, Sneak Attack, etc.), and publishes the per-viewer
+// AttackResolved / DamageDealt events. The orchestrator does no attack math — it
+// loads, invokes the verb by reference, and persists.
+//
+// Phased reaction pause (Wave 2.11d): when phase 1 surfaces a readied player
+// reaction (outcome.Reactions non-empty), NO outcome events fire yet. The
+// orchestrator persists the in-flight phase-1 attack context as a pending
+// reaction prompt on the snapshot, saves, THEN publishes InputRequiredDelivered
+// to the reactor's stream. The save-before-publish ordering (rpg-api#538 A) is
+// load-bearing: the stream translator reloads PendingReactionPrompts from the
+// repo when it receives the event, so a fast subscriber must never see the
+// pre-prompt snapshot. The reactor later resolves via SubmitReactionCheck.
+//
+// The single rulebook-touching piece — serializing the resolver's native
+// attack-context payload into the opaque AttackContextJSON — is injected as
+// ReactionResume.MarshalAttackContext (handler-side), so the orchestrator never
+// type-asserts the rulebook shape.
+func (o *Orchestrator) TakeAction(ctx context.Context, in *TakeActionInput) (*TakeActionOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: TakeActionInput is required")
+	}
+	if o.reactionResume.MarshalAttackContext == nil {
+		return nil, errors.New("encounter orchestrator: ReactionResume.MarshalAttackContext is required for TakeAction")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		EntityID:    string(in.ActorID),
+		// #689: combat-capable verb — attach the player character blobs so the
+		// resolver reads the held attacker/defender rather than re-loading them
+		// mid-attack (the #684 double-subscribe cure).
+		WithCharacterData: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	outcome, takeErr := enc.TakeActionPhased(in.PlayerID, in.ActionRef, tkenc.ActionTarget{EntityID: in.TargetEntityID})
+	if takeErr != nil {
+		// The toolkit returns typed sentinels for its gates (ErrNotTurnBased,
+		// ErrNotYourTurn, ErrUnsupportedAction, ErrNonCombatant, ErrUnknownTarget,
+		// ErrEncounterEnded, ErrNoCombatants). Surface them unwrapped so the
+		// handler maps each distinctly via errors.Is.
+		return nil, takeErr
+	}
+	// Defensive nil check: TakeActionPhased must return non-nil outcome on
+	// success (project rule: never return (nil, nil)). Guard so a future toolkit
+	// regression produces a clean error rather than a nil dereference below.
+	if outcome == nil {
+		return nil, errors.New("encounter orchestrator: toolkit TakeActionPhased returned nil outcome with nil error")
+	}
+
+	// Phased reaction pause: persist the in-flight phase-1 state as a pending
+	// prompt BEFORE saving so the snapshot carries it; collect reactor PlayerIDs
+	// to notify AFTER the save commits (rpg-api#538 A save-before-publish).
+	var promptsToPublish []core.PlayerID
+	if len(outcome.Reactions) > 0 {
+		pids, persistErr := o.persistPendingReactions(enc, outcome)
+		if persistErr != nil {
+			return nil, fmt.Errorf("persist pending reactions %q: %w", in.EncounterID, persistErr)
+		}
+		promptsToPublish = pids
+	}
+
+	if err := o.persistWithCharacterData(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+
+	// Save committed — now safe to publish prompt events. Stream subscribers
+	// that reload from the repo will see the persisted prompts.
+	for _, pid := range promptsToPublish {
+		if err := enc.PublishInputRequiredDelivered(pid, tkevents.PromptKindReaction); err != nil {
+			return nil, fmt.Errorf("publish reaction prompt event %q: %w", in.EncounterID, err)
+		}
+	}
+
+	return &TakeActionOutput{}, nil
+}
+
+// persistPendingReactions records the first eligible player-reaction trigger
+// from the phased outcome as a PendingReactionPrompt on the encounter snapshot.
+// Returns the list of reactor PlayerIDs whose prompts were persisted (0 or 1
+// entries — see single-reactor enforcement note) for the caller to publish
+// InputRequiredDelivered AFTER the snapshot save commits.
+//
+// The phase-1 attack context (opaque to the SDK; the resolver's native
+// *combat.AttackContext under the hood) is serialized via the injected
+// ReactionResume.MarshalAttackContext, keeping the rulebook type assertion
+// handler-side. The orchestrator routes triggers to players by reference (entity
+// -> controlling player) — orchestration, not rules.
+//
+// Single-reactor enforcement (rpg-api#538 C, Option 1): CompleteTakeAction is
+// destructive (publishes AttackResolved + applies damage once per call), so
+// persisting multiple reactor prompts on the same paused attack risks
+// double-resolution. For the shipped scope (Shield is the only post-hit
+// modifier; OA is fan-out as separate attacks, not modifier stacking) picking
+// the first resolvable player trigger is correct. Multi-reactor aggregation is
+// tracked as rpg-api#540.
+func (o *Orchestrator) persistPendingReactions(
+	enc *tkenc.Encounter,
+	outcome *tkenc.TakeActionOutcome,
+) ([]core.PlayerID, error) {
+	if outcome.AttackContext == nil {
+		return nil, errors.New("phased outcome has reactions but no attack context")
+	}
+	ctxJSON, err := o.reactionResume.MarshalAttackContext(outcome.AttackContext)
+	if err != nil {
+		return nil, fmt.Errorf("marshal attack context: %w", err)
+	}
+
+	// Single-reactor enforcement: pick the first trigger whose reactor resolves
+	// to a player. Subsequent triggers are dropped (see rpg-api#540).
+	for i := range outcome.Reactions {
+		trig := outcome.Reactions[i]
+		reactorPlayerID, ok := o.reactorPlayerID(enc, trig.ReactorID)
+		if !ok {
+			// SDK contract: only player reactors are surfaced (NPC triggers
+			// auto-resolve inside TakeActionPhased). Missing playerID means data
+			// inconsistency; skip and try the next trigger.
+			continue
+		}
+
+		enc.SetPendingReactionPrompt(reactorPlayerID, &tkenc.PendingReactionPrompt{
+			ReactorEntityID:   trig.ReactorID,
+			ConditionRef:      trig.ConditionRef,
+			TriggerKind:       trig.TriggerKind,
+			SourceEntity:      trig.SourceEntity,
+			AttackContextJSON: ctxJSON,
+		})
+		return []core.PlayerID{reactorPlayerID}, nil
+	}
+
+	// No eligible player-reactor trigger found.
+	return []core.PlayerID{}, nil
+}
+
+// reactorPlayerID resolves the controlling player for a reactor entity through
+// the encounter's synced snapshot (the same "ask the encounter for its state"
+// surface Interact uses for doors). Returns false when the entity is not a
+// player-controlled seat (e.g. a monster — should never happen on a surfaced
+// reaction since NPC triggers auto-resolve inside TakeActionPhased, but checked
+// defensively).
+func (o *Orchestrator) reactorPlayerID(enc *tkenc.Encounter, reactorID core.EntityID) (core.PlayerID, bool) {
+	for pid, pd := range enc.ToData().Players {
+		if pd.EntityID == reactorID {
+			return pid, true
+		}
+	}
+	return "", false
+}

--- a/internal/orchestrators/encounter/v2/take_action_test.go
+++ b/internal/orchestrators/encounter/v2/take_action_test.go
@@ -1,0 +1,241 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// TakeAction orchestrator tests (#582 step 5). These exercise the orchestrator's
+// load → TakeActionPhased verb → persist core directly, proving:
+//   - the shared load preconditions (membership + entity ownership) classify as
+//     the orchestrator sentinels the handler maps to gRPC codes;
+//   - toolkit verb gates (unsupported action, not-your-turn, unknown target,
+//     non-turn-based) surface UNWRAPPED so the handler maps each distinctly;
+//   - the inline-resolution happy path (no readied reactions) resolves the
+//     attack, applies damage to the target, and persists the snapshot.
+//
+// The phased reaction-pause path (player reactor → pending prompt persisted +
+// InputRequiredDelivered published) is covered end-to-end through the handler by
+// the Shield + barbarian-rage integration suites; these unit tests use a
+// non-phased stand-in CombatResolver so TakeActionPhased takes the inline
+// Resolved=true branch, isolating the orchestrator's load/persist contract.
+
+const (
+	taEncID     = "enc-take-action"
+	taPlayerBob = "bob"
+	taEntityBob = "char-bob"
+	taGoblinID  = "goblin-ta"
+	taAttackRef = "attack"
+)
+
+// stubCombatResolver is a non-phased CombatResolver that returns a fixed hit for
+// a deterministic damage amount. Because it does NOT implement
+// PhasedCombatResolver, TakeActionPhased runs the inline single-phase branch
+// (Resolved=true) — no reaction triggers, the cleanest path to prove the
+// orchestrator's load → verb → persist contract without a rulebook.
+type stubCombatResolver struct {
+	damage int
+}
+
+func (r stubCombatResolver) ResolveAttack(input tkenc.AttackInput) (*tkenc.AttackOutcome, error) {
+	return &tkenc.AttackOutcome{
+		Hit:        true,
+		AttackRoll: 15,
+		TargetAC:   input.TargetAC,
+		Damage:     r.damage,
+		DamageType: input.AttackerDamageType,
+	}, nil
+}
+
+type TakeActionSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *TakeActionSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		// Stand-in combat resolver: fixed 7-damage hit, non-phased so the inline
+		// resolution branch runs (no reaction prompts in these unit tests).
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return stubCombatResolver{damage: 7}
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		// MarshalAttackContext is required by TakeAction even though the
+		// non-phased stand-in never produces a reaction to marshal.
+		ReactionResume: encounterorch.ReactionResume{
+			MarshalAttackContext: func(_ *tkenc.PhasedAttackContext) ([]byte, error) {
+				return []byte(`{}`), nil
+			},
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedCombat persists a turn-based encounter with bob (player, combatant) and a
+// goblin (monster), then forces bob to be the active actor by overriding the
+// randomly-rolled initiative on the saved snapshot. Deterministic so TakeAction
+// always passes the active-actor gate for bob.
+func (s *TakeActionSuite) seedCombat(encID string, goblinHP int) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    taPlayerBob,
+		EntityID:    taEntityBob,
+		Position:    core.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID:          taGoblinID,
+		Position:    core.Hex{Q: 1, R: 0, S: -1},
+		HP:          goblinHP,
+		MaxHP:       goblinHP,
+		AC:          15,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	data := enc.ToData()
+	// Force bob active so the active-actor gate passes deterministically.
+	data.Initiative = []core.EntityID{taEntityBob, taGoblinID}
+	data.ActiveIdx = 0
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+}
+
+func (s *TakeActionSuite) takeAttack(encID, actor, target string) (*encounterorch.TakeActionOutput, error) {
+	return s.orch.TakeAction(s.ctx, &encounterorch.TakeActionInput{
+		EncounterID:    encID,
+		PlayerID:       taPlayerBob,
+		ActorID:        core.EntityID(actor),
+		ActionRef:      tkenc.ActionRef{Module: "dnd5e", Type: "action", ID: taAttackRef},
+		TargetEntityID: core.EntityID(target),
+	})
+}
+
+// --- nil input ---
+
+func (s *TakeActionSuite) TestTakeAction_NilInput_Error() {
+	_, err := s.orch.TakeAction(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+// --- load preconditions ---
+
+func (s *TakeActionSuite) TestTakeAction_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.takeAttack("nope", taEntityBob, taGoblinID)
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *TakeActionSuite) TestTakeAction_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-no-player", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other", EntityID: "other-char", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.takeAttack("enc-no-player", taEntityBob, taGoblinID)
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+func (s *TakeActionSuite) TestTakeAction_EntityMismatch_ErrEntityOwnershipMismatch() {
+	s.seedCombat("enc-mismatch", 100)
+	_, err := s.takeAttack("enc-mismatch", "char-someone-else", taGoblinID)
+	s.Require().ErrorIs(err, encounterorch.ErrEntityOwnershipMismatch)
+}
+
+// --- toolkit gate sentinels surface UNWRAPPED so the handler maps distinctly ---
+
+func (s *TakeActionSuite) TestTakeAction_UnsupportedAction_ErrUnsupportedAction() {
+	s.seedCombat("enc-unsupported", 100)
+	_, err := s.orch.TakeAction(s.ctx, &encounterorch.TakeActionInput{
+		EncounterID:    "enc-unsupported",
+		PlayerID:       taPlayerBob,
+		ActorID:        taEntityBob,
+		ActionRef:      tkenc.ActionRef{Module: "dnd5e", Type: "action", ID: "dodge"},
+		TargetEntityID: taGoblinID,
+	})
+	s.Require().ErrorIs(err, tkenc.ErrUnsupportedAction)
+}
+
+func (s *TakeActionSuite) TestTakeAction_UnknownTarget_ErrUnknownTarget() {
+	s.seedCombat("enc-unknown-target", 100)
+	_, err := s.takeAttack("enc-unknown-target", taEntityBob, "no-such-monster")
+	s.Require().ErrorIs(err, tkenc.ErrUnknownTarget)
+}
+
+func (s *TakeActionSuite) TestTakeAction_NotTurnBased_ErrNotTurnBased() {
+	// Free-roam encounter: TakeActionPhased gates on ModeTurnBased.
+	enc := tkenc.New(s.ctx, "enc-free-roam", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: taPlayerBob, EntityID: taEntityBob, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+		HP: 14, MaxHP: 14, AC: 14, AttackBonus: 5, DamageDice: "1d12+3", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: taGoblinID, Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 100, MaxHP: 100, AC: 15, Speed: 6,
+		MonsterRef: "dnd5e:monsters:goblin", AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.takeAttack("enc-free-roam", taEntityBob, taGoblinID)
+	s.Require().ErrorIs(err, tkenc.ErrNotTurnBased)
+}
+
+// --- happy path: inline resolution applies damage + persists snapshot ---
+//
+// Proves the orchestrator's load → TakeActionPhased(inline) → persist contract:
+// the stand-in resolver's 7-damage hit lands, the goblin's HP drops 100 → 93,
+// and the snapshot is persisted (the next Get sees the reduced HP). No reaction
+// prompt is set because the non-phased resolver never triggers one.
+func (s *TakeActionSuite) TestTakeAction_InlineResolution_AppliesDamageAndPersists() {
+	const goblinStartHP = 100
+	s.seedCombat(taEncID, goblinStartHP)
+
+	out, err := s.takeAttack(taEncID, taEntityBob, taGoblinID)
+	s.Require().NoError(err, "inline attack resolution must succeed via the toolkit verb")
+	s.Require().NotNil(out)
+
+	loaded, getErr := s.repo.Get(s.ctx, taEncID)
+	s.Require().NoError(getErr)
+	s.Require().NotNil(loaded)
+
+	goblin, ok := loaded.Monsters[taGoblinID]
+	s.Require().True(ok, "goblin must still be in the persisted snapshot")
+	s.Equal(goblinStartHP-7, goblin.HP, "goblin HP must drop by the resolver's 7 damage and persist")
+
+	// No reaction prompt on the inline (non-phased) path.
+	s.Empty(loaded.PendingReactionPrompts, "inline resolution must not persist a pending reaction prompt")
+}
+
+func TestTakeActionSuite(t *testing.T) {
+	suite.Run(t, new(TakeActionSuite))
+}


### PR DESCRIPTION
**Part of #582** (chunk 2, step 5: TakeAction — the first attack verb).

Carves the `TakeAction` attack verb off the inline handler body onto `Orchestrator.TakeAction`, matching the merged #582 pattern: shared `load(ctx, in)` (2-return, no side `*Data`) → `enc.TakeActionPhased` → `persistWithCharacterData` (SyncErr check + #689 character flush). The handler is now thin proto↔input + sentinel→gRPC status mapping; the inline load/verb/persist/reaction body is deleted.

## What moved
- **Orchestrator `TakeAction`** (`internal/orchestrators/encounter/v2/take_action.go`): load (with the #689 hydration cascade so the combat resolver reads the **held** attacker/defender — the #684 double-subscribe cure, never a re-load) → `TakeActionPhased` → persist. The phased reaction pause (player reactor → `persistPendingReactions` sets the pending prompt, save, then `PublishInputRequiredDelivered`) moves into the orchestrator, preserving the save-before-publish ordering (#538 A).
- **Rulebook seam stays handler-side**: the one rulebook-touching piece — marshaling the resolver's native `*combat.AttackContext` into the opaque `AttackContextJSON` — is the new injected `ReactionResume.MarshalAttackContext` (the phase-1 counterpart to the existing `DecodeAttackContext`), kept in `reaction_resume.go`. The orchestrator never type-asserts the rulebook shape. The `Dnd5eCombatResolver` remains handler-side, injected behind its interface.
- **Thin handler** (`internal/handlers/dnd5e/v2/encounter/take_action.go`): envelope validation + proto→Input + `takeActionStatusError` mapping. Toolkit gate sentinels (`ErrUnsupportedAction`, `ErrNotTurnBased`, `ErrNotYourTurn`, `ErrNonCombatant`, `ErrUnknownTarget`, `ErrNoCombatants`, `ErrEncounterEnded`) surface unwrapped from the orchestrator so the handler maps each distinctly via `errors.Is`.

## depguard
Added `internal/orchestrators/encounter/v2/take_action.go` to the guarded `files:` set (NOT the resolver adapters). Verified the guard fires: injecting a `rulebooks/dnd5e/conditions` import produces `import '…/conditions' is not allowed from list 'no-rulebook-internals-in-action-handlers' (depguard)`.

## Rage+combat behavior preserved
`TestIntegration_RageResistance_HalvesGoblinDamage` exercises this exact path and passes through the carved `TakeAction`:
- non-raging baseline goblin damage = **8** (scimitar 1d6 + DEX +2, fixedRoller{10})
- raging = **4** (floor(8/2), Rage halves physical damage)

All four barbarian-rage integration tests + the Shield/sneak-attack/movement-OA suites pass on the carved path.

## Tests
New `take_action_test.go` orchestrator suite: nil input, load preconditions (`ErrEncounterNotFound` / `ErrPlayerNotInEncounter` / `ErrEntityOwnershipMismatch`), toolkit-gate passthrough (unwrapped `ErrUnsupportedAction` / `ErrUnknownTarget` / `ErrNotTurnBased`), and the inline-resolution happy path (damage applied + snapshot persisted, no pending prompt).

## Verification
- `go build ./...` + `go test -race ./internal/orchestrators/encounter/v2/... ./internal/handlers/dnd5e/v2/encounter/...` green
- depguard fires on the new orchestrator file (verified)
- Pre-existing repo conditions (NOT introduced here, identical on `main`): the #580 mockgen import-order drift across 13 unrelated mocks, and 70 pre-existing golangci-lint issues in v1alpha1/legacy files. CI (`test.yml`) runs `make generate` + `go test -race` only — no lint job — and is green. My changed files pass lint/fmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)