### PR TITLE
feat(encounter/v2): carve MoveEntity onto the orchestrator (#582 step 6)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,8 +52,9 @@ linters:
         #     interact, submit_check, handler, create, get)
         #   - the v2 encounter orchestrator method files (orchestrator, load,
         #     interact, submit_check, submit_check_reaction, set_reaction_ready,
-        #     activate_feature, take_action) under internal/orchestrators/encounter/v2
-        #     (rpg-api#582): load → toolkit-verb → persist, by reference only.
+        #     activate_feature, take_action, move_entity) under
+        #     internal/orchestrators/encounter/v2 (rpg-api#582): load →
+        #     toolkit-verb → persist, by reference only.
         # Excludes: combat/movement resolver files (translate held entities → the
         # rulebook chain; legitimately import combat/character/monster/weapons),
         # hydrate_players.go (marshals the character blob for the SDK cascade),
@@ -88,6 +89,7 @@ linters:
             - "**/internal/orchestrators/encounter/v2/set_reaction_ready.go"
             - "**/internal/orchestrators/encounter/v2/activate_feature.go"
             - "**/internal/orchestrators/encounter/v2/take_action.go"
+            - "**/internal/orchestrators/encounter/v2/move_entity.go"
           deny:
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
               desc: "game logic belongs in the toolkit — do not import dnd5e conditions in action handler files"

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -13,7 +13,7 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 
 | File | Purpose |
 |---|---|
-| `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct, constructor, MoveEntity, StreamEncounter |
+| `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct, constructor, MoveEntity (thin delegate → v2 orchestrator `move_entity.go`, #582 step 6), StreamEncounter |
 | `internal/handlers/dnd5e/v2/encounter/create.go` | CreateEncounter RPC |
 | `internal/handlers/dnd5e/v2/encounter/get.go` | GetEncounter RPC |
 | `internal/handlers/dnd5e/v2/encounter/interact.go` | Interact RPC (Wave 2.7 — door interactions) |

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -60,6 +60,20 @@ What's here as of Wave 2.11e:
   SubmitCheck-side decode), kept in `reaction_resume.go` so the orchestrator
   stays rulebook-free. Joins `Interact`/`SubmitCheck`/`SetReactionReady`/
   `ActivateFeature` on the orchestrator's single-`load` core.
+- `MoveEntity` (`handler.go`) — RPC for moving a player's controlled entity
+  along a proposed path. Carved onto the v2 orchestrator
+  (`internal/orchestrators/encounter/v2/move_entity.go`, #582 step 6): the
+  handler is now proto↔input (proto positions → `core.Hex`) + sentinel→status
+  mapping; the orchestrator owns load (with the #689 hydration cascade so the
+  movement resolver reads the held mover — the #684 double-subscribe cure) →
+  `enc.Move` → `persistWithCharacterData`. Empty-path is classified as
+  `ErrEmptyPath` after load so the auth sentinels keep precedence; toolkit Move
+  refusals join `ErrMoveRefused` → `FailedPrecondition`. The opportunity-attack
+  resolution rides the injected `BuildMovementResolver` (the rulebook-importing
+  `Dnd5eMovementResolver` translation seam stays handler-side); its lookup-only
+  threatener load runs on a throwaway bus (not the encounter bus), so it is not a
+  #684 source and is carried as-is. Joins the rest of the verbs on the
+  orchestrator's single-`load` core.
 - `SubmitCheck` (`submit_check.go` + `submit_check_reaction.go`) — dispatches
   to the reaction branch when the caller's pending prompt is a reaction;
   unmarshals the persisted `AttackContextJSON` back into `combat.AttackContext`

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -173,11 +173,19 @@ func (h *Handler) buildMovementResolver(data *encounter.Data) *Dnd5eMovementReso
 	return NewDnd5eMovementResolverForData(h.movementResolverConfig, data)
 }
 
-// MoveEntity loads the encounter, validates that the request's entity_id matches
-// the auth player's controlled entity, dispatches to the toolkit's Encounter.Move
-// verb (which publishes per-viewer events to the broker), and saves the updated
-// state. The empty MoveEntityResponse is by proto design — world changes flow as
-// events on StreamEncounter.
+// MoveEntity moves the auth player's controlled entity along a proposed path.
+// The handler validates the envelope (auth, encounter_id), converts the proto
+// path positions to core.Hex, delegates the load → Move verb → persist cycle to
+// the v2 orchestrator (#582 step 6, retiring the inline body), and maps the
+// orchestrator's sentinel errors onto gRPC status codes. The empty
+// MoveEntityResponse is by proto design — world changes (the mover landing,
+// opportunity attacks resolving) flow as events on StreamEncounter.
+//
+// NO rule logic lives here. The toolkit's Encounter.Move owns all movement rules
+// (per-step MovementChain, opportunity-attack triggers, path truncation); the
+// movement resolver (the rulebook-importing tkenc↔dnd5e seam) is injected into
+// the orchestrator via BuildMovementResolver, so the orchestrator stays
+// rulebook-free.
 func (h *Handler) MoveEntity(ctx context.Context, req *encounterv2pb.MoveEntityRequest) (*encounterv2pb.MoveEntityResponse, error) {
 	playerID := auth.GetPlayerID(ctx)
 	if playerID == "" {
@@ -187,67 +195,53 @@ func (h *Handler) MoveEntity(ctx context.Context, req *encounterv2pb.MoveEntityR
 		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
 	}
 
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
-	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	// entity_id validation: the player's controlled entity must match the
-	// request's entity_id. Read from data BEFORE LoadFromData consumes it.
-	pd, ok := data.Players[core.PlayerID(playerID)]
-	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
-	}
-	if string(pd.EntityID) != req.GetEntityId() {
-		return nil, status.Error(codes.PermissionDenied, "entity_id does not match player's controlled entity")
-	}
-
-	if len(req.GetProposedPath()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "proposed_path is required")
-	}
-
-	// #689: attach player character blobs (transient) so the hydration cascade
-	// holds the mover; the movement resolver reads the held mover (no re-load).
-	if attachErr := attachPlayerCharacterData(ctx, data, h.combatResolverConfig.CharacterRepo); attachErr != nil {
-		return nil, status.Errorf(codes.Internal, "attach character data %q: %v", req.GetEncounterId(), attachErr)
-	}
-
-	enc, err := encounter.LoadFromData(ctx, data, h.broker,
-		encounter.WithCharacterResolver(h.resolver),
-		encounter.WithCombatResolver(h.buildCombatResolver(data)),
-		encounter.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
-	}
-
+	// Proto → entity conversion: the path positions become toolkit hexes. Empty
+	// path is classified by the orchestrator (ErrEmptyPath) AFTER load so the auth
+	// sentinels keep precedence over the argument-shaped error.
 	path := make([]core.Hex, 0, len(req.GetProposedPath()))
 	for _, p := range req.GetProposedPath() {
 		path = append(path, core.Hex{Q: int(p.X), R: int(p.Y), S: int(p.Z)})
 	}
 
-	if err := enc.Move(core.PlayerID(playerID), path); err != nil {
-		// Toolkit Move errors are state-dependent (turn order, blocked path,
-		// out-of-range, entity not in encounter, etc.) — these are
-		// FailedPrecondition per gRPC convention. Empty-path is the only
-		// genuinely argument-shaped error and is filtered before we reach Move.
-		return nil, status.Errorf(codes.FailedPrecondition, "move: %v", err)
-	}
-
-	out := enc.ToData()
-	if syncErr := enc.SyncErr(); syncErr != nil {
-		return nil, status.Errorf(codes.Internal, "sync encounter state %q: %v", req.GetEncounterId(), syncErr)
-	}
-	if err := persistPlayerCharacterData(ctx, out, h.combatResolverConfig.CharacterRepo); err != nil {
-		return nil, status.Errorf(codes.Internal, "persist character data %q: %v", req.GetEncounterId(), err)
-	}
-	if err := h.encRepo.Save(ctx, out); err != nil {
-		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
+	_, err := h.orch.MoveEntity(ctx, &encounterorch.MoveEntityInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+		EntityID:    core.EntityID(req.GetEntityId()),
+		Path:        path,
+	})
+	if err != nil {
+		return nil, moveEntityStatusError(err)
 	}
 
 	return &encounterv2pb.MoveEntityResponse{}, nil
+}
+
+// moveEntityStatusError maps the orchestrator's MoveEntity errors onto gRPC
+// status codes per pat-v2-status-code-mapping. The orchestrator's load sentinels
+// carry the auth classification; ErrEmptyPath is the argument-shaped error; the
+// toolkit Move refusals (joined with ErrMoveRefused) carry the state-dependent
+// classification.
+//
+//   - ErrEncounterNotFound → NotFound
+//   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
+//   - ErrEmptyPath → InvalidArgument (the request shape is wrong, not the state)
+//   - ErrMoveRefused → FailedPrecondition (turn order, blocked path, out-of-range)
+//   - load / save / unclassified failures → Internal
+func moveEntityStatusError(err error) error {
+	switch {
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounterorch.ErrEntityOwnershipMismatch):
+		return status.Error(codes.PermissionDenied,
+			"entity_id does not match player's controlled entity")
+	case errors.Is(err, encounterorch.ErrEmptyPath):
+		return status.Error(codes.InvalidArgument, "proposed_path is required")
+	case errors.Is(err, encounterorch.ErrMoveRefused):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	}
+	return status.Errorf(codes.Internal, "move entity: %v", err)
 }
 
 // StreamEncounter opens a server-streaming session for the authenticated player.

--- a/internal/orchestrators/encounter/v2/move_entity.go
+++ b/internal/orchestrators/encounter/v2/move_entity.go
@@ -1,0 +1,119 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ErrEmptyPath means the MoveEntity request carried no proposed path. The
+// handler maps it to codes.InvalidArgument (the request shape is wrong, not the
+// world state). It is checked AFTER load so the load preconditions (NotFound /
+// PermissionDenied) keep their precedence over this argument-shaped error —
+// matching the inline handler the carve replaces.
+var ErrEmptyPath = errors.New("proposed path is required")
+
+// ErrMoveRefused wraps a state-dependent refusal from the toolkit's Move verb
+// (turn order, blocked path, out-of-range, entity not in encounter, etc.). The
+// toolkit returns these as plain fmt.Errorf rather than typed sentinels, so the
+// orchestrator joins them with this sentinel and the handler maps it to
+// codes.FailedPrecondition per pat-v2-status-code-mapping (mirrors
+// ErrDoorVerbRefused / ErrActivateFeatureRefused / ErrSetReactionReadyRefused on
+// the other verbs). Empty-path is filtered before Move via ErrEmptyPath, so the
+// only errors reaching here are genuinely state-dependent.
+var ErrMoveRefused = errors.New("move refused")
+
+// MoveEntityInput carries the entity-typed MoveEntity request. The handler
+// builds it from the proto request after envelope validation (auth, empty
+// encounter id) and converts the proto path positions into core.Hex (the
+// proto↔entity conversion stays handler-side; the orchestrator speaks core.Hex).
+type MoveEntityInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player moving the entity. Membership +
+	// entity ownership are verified by load.
+	PlayerID core.PlayerID
+
+	// EntityID is the entity the player controls and is moving. load verifies the
+	// encounter maps PlayerID -> EntityID and returns ErrEntityOwnershipMismatch
+	// otherwise (a player may only move their own controlled entity).
+	EntityID core.EntityID
+
+	// Path is the proposed movement path as toolkit hexes. The orchestrator
+	// passes it through to the toolkit Move verb, which owns all movement rules
+	// (per-step MovementChain, opportunity-attack triggers via the injected
+	// movement resolver, path truncation when a step is prevented). Empty path is
+	// classified as ErrEmptyPath after load.
+	Path []core.Hex
+}
+
+// MoveEntityOutput is the lean result of a MoveEntity. World changes (the mover
+// landing, opportunity attacks resolving against the mover) flow to clients as
+// broker events published per-viewer by the toolkit verb, not in this output —
+// so the empty output is intentional, matching the empty proto MoveEntityResponse.
+type MoveEntityOutput struct{}
+
+// MoveEntity moves a player's controlled entity along a proposed path: load the
+// encounter with the #689 hydration cascade (so the movement resolver reads the
+// held mover rather than re-loading it mid-move — the #684 double-subscribe
+// cure), invoke the toolkit's Move verb, and persist.
+//
+// The toolkit owns ALL movement rules: per-step MovementChain dispatch, the
+// opportunity-attack trigger/resolve path (a fleeing combatant leaving reach),
+// and path truncation when a step is prevented (Disengage). The orchestrator
+// does no movement math — it loads, invokes Move by reference, and persists.
+//
+// The opportunity-attack resolution rides the injected movement resolver
+// (BuildMovementResolver), which is the tkenc↔rulebook translation seam kept
+// handler-side (the resolver legitimately imports the dnd5e rulebook; the
+// orchestrator stays rulebook-free). The resolver's lookup-only threatener load
+// (loadCharacterForLookup) runs on a throwaway bus — NOT the encounter bus — so
+// it is not a #684 source; it is carried faithfully as-is.
+func (o *Orchestrator) MoveEntity(ctx context.Context, in *MoveEntityInput) (*MoveEntityOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: MoveEntityInput is required")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		EntityID:    string(in.EntityID),
+		// #689: combat-capable verb — attach the player character blobs so the
+		// movement resolver reads the held mover (and the held OA-condition
+		// instances on the encounter bus fire) rather than re-loading them
+		// mid-move (the #684 double-subscribe cure).
+		WithCharacterData: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Empty-path is the one genuinely argument-shaped error. Checked AFTER load so
+	// the auth sentinels keep precedence (the inline handler validated emptiness
+	// after the Get for the same reason). The toolkit Move also rejects it, but
+	// classifying it here lets the handler return InvalidArgument distinctly from
+	// the FailedPrecondition state refusals.
+	if len(in.Path) == 0 {
+		return nil, ErrEmptyPath
+	}
+
+	if moveErr := enc.Move(in.PlayerID, in.Path); moveErr != nil {
+		// Toolkit Move errors are state-dependent (turn order, blocked path,
+		// out-of-range, entity not in encounter, etc.) — join with the sentinel so
+		// the handler maps to FailedPrecondition without string matching.
+		return nil, fmt.Errorf("%w: %w", ErrMoveRefused, moveErr)
+	}
+
+	// persistWithCharacterData flushes the cascaded player DataJSON back to the
+	// character store (so the next RPC re-attaches fresh state and the snapshot
+	// does not carry a soon-stale char blob) after the SyncErr check, then saves —
+	// mirroring the inline handler's persistPlayerCharacterData + Save.
+	if err := o.persistWithCharacterData(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+
+	return &MoveEntityOutput{}, nil
+}

--- a/internal/orchestrators/encounter/v2/move_entity_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_test.go
@@ -1,0 +1,164 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// MoveEntity orchestrator tests (#582 step 6). These exercise the orchestrator's
+// load → Move verb → persist core directly, proving:
+//   - the shared load preconditions (membership + entity ownership) classify as
+//     the orchestrator sentinels the handler maps to gRPC codes;
+//   - empty-path classifies as ErrEmptyPath AFTER load (so the auth sentinels
+//     keep precedence over the argument-shaped error);
+//   - the happy path moves the player to the path destination and persists.
+//
+// The opportunity-attack path (a fleeing combatant leaving reach → resolver
+// triggers an OA) is covered end-to-end through the handler by the movement-OA
+// integration suite; these unit tests wire a nil movement resolver so the
+// toolkit Move takes the legacy single-jump branch (no OAs), isolating the
+// orchestrator's load → verb → persist contract.
+
+const (
+	meEncID     = "enc-move-entity"
+	mePlayerAmy = "amy"
+	meEntityAmy = "char-amy"
+)
+
+type MoveEntitySuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *MoveEntitySuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return nil
+		},
+		// nil movement resolver: the toolkit Move takes the legacy single-jump
+		// branch (no per-step chain, no OAs) — the cleanest path to prove the
+		// orchestrator's load → Move → persist contract without a rulebook.
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedMover persists a free-roam encounter with amy controlling char-amy at the
+// origin. Move has no turn-order gate (slice scope), so no initiative override
+// is needed.
+func (s *MoveEntitySuite) seedMover(encID string) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   mePlayerAmy,
+		EntityID:   meEntityAmy,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		HP:         14,
+		MaxHP:      14,
+		AC:         14,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+}
+
+func (s *MoveEntitySuite) move(encID, entity string, path []core.Hex) (*encounterorch.MoveEntityOutput, error) {
+	return s.orch.MoveEntity(s.ctx, &encounterorch.MoveEntityInput{
+		EncounterID: encID,
+		PlayerID:    mePlayerAmy,
+		EntityID:    core.EntityID(entity),
+		Path:        path,
+	})
+}
+
+// --- nil input ---
+
+func (s *MoveEntitySuite) TestMoveEntity_NilInput_Error() {
+	_, err := s.orch.MoveEntity(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+// --- load preconditions ---
+
+func (s *MoveEntitySuite) TestMoveEntity_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.move("nope", meEntityAmy, []core.Hex{{Q: 1, R: -1, S: 0}})
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *MoveEntitySuite) TestMoveEntity_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-no-player", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other", EntityID: "other-char", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.move("enc-no-player", meEntityAmy, []core.Hex{{Q: 1, R: -1, S: 0}})
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+func (s *MoveEntitySuite) TestMoveEntity_EntityMismatch_ErrEntityOwnershipMismatch() {
+	s.seedMover("enc-mismatch")
+	_, err := s.move("enc-mismatch", "char-someone-else", []core.Hex{{Q: 1, R: -1, S: 0}})
+	s.Require().ErrorIs(err, encounterorch.ErrEntityOwnershipMismatch)
+}
+
+// --- empty path classified AFTER load (auth sentinels keep precedence) ---
+
+func (s *MoveEntitySuite) TestMoveEntity_EmptyPath_ErrEmptyPath() {
+	s.seedMover("enc-empty-path")
+	_, err := s.move("enc-empty-path", meEntityAmy, nil)
+	s.Require().ErrorIs(err, encounterorch.ErrEmptyPath)
+}
+
+// Empty path on a MISSING encounter must classify as the load sentinel, NOT
+// ErrEmptyPath — proving the empty-path check runs after load.
+func (s *MoveEntitySuite) TestMoveEntity_EmptyPathMissingEncounter_LoadSentinelWins() {
+	_, err := s.move("nope", meEntityAmy, nil)
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+	s.Require().NotErrorIs(err, encounterorch.ErrEmptyPath)
+}
+
+// --- happy path: moves to destination + persists snapshot ---
+
+func (s *MoveEntitySuite) TestMoveEntity_HappyPath_MovesAndPersists() {
+	s.seedMover(meEncID)
+
+	out, err := s.move(meEncID, meEntityAmy, []core.Hex{
+		{Q: 0, R: 0, S: 0},
+		{Q: 1, R: -1, S: 0},
+	})
+	s.Require().NoError(err, "move must succeed via the toolkit verb")
+	s.Require().NotNil(out)
+
+	loaded, getErr := s.repo.Get(s.ctx, meEncID)
+	s.Require().NoError(getErr)
+	s.Require().NotNil(loaded)
+	s.Require().Contains(loaded.Players, core.PlayerID(mePlayerAmy))
+	s.Equal(core.Hex{Q: 1, R: -1, S: 0}, loaded.Players[mePlayerAmy].View.Position,
+		"mover must land at the path destination and persist")
+}
+
+func TestMoveEntitySuite(t *testing.T) {
+	suite.Run(t, new(MoveEntitySuite))
+}


### PR DESCRIPTION
Part of #582 (chunk 2, step 6: MoveEntity).

Carves the `MoveEntity` verb off the inline handler body onto `Orchestrator.MoveEntity` in a new `internal/orchestrators/encounter/v2/move_entity.go`, matching the merged #582 pattern (shared `load(ctx, in)` → `enc.<verb>` → `persistWithCharacterData` + `SyncErr()`; thin handler; sentinel-wrap; depguard).

## What changed

- **New `internal/orchestrators/encounter/v2/move_entity.go`** — `Orchestrator.MoveEntity` owns `load` (with the #689 hydration cascade so the movement resolver reads the held mover rather than re-loading it mid-move — the #684 double-subscribe cure) → `enc.Move` → `persistWithCharacterData`. Two sentinels: `ErrEmptyPath` (→ InvalidArgument) and `ErrMoveRefused` (toolkit Move state refusals → FailedPrecondition).
- **Thin handler** — `Handler.MoveEntity` is now envelope validation (auth, encounter_id) + proto→`core.Hex` conversion + delegate + `moveEntityStatusError` mapping. The inline `Get`/membership/entity-id/attach/`LoadFromData`/`Move`/`SyncErr`/persist/`Save` body is deleted.
- **Empty-path classified AFTER load** so the auth sentinels (NotFound / PermissionDenied) keep precedence over the argument-shaped error — matching the inline handler's ordering, proven by a dedicated test.
- **Movement resolver stays handler-side** — the rulebook-importing `Dnd5eMovementResolver` (and its lookup-only `loadCharacterForLookup` on a throwaway bus, which is NOT a #684 source — carried as-is) is injected behind `BuildMovementResolver`. The orchestrator never imports the rulebook.
- **depguard** — `move_entity.go` added to the guarded `files:` set (resolver adapters stay excluded). Verified the guard fires on a rulebook import.
- **Docs** — `quality.md` gains a MoveEntity carve entry; `encounter.md` handler.go row notes the delegate.

## Boundary

No rules logic in the orchestrator: it loads, invokes `enc.Move` by reference, and persists. All movement rules (per-step MovementChain, OA triggers, path truncation) live in the toolkit; the tkenc↔rulebook seam is the injected movement resolver.

## Verification

- `go build ./...` + `go test ./...` green.
- Existing handler MoveEntity tests + the movement-OA integration suite pass through the carved path (movement + opportunity-attack behavior preserved).
- New orchestrator suite: load preconditions, empty-path-after-load precedence, move-and-persist happy path.
- depguard fires on a forbidden rulebook import in `move_entity.go` (verified).
- `make ci-check`: the only two flags are the pre-existing repo-wide #580 mockgen-version drift (13 mocks, none for touched code) and pre-existing lint noise in `internal/integration/harness` + `internal/components/dungeon` (untouched files; `golangci-lint run` exits 0). No findings in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)