### PR TITLE
feat(encounter): carve EndTurn onto the v2 orchestrator (#582 step 7, final verb)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,8 +42,8 @@ linters:
         # Architecture invariant: the core action-verb handler files in the v2
         # encounter package AND the v2 encounter orchestrator method files must
         # never import rpg-toolkit rulebook internals (conditions, resources,
-        # classes, weapons, armor). All rule logic belongs in the toolkit; rpg-api
-        # is a thin shuttle. If you need one of these types in a handler or
+        # classes, weapons, armor, combat). All rule logic belongs in the toolkit;
+        # rpg-api is a thin shuttle. If you need one of these types in a handler or
         # orchestrator file, you are about to add business logic — stop and push
         # the logic into the toolkit instead.
         #
@@ -52,7 +52,7 @@ linters:
         #     interact, submit_check, handler, create, get)
         #   - the v2 encounter orchestrator method files (orchestrator, load,
         #     interact, submit_check, submit_check_reaction, set_reaction_ready,
-        #     activate_feature, take_action, move_entity) under
+        #     activate_feature, take_action, move_entity, end_turn) under
         #     internal/orchestrators/encounter/v2 (rpg-api#582): load →
         #     toolkit-verb → persist, by reference only.
         # Excludes: combat/movement resolver files (translate held entities → the
@@ -61,9 +61,16 @@ linters:
         # reaction_resume.go (the SubmitCheck take_reaction adapter seam: decodes
         # the opaque combat.AttackContext blob + carries the Shield +5 AC
         # magnitude — kept handler-side so the orchestrator stays rulebook-free),
-        # tests. reaction_conditions.go is gone: OA now rides the toolkit's #689
-        # hydration cascade, so rpg-api no longer constructs conditions.New* and
-        # that depguard exclusion is retired.
+        # tests. These excluded files are NOT in the guarded set below, so denying
+        # combat does not affect them. reaction_conditions.go is gone: OA now rides
+        # the toolkit's #689 hydration cascade, so rpg-api no longer constructs
+        # conditions.New* and that depguard exclusion is retired.
+        #
+        # combat is denied (rpg-api#582 step 7): the EndTurn carve moved the last
+        # combat.AttackContext marshal out of the guarded handler end_turn.go into
+        # the injected ReactionResume.MarshalAttackContext adapter (reaction_resume.go,
+        # excluded). No guarded file imports combat any more, so the boundary is
+        # locked shut here to stop future re-introduction.
         #
         # This rule fires CI so drift is caught by the pipeline, not reviewer memory.
         no-rulebook-internals-in-action-handlers:
@@ -90,6 +97,7 @@ linters:
             - "**/internal/orchestrators/encounter/v2/activate_feature.go"
             - "**/internal/orchestrators/encounter/v2/take_action.go"
             - "**/internal/orchestrators/encounter/v2/move_entity.go"
+            - "**/internal/orchestrators/encounter/v2/end_turn.go"
           deny:
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
               desc: "game logic belongs in the toolkit — do not import dnd5e conditions in action handler files"
@@ -101,6 +109,8 @@ linters:
               desc: "game logic belongs in the toolkit — do not import dnd5e weapons in action handler files"
             - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
               desc: "game logic belongs in the toolkit — do not import dnd5e armor in action handler files"
+            - pkg: "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+              desc: "game logic belongs in the toolkit — do not import dnd5e combat in action handler / orchestrator files; the opaque AttackContext marshal/decode lives in the injected ReactionResume adapter (reaction_resume.go, excluded)"
 
     dupl:
       threshold: 300  # Allow duplication for bidirectional converters (tool enums are ~90 lines)

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,24 +1,32 @@
 ---
 name: encounter (v1alpha2)
-description: v1alpha2 encounter service — lightweight toolkit adapter, no orchestrator
-updated: 2026-05-25
-confidence: high — verified by reading handler.go, dnd5e_movement_resolver.go, dnd5e_combat_resolver.go, hex_room.go, reaction_conditions.go, integration_movement_oa_test.go
+description: v1alpha2 encounter service — thin handlers over a clean load→verb→persist orchestrator
+updated: 2026-05-31
+confidence: high — verified by reading handler.go, end_turn.go, orchestrators/encounter/v2/{orchestrator,load,end_turn,take_action,move_entity,submit_check_reaction}.go, reaction_resume.go, .golangci.yml, combat_handlers_test.go
 ---
 
 # encounter (v1alpha2)
 
-The v1alpha2 encounter service is the second-generation encounter handler. Unlike the v1alpha1 handler which delegates through a full orchestrator stack, v2 talks directly to the rpg-toolkit encounter SDK and a v2 repository. The handler is a thin wire adapter — no business logic, no orchestrator.
+The v1alpha2 encounter service is the second-generation encounter vertical. As of the #582 carve (Chapter 1, Architecture Honesty) it is split into two layers:
+
+- **Handlers** (`internal/handlers/dnd5e/v2/encounter/`) do proto ↔ entity conversion only: validate the envelope (auth, required ids), build the orchestrator's entity-typed Input, delegate, and map the orchestrator's sentinel errors onto gRPC status codes. No business logic, no load/persist.
+- **Orchestrator** (`internal/orchestrators/encounter/v2/`) is the single `load → toolkit-verb → persist` core — one method per RPC, each doing exactly one load + one toolkit-verb dispatch + one persist. It speaks entity / toolkit types only and NEVER imports proto (`pb.*`). This replaced the retired handler-package `Runner` + the scattered inline verb bodies.
+
+The orchestrator stays **rulebook-free**. All game complexity lives in the rpg-toolkit encounter SDK + the dnd5e rulebook, reached only through injected adapters (the combat / movement resolver builders and the `ReactionResume` seam) built handler-side. A depguard lint rule (`no-rulebook-internals-in-action-handlers`) denies `rulebooks/dnd5e/{conditions,resources,classes,weapons,armor,combat}` in both the guarded handler verb files and the orchestrator method files; the resolver-adapter files (which legitimately translate held entities through the rulebook) are excluded and not in the guarded set.
 
 ## Files
 
 | File | Purpose |
 |---|---|
-| `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct, constructor, MoveEntity (thin delegate → v2 orchestrator `move_entity.go`, #582 step 6), StreamEncounter |
-| `internal/handlers/dnd5e/v2/encounter/create.go` | CreateEncounter RPC |
-| `internal/handlers/dnd5e/v2/encounter/get.go` | GetEncounter RPC |
-| `internal/handlers/dnd5e/v2/encounter/interact.go` | Interact RPC (Wave 2.7 — door interactions) |
+| `internal/handlers/dnd5e/v2/encounter/handler.go` | Handler struct + constructor (wires the orchestrator with the injected resolver builders, `CharacterDataCascade`, and `ReactionResume` funcs), MoveEntity, StreamEncounter |
+| `internal/handlers/dnd5e/v2/encounter/{create,get,interact,take_action,submit_check,submit_check_reaction,set_reaction_ready,activate_feature,end_turn}.go` | Thin verb handlers — proto↔entity + delegate to the orchestrator + sentinel→gRPC mapping |
+| `internal/handlers/dnd5e/v2/encounter/reaction_resume.go` | Rulebook-touching adapter seam (excluded from depguard): marshal/decode the opaque `*combat.AttackContext`, build reaction modifiers (Shield +5 AC), one-shot-reaction predicate — injected into the orchestrator's `ReactionResume` |
+| `internal/handlers/dnd5e/v2/encounter/{dnd5e_combat_resolver,dnd5e_combat_resolver_phased,dnd5e_movement_resolver,combatant,hydrate_players}.go` | Resolver / cascade adapters (excluded from depguard) — translate held entities through the rulebook |
 | `internal/handlers/dnd5e/v2/encounter/project.go` | ProjectFor helper — toolkit Data → proto Encounter |
 | `internal/handlers/dnd5e/v2/encounter/translate.go` | Event translator — toolkit events → proto EncounterEvent |
+| `internal/orchestrators/encounter/v2/orchestrator.go` | Orchestrator struct + `Config` (Broker, repo, resolver builders, `CharacterDataCascade`, `ReactionResume`) + `New` |
+| `internal/orchestrators/encounter/v2/load.go` | The single load core: Get → auth (membership + optional entity-ownership) → #689 character-data attach → `LoadFromData` with resolvers wired uniformly. Defines `ErrEncounterNotFound` / `ErrPlayerNotInEncounter` / `ErrEntityOwnershipMismatch` |
+| `internal/orchestrators/encounter/v2/{interact,take_action,move_entity,submit_check,submit_check_reaction,set_reaction_ready,activate_feature,end_turn}.go` | One orchestrator method per RPC |
 | `internal/repositories/encounters/v2/repository.go` | Repository interface (Get, Save) |
 | `internal/repositories/encounters/v2/in_memory.go` | In-memory implementation (JSON round-trip) |
 | `internal/repositories/encounters/v2/redis.go` | Redis implementation |
@@ -30,8 +38,38 @@ The v1alpha2 encounter service is the second-generation encounter handler. Unlik
 | `CreateEncounter` | Implemented (#499) | 2.6 |
 | `GetEncounter` | Implemented (#500) | 2.6 |
 | `StreamEncounter` | Implemented (#496, replay #497) | 2.5 / 2.7 |
-| `MoveEntity` | Implemented (#496) | 2.5 |
-| `Interact` | Implemented for doors (#504) | 2.7 |
+| `MoveEntity` | Implemented; orchestrator carve #582 step 6 | 2.5 |
+| `Interact` | Implemented for doors (#504); orchestrator carve #582 | 2.7 |
+| `TakeAction` | Implemented (two-phase); orchestrator carve #582 step 5 | 2.8 / 2.11d |
+| `SubmitCheck` | Implemented (skill check + take_reaction branch); orchestrator carve #582 | 2.9 / 2.11d |
+| `SetReactionReady` | Implemented; orchestrator carve #582 | 2.11d |
+| `ActivateFeature` | Implemented; orchestrator carve #582 step 4 | 2.x |
+| `EndTurn` | Implemented; orchestrator carve #582 step 7 (final verb) | 2.10 / 2.11d |
+
+## Orchestrator method anatomy (the `load → verb → persist` shape)
+
+Every orchestrator method follows the same skeleton (see `move_entity.go`, `take_action.go`, `end_turn.go`):
+
+1. Nil-guard the `*Input` (never `(nil, nil)`).
+2. `o.load(ctx, loadInput{...})` — Get + auth + (combat-capable verbs) the #689 character-data attach + `LoadFromData`. Auth runs before rehydration so the auth-fail path pays no rehydration cost. Returns ONLY the encounter (the synced state); there is no parallel `*Data` handle to drift.
+3. Invoke the toolkit verb on the encounter. Toolkit gate sentinels (`ErrEncounterEnded`, `ErrNotTurnBased`, `ErrNotYourTurn`, `ErrNoCombatants`, `ErrUnsupportedAction`, `ErrUnknownTarget`, …) surface **unwrapped** so the handler maps each distinctly via `errors.Is`. State-dependent refusals that the toolkit returns as plain errors are joined with a verb-specific sentinel (e.g. `ErrMoveRefused`).
+4. `o.persistWithCharacterData(ctx, enc, encID)` — `ToData` + `SyncErr` check + (combat-capable) flush the cascaded player `DataJSON` back to the character store + `Save`.
+
+### EndTurn specifics (#582 step 7)
+
+`Orchestrator.EndTurn` carries three concerns, all kept rulebook-free:
+
+1. **NPC-dispatch loop** — after the toolkit `enc.EndTurn` advances initiative, if the new active actor is an NPC the orchestrator runs `enc.NPCAct` + `enc.EndTurn`-the-NPC server-side until a player is active, the encounter ends (`enc.Mode() == ModeEnded`), or the roster-derived cap (`len(enc.ToData().Initiative) + npcChainSafetyMargin`) is hit. The cap is read from the synced snapshot, not a side `*Data`.
+2. **Turn-end reset** — clean post-#689: `enc.EndTurn(ctx, …)` emits the dnd5e `TurnEndTopic` on the encounter bus itself, so held conditions (SneakAttack, etc.) reset their per-turn state in place — no host-side publish, no character re-load.
+3. **Pause-for-reaction bookkeeping** — when a dispatched NPC attack pauses (`IsNPCPausedForReaction`), the SDK has already persisted the pending prompt + published `InputRequiredDelivered` from inside `NPCAct`. The orchestrator drops all-but-one prompt (`enforceSingleReactor`, single-reactor enforcement per #538 C) and marshals the cached `*combat.AttackContext` into the prompt's `AttackContextJSON` via the **injected `ReactionResume.MarshalAttackContext`** (`serializeNPCPendingReactions`) — the SAME seam TakeAction phase-1 uses — then persists and returns success.
+
+`ErrNPCChainExhausted` (no players in initiative) and `ErrNPCAct` (system-shaped NPCAct failure) are the orchestrator-specific sentinels; the handler maps the former to `FailedPrecondition` and the latter to `Internal`. `ErrNPCChainExhausted` is a defensive guard — unreachable through the player-gated entrypoint (the first `EndTurn` requires the player to be active, so the player is always in initiative and the loop re-reaches them on wrap).
+
+### Reaction resume seam (`reaction_resume.go`)
+
+The two-phase attack (TakeAction phase-1 pause → SubmitReactionCheck phase-2 resume, and the NPC-pause serialization) needs the rulebook's opaque `*combat.AttackContext` marshaled/decoded and the rule-ish reaction magnitudes (Shield = +5 AC). These live in `reaction_resume.go` (handler-side, depguard-excluded) and are injected into the orchestrator as the `ReactionResume` struct: `MarshalAttackContext`, `DecodeAttackContext`, `BuildReactionModifiers`, `IsOneShotReaction`. The orchestrator never type-asserts the rulebook payload — it calls the injected funcs.
+
+**Deferred:** the cross-RPC reaction *wire-pause* is NOT built. NPC reaction pauses resolve through the existing single-RPC `SubmitReactionCheck`; the reaction step stays internal.
 
 ## CreateEncounter flow
 
@@ -133,13 +171,13 @@ Implements `spatial.Room` over the encounter's `*tkenc.Data`. Key methods:
 - `MoveEntity` — mutates positions in-place so successive `ResolveStep` calls see updated state within the same RPC.
 - `GetGrid()` returns `SquareGrid` (Chebyshev distance). This is required because `OpportunityAttackCondition.isLeavingMyThreatRange` calls `room.GetGrid().Distance(...)`, and `HexGrid` expects offset coordinates while our positions carry axial values (Q→X, R→Y). SquareGrid + adjacent hexes (axial distance 1) gives correct D&D 5e adjacency.
 
-### Reaction conditions (`reaction_conditions.go`)
+### Reaction conditions (post-#689: toolkit-cascade owned)
 
-`applyReactionConditions` and `applyMonsterReactionConditions` are called on every character/monster rehydration (inside the combat resolver at entity-load time). They wire:
+The standalone `reaction_conditions.go` is **gone**. rpg-api no longer constructs `conditions.New*` for player OA/Shield: the #689 hydration cascade holds each combatant's `*character.Character` (with its conditions already applied) on the encounter bus exactly once per RPC, so player reaction conditions ride that held instance rather than being re-applied handler-side. This was the cure for the #684 double-subscribe class. The cascade is plumbed via `CharacterDataCascade` (attach before `LoadFromData`, persist after `ToData`), injected into the orchestrator handler-side.
 
-- `OpportunityAttackCondition` on every melee combatant (character + monster). The condition's predicate gates on `IsReactionReady` — the encounter SDK's `seedOAReadiness` seeds this to `true` for every combatant with `DamageDice` set at `AddPlayer`/`AddMonster`.
-- `ShieldSpellCondition` on characters with at least one 1st-level spell slot (heuristic gate).
-- **Not applied**: `DisengagingCondition`. Its predicate has no "activated this turn" gate — applying universally would suppress OAs for everyone. Disengage must go through `combatabilities.Disengage.Activate` on the encounter's bus, which applies the condition itself. Cross-RPC persistence (condition applied in TakeAction, needed in MoveEntity) is a follow-up.
+The one survivor is `applyMonsterReactionConditions` (in `dnd5e_movement_resolver.go`, a depguard-excluded adapter), which wires `OpportunityAttackCondition` on monsters at rehydration time — without it, NPC-direction OA never fires because the condition's bus subscription never installs. Its predicate gates on `IsReactionReady`, which the encounter SDK's `seedOAReadiness` seeds to `true` for every combatant with `DamageDice` set at `AddPlayer`/`AddMonster`.
+
+**Not applied**: `DisengagingCondition`. Its predicate has no "activated this turn" gate — applying universally would suppress OAs for everyone. Disengage must go through `combatabilities.Disengage.Activate` on the encounter's bus, which applies the condition itself. Cross-RPC persistence (condition applied in TakeAction, needed in MoveEntity) is a follow-up.
 
 ### Known gaps / deferred scope
 
@@ -152,7 +190,8 @@ Implements `spatial.Room` over the encounter's `*tkenc.Data`. Key methods:
 
 ## Architecture notes
 
-- Handler imports no orchestrator — direct toolkit dependency is intentional for v2.
+- As of #582 the action-verb handlers delegate to the `internal/orchestrators/encounter/v2` orchestrator (one `load → verb → persist` method per RPC); the handler-package `Runner` + inline verb bodies are retired. `CreateEncounter` / `GetEncounter` / `StreamEncounter` still touch the repo + `ProjectFor` directly (read/projection paths, not action verbs). The orchestrator imports the toolkit but NEVER proto; the handlers own all proto↔entity conversion.
+- The orchestrator stays rulebook-free — rulebook-touching work (resolver translation, the `*combat.AttackContext` marshal/decode, reaction magnitudes, the #689 character-blob cascade) lives in handler-side adapter funcs injected via `Config`, and depguard enforces no `rulebooks/dnd5e/{conditions,resources,classes,weapons,armor,combat}` import in the guarded handler + orchestrator files.
 - `encounter.Broker` is process-scoped (one broker per server process, shared across all v2 RPCs).
 - Repository follows the standard Input/Output interface pattern but `Get` returns `*encounter.Data` directly (toolkit's native type is the domain entity here).
 - Entity ID in CreateEncounter defaults to player ID for the initial seat; future PRs will wire in character selection.

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,24 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**Chapter 1 (Architecture Honesty) — v2 encounter orchestrator carve COMPLETE (#582, 2026-05-31)** —
+The v2 encounter vertical now runs through a clean `internal/orchestrators/encounter/v2`
+orchestrator: one method per RPC, each doing exactly one `load → toolkit-verb → persist`.
+The handler-package `Runner` + scattered inline verb bodies are retired. EndTurn was the
+final verb (step 7): `Orchestrator.EndTurn` owns the NPC-dispatch loop, the (post-#689 clean)
+turn-end reset via `enc.EndTurn`, and the pause-for-reaction prompt bookkeeping. The handler
+`end_turn.go` is now the ~25-line canonical shape (auth + envelope + `EndTurnInput` + delegate
++ `endTurnStatusError`). The orchestrator stays rulebook-free: the one rulebook-touching piece
+on the NPC pause path — marshaling the opaque `*combat.AttackContext` — reuses the existing
+injected `ReactionResume.MarshalAttackContext` adapter (the same seam TakeAction phase-1 uses).
+Depguard now denies `rulebooks/dnd5e/combat` in the guarded handler + orchestrator files (the
+last `combat` import left those files with the EndTurn carve), locking the boundary shut.
+Behavior parity is proven by the unchanged handler `TestEndTurn_*` suite; new orchestrator-level
+`EndTurnSuite` + `EndTurnPauseSuite` cover load/verb/persist + the prompt-bookkeeping helpers.
+**Note:** the cross-RPC reaction wire-pause remains DEFERRED — the NPC reaction step stays
+internal (resolved via the already-carved `SubmitReactionCheck` single-RPC). #582 closes after
+the playtest sign-off.
+
 **Chapter 2 Wave 2 (monk) — Entity.armor_class populated in v2 snapshot (2026-05-29)** —
 `ProjectFor` now sets `Entity.armor_class` for both players (`PlayerData.AC`) and monsters
 (`MonsterData.AC`) when the value is non-zero. Charli's AC=15 (UnarmoredDefense) and the

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -2,56 +2,35 @@ package encounter
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
-	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 )
 
-// npcChainSafetyMargin is added to the initiative roster size to derive the
-// per-call NPC dispatch cap. The cap (initiative_len + margin) lets the loop
-// cycle past every combatant once and absorb a few extra rounds of pure-NPC
-// initiative without deadlocking, while still bounding the worst case.
+// EndTurn ends the active actor's turn, advances initiative, and — when the new
+// active actor is an NPC — dispatches the toolkit's NPCAct verb server-side
+// until a player is active, the encounter ends, or the NPC-chain cap is reached.
 //
-// Why "len(Initiative) + margin" instead of a fixed value: with a fixed cap
-// of N, an all-NPC encounter (initiative larger than N — degenerate but
-// possible if a future scenario seeds 20 monsters and 0 players) would exit
-// the loop with an NPC still active. Since EndTurn requires a player-owned
-// entity_id, the RPC would deadlock — players couldn't progress past the
-// NPC chain.
+// The handler is thin (#582 step 7, the final verb carve): validate the
+// envelope (auth, encounter_id, entity_id), build the entity-typed EndTurnInput,
+// delegate the load → EndTurn verb (+ NPC dispatch loop + pause-for-reaction
+// serialization) → persist cycle to the v2 orchestrator, and map the
+// orchestrator's sentinel errors onto gRPC status codes. The empty
+// EndTurnResponse is by proto design — initiative advancement and NPC-turn
+// outcomes flow as events on StreamEncounter.
 //
-// With the size-derived cap, the loop is guaranteed to either reach a player
-// or exhaust the entire roster (in which case the encounter genuinely has no
-// players and the deadlock is the encounter's own design, not the handler's).
-// We still surface a defensive error if the cap is hit while isNPC is true
-// (see the post-loop check below) so operators can spot misconfigured
-// encounters rather than seeing them silently freeze.
-const npcChainSafetyMargin = 4
-
-// EndTurn ends the active actor's turn, advances initiative, and — when the
-// new active actor is an NPC — dispatches the toolkit's NPCAct verb on
-// behalf of the server. The NPC dispatch loop continues cycling through any
-// chain of consecutive NPC turns until the active actor is a player or the
-// chain depth cap is reached.
-//
-// This is the orchestrator-side half of pat-v2-npc-turn-dispatch: the
-// toolkit's EndTurn returns (newActiveID, isNPC, err) so the handler knows
-// whether to call NPCAct without re-querying state. After NPCAct returns,
-// the handler must call EndTurn again to advance the NPC's turn — NPCAct
-// itself is single-purpose (resolve the NPC's action) and does not touch
-// turn state.
-//
-// Mode-gating, turn-violation, no-combatants errors are surfaced by the
-// toolkit and mapped per pat-v2-status-code-mapping.
+// NO rule logic lives here. The toolkit owns the turn-end reset (the #689
+// TurnEndTopic publish that resets per-turn conditions) and all NPC combat
+// resolution; the one rulebook-touching piece on the NPC pause-for-reaction path
+// (marshaling the opaque *combat.AttackContext) lives in the injected
+// ReactionResume adapter, so the orchestrator stays rulebook-free.
 func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest) (*encounterv2pb.EndTurnResponse, error) {
 	playerID := auth.GetPlayerID(ctx)
 	if playerID == "" {
@@ -64,281 +43,39 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 		return nil, status.Error(codes.InvalidArgument, "entity_id is required")
 	}
 
-	data, err := h.encRepo.Get(ctx, req.GetEncounterId())
-	if err != nil {
-		if errors.Is(err, encountersv2.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "encounter not found")
-		}
-		return nil, status.Errorf(codes.Internal, "load encounter %q: %v", req.GetEncounterId(), err)
-	}
-
-	// Caller must be in the encounter and the entity_id must be the caller's
-	// controlled entity (you can't end someone else's turn). The toolkit
-	// also enforces "is the active actor" via ErrNotYourTurn.
-	pd, ok := data.Players[core.PlayerID(playerID)]
-	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
-	}
-	if string(pd.EntityID) != req.GetEntityId() {
-		return nil, status.Error(codes.PermissionDenied, "entity_id does not match player's controlled entity")
-	}
-
-	// #689: attach player character blobs (transient) so the hydration cascade
-	// holds each combatant; the held conditions reset on the SDK's TurnEndTopic
-	// publish below — no separate character re-load.
-	if attachErr := attachPlayerCharacterData(ctx, data, h.combatResolverConfig.CharacterRepo); attachErr != nil {
-		return nil, status.Errorf(codes.Internal, "attach character data %q: %v", req.GetEncounterId(), attachErr)
-	}
-
-	enc, err := tkenc.LoadFromData(ctx, data, h.broker,
-		tkenc.WithCharacterResolver(h.resolver),
-		tkenc.WithCombatResolver(h.buildCombatResolver(data)),
-		tkenc.WithMovementResolver(h.buildMovementResolver(data)))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "load from data %q: %v", req.GetEncounterId(), err)
-	}
-
-	endingEntityID := req.GetEntityId()
-	// #689: EndTurn(ctx, ...) now emits dnd5eEvents.TurnEndTopic on the
-	// encounter bus itself, so held conditions (e.g. SneakAttack) reset their
-	// per-turn state in place with no re-load. The old host-side
-	// publishTurnEndAndPersistReset (a scattered character re-load guarded by
-	// defer Cleanup) is gone — the SDK owns the turn-boundary publish, and
-	// ToData persists the reset state back. The TurnEndTopic publish error is
-	// now propagated by the SDK (it is the ONLY thing that resets per-turn
-	// state), so a failure surfaces here rather than being swallowed.
-	newActive, isNPC, err := enc.EndTurn(ctx, core.EntityID(endingEntityID))
+	_, err := h.orch.EndTurn(ctx, &encounterorch.EndTurnInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+		EntityID:    core.EntityID(req.GetEntityId()),
+	})
 	if err != nil {
 		return nil, endTurnStatusError(err)
-	}
-
-	// NPC dispatch loop. After the toolkit's EndTurn advances initiative, if
-	// the new active actor is an NPC the handler runs its turn server-side
-	// and ends it, then re-checks. The cap is initiative-size + margin so an
-	// all-NPC roster cycles all the way through rather than freezing the RPC.
-	//
-	// Wave 2.10: after each NPCAct / EndTurn cycle, if the encounter has
-	// transitioned to ModeEnded (e.g., NPC's attack killed the last hostile
-	// — not possible today since killEntity only runs in TakeAction's
-	// player-attack path, but cheap insurance for future paths like
-	// faction-on-faction NPC kills, environmental damage, etc.), break out
-	// of the loop. The post-loop save persists the terminal state and the
-	// RPC returns success — the EncounterEnded event already fired through
-	// the broker, and the next combat verb will get ErrEncounterEnded.
-	npcChainCap := len(data.Initiative) + npcChainSafetyMargin
-	for depth := 0; isNPC && depth < npcChainCap; depth++ {
-		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
-			// Wave 2.11d: NPC turn paused for a player reaction. The encounter
-			// has the pending reaction prompt + the InputRequiredDelivered event
-			// already published BY THE SDK from inside NPCAct (encounter/npc.go
-			// at the player-trigger loop). Marshal the cached PhasedAttackContext
-			// into the prompt's AttackContextJSON so SubmitCheck can rebuild it
-			// on resume, then save and return success — the player must respond
-			// before the NPC's turn (and the rest of the dispatch loop) continues.
-			//
-			// Wave 2.11d closeout (#538 B): the SDK-side publish-then-host-
-			// serialize ordering creates a race window where a fast stream
-			// subscriber reloads from repo BEFORE the host's
-			// serializePendingPhasedAttacks call + Save below. The subscriber
-			// could see either the old snapshot (no prompt at all) or a
-			// snapshot with a prompt but AttackContextJSON=nil. The proper
-			// fix lives in the SDK: a resolver-supplied serializer callback
-			// that lets the SDK populate AttackContextJSON itself BEFORE
-			// publishing the event. Tracked in
-			// https://github.com/KirkDiggler/rpg-toolkit/issues/657 (implicit
-			// in https://github.com/KirkDiggler/rpg-toolkit/issues/658 for
-			// movement-paused reactions). We cannot fix this at the rpg-api
-			// layer without changing the SDK contract — the publish happens
-			// inside NPCAct, before we return here.
-			if tkenc.IsNPCPausedForReaction(actErr) {
-				// Single-reactor enforcement (Wave 2.11d closeout #538 C,
-				// Option 1): if the SDK persisted multiple prompts for this
-				// pause, drop all but the first. Orphan InputRequiredDelivered
-				// events already went out from inside NPCAct; subscribers
-				// reloading from repo will find no matching prompt and drop
-				// silently — acceptable behavior under single-reactor
-				// semantics. See the v2 orchestrator's TakeAction
-				// persistPendingReactions for the design rationale + Wave 2.11e follow-up
-				// https://github.com/KirkDiggler/rpg-api/issues/540 for the
-				// proper aggregate-then-complete fix.
-				enforceSingleReactor(enc)
-				if err := h.serializePendingPhasedAttacks(enc); err != nil {
-					return nil, status.Errorf(codes.Internal, "serialize npc pending reactions: %v", err)
-				}
-				pauseData := enc.ToData()
-				if syncErr := enc.SyncErr(); syncErr != nil {
-					return nil, status.Errorf(codes.Internal, "sync encounter state %q: %v", req.GetEncounterId(), syncErr)
-				}
-				if persistErr := persistPlayerCharacterData(ctx, pauseData, h.combatResolverConfig.CharacterRepo); persistErr != nil {
-					return nil, status.Errorf(codes.Internal, "persist character data %q: %v", req.GetEncounterId(), persistErr)
-				}
-				if saveErr := h.encRepo.Save(ctx, pauseData); saveErr != nil {
-					return nil, status.Errorf(codes.Internal,
-						"save encounter %q after npc reaction pause: %v",
-						req.GetEncounterId(), saveErr)
-				}
-				return &encounterv2pb.EndTurnResponse{}, nil
-			}
-			// NPCAct errors are surfaced as Internal — they indicate either a
-			// rehydration / bus / publish failure (system-shaped) or an
-			// unexpected state mismatch. Save what state we have first so the
-			// player isn't stuck on the NPC's turn forever; the next manual
-			// EndTurn picks up.
-			if saveErr := h.encRepo.Save(ctx, enc.ToData()); saveErr != nil {
-				return nil, status.Errorf(codes.Internal,
-					"npc act failed (%v) and save failed (%v)", actErr, saveErr)
-			}
-			return nil, status.Errorf(codes.Internal, "npc act %q: %v", string(newActive), actErr)
-		}
-		// Post-NPCAct end-of-encounter check (Wave 2.10 guard).
-		if enc.Mode() == core.ModeEnded {
-			isNPC = false
-			break
-		}
-		var endErr error
-		// #689: enc.EndTurn(ctx, ...) emits the dnd5e TurnEndTopic on the
-		// encounter bus itself for the NPC whose turn is ending — held
-		// conditions reset in place, no host-side publish needed.
-		newActive, isNPC, endErr = enc.EndTurn(ctx, newActive)
-		if endErr != nil {
-			// ErrEncounterEnded here means the NPC's action ended the
-			// encounter and the subsequent EndTurn rejected the call.
-			// Treat as success — the encounter has terminated, the events
-			// already fired, and we just need to persist the terminal
-			// state. Fall through to the post-loop save by clearing isNPC.
-			if errors.Is(endErr, tkenc.ErrEncounterEnded) {
-				isNPC = false
-				break
-			}
-			return nil, endTurnStatusError(endErr)
-		}
-		// Post-EndTurn end-of-encounter check (Wave 2.10 guard, defensive
-		// — EndTurn doesn't mutate liveness today, but stays robust to
-		// future paths that fold post-turn cleanup into EndTurn).
-		if enc.Mode() == core.ModeEnded {
-			isNPC = false
-			break
-		}
-	}
-
-	// Defensive: if the cap was reached while isNPC is still true, the
-	// encounter has more consecutive NPCs than the cap allows. Save what we
-	// have and surface FailedPrecondition so the caller (and any operator
-	// watching logs) sees the misconfiguration rather than a silent freeze.
-	// This shouldn't happen with valid encounter setups; the cap-by-roster
-	// math above guarantees the loop reaches a player whenever one exists.
-	if isNPC {
-		out := enc.ToData()
-		if syncErr := enc.SyncErr(); syncErr != nil {
-			return nil, status.Errorf(codes.Internal, "sync encounter state %q: %v", req.GetEncounterId(), syncErr)
-		}
-		// Flush cascaded player state back to the authoritative character store
-		// and clear the transient DataJSON before saving — same as the normal
-		// and pause exits. Without this, cascaded player DataJSON would persist
-		// onto the encounter snapshot (violating the transient-blob invariant)
-		// and the character store would be left stale on this error exit.
-		if persistErr := persistPlayerCharacterData(ctx, out, h.combatResolverConfig.CharacterRepo); persistErr != nil {
-			return nil, status.Errorf(codes.Internal, "persist character data %q: %v", req.GetEncounterId(), persistErr)
-		}
-		if saveErr := h.encRepo.Save(ctx, out); saveErr != nil {
-			return nil, status.Errorf(codes.Internal,
-				"npc dispatch loop exhausted and save failed: %v", saveErr)
-		}
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"npc dispatch loop exhausted with NPC %q still active; encounter may have no players in initiative",
-			string(newActive))
-	}
-
-	out := enc.ToData()
-	if syncErr := enc.SyncErr(); syncErr != nil {
-		return nil, status.Errorf(codes.Internal, "sync encounter state %q: %v", req.GetEncounterId(), syncErr)
-	}
-	// Flush cascaded player state (turn-end condition resets, NPC-attack damage
-	// flags) back to the authoritative character store.
-	if err := persistPlayerCharacterData(ctx, out, h.combatResolverConfig.CharacterRepo); err != nil {
-		return nil, status.Errorf(codes.Internal, "persist character data %q: %v", req.GetEncounterId(), err)
-	}
-	if err := h.encRepo.Save(ctx, out); err != nil {
-		return nil, status.Errorf(codes.Internal, "save encounter %q: %v", req.GetEncounterId(), err)
 	}
 
 	return &encounterv2pb.EndTurnResponse{}, nil
 }
 
-// enforceSingleReactor drops all but the first PendingReactionPrompt on the
-// encounter. Used after the SDK's NPCAct path persists multiple reactor
-// prompts during a single paused attack (npc.go's playerTriggers loop) —
-// CompleteTakeAction is destructive per call, so multiple persisted prompts
-// risk double-resolution.
+// endTurnStatusError maps the orchestrator's EndTurn errors onto gRPC status
+// codes per pat-v2-status-code-mapping. The orchestrator's load sentinels carry
+// the auth classification; the toolkit EndTurn gate sentinels (surfaced
+// unwrapped) are state-dependent → FailedPrecondition; ErrNPCChainExhausted is
+// the no-players-in-initiative misconfiguration → FailedPrecondition; everything
+// else (ErrNPCAct, persist / save failures) → Internal.
 //
-// Wave 2.11d closeout (#538 C, Option 1): single-reactor enforcement.
-// Wave 2.11e (https://github.com/KirkDiggler/rpg-api/issues/540) replaces
-// this with aggregate-then-complete once a second post-hit reaction ships
-// (Counterspell, etc.). Until then, first-eligible-wins.
-//
-// Map iteration order in Go is unspecified, so "first" here means "any one"
-// — acceptable for the Wave 2.11d Shield-only scope where the only
-// multi-reactor case is two wizards both having Shield ready against the
-// same target (1-target-per-attack scenario; both wouldn't both be the
-// target of the same attack).
-func enforceSingleReactor(enc *tkenc.Encounter) {
-	prompts := enc.ToData().PendingReactionPrompts
-	if len(prompts) <= 1 {
-		return
-	}
-	var kept core.PlayerID
-	for pid := range prompts {
-		kept = pid
-		break
-	}
-	for pid := range prompts {
-		if pid != kept {
-			enc.ClearPendingReactionPrompt(pid)
-		}
-	}
-}
-
-// serializePendingPhasedAttacks marshals each in-process PhasedAttackContext
-// (from NPC attacks that paused for a player reaction) into the corresponding
-// PendingReactionPrompt.AttackContextJSON. Without this, the encounter
-// snapshot would persist the prompt metadata but not the rulebook-specific
-// AttackContext, so SubmitCheck on the resume path could not rebuild phase 2.
-//
-// Wave 2.11d: NPC pause-for-reaction is mediated by the SDK keeping the
-// AttackContext in-memory only (the SDK is rulebook-agnostic; it can't
-// marshal the rulebook-side context itself). The orchestrator does the
-// marshaling because it knows the *combat.AttackContext shape.
-func (h *Handler) serializePendingPhasedAttacks(enc *tkenc.Encounter) error {
-	for pid, prompt := range enc.ToData().PendingReactionPrompts {
-		if len(prompt.AttackContextJSON) > 0 {
-			continue // already serialized (player-attack path filled this in)
-		}
-		phasedCtx := enc.PendingPhasedAttackContext(pid)
-		if phasedCtx == nil {
-			continue
-		}
-		rulebookCtx, ok := phasedCtx.Rulebook.(*combat.AttackContext)
-		if !ok {
-			return fmt.Errorf("pending phased attack rulebook is %T, expected *combat.AttackContext", phasedCtx.Rulebook)
-		}
-		ctxJSON, err := json.Marshal(rulebookCtx)
-		if err != nil {
-			return fmt.Errorf("marshal pending attack context: %w", err)
-		}
-		prompt.AttackContextJSON = ctxJSON
-	}
-	return nil
-}
-
-// endTurnStatusError maps toolkit EndTurn sentinel errors onto gRPC status
-// codes. All EndTurn errors are state-dependent → FailedPrecondition,
-// except wrapping/internal failures which surface as Internal.
-//
-// Wave 2.10: ErrEncounterEnded is the terminal-state sentinel returned
-// when EndTurn is called against an encounter whose mode is ModeEnded.
-// State-dependent → FailedPrecondition.
+//   - ErrEncounterNotFound → NotFound
+//   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
+//   - tkenc.Err{EncounterEnded,NotTurnBased,NotYourTurn,NoCombatants} → FailedPrecondition
+//   - ErrNPCChainExhausted → FailedPrecondition
+//   - ErrNPCAct / unclassified failures → Internal
 func endTurnStatusError(err error) error {
 	switch {
+	case errors.Is(err, encounterorch.ErrEncounterNotFound):
+		return status.Error(codes.NotFound, "encounter not found")
+	case errors.Is(err, encounterorch.ErrPlayerNotInEncounter):
+		return status.Error(codes.PermissionDenied, "player is not in this encounter")
+	case errors.Is(err, encounterorch.ErrEntityOwnershipMismatch):
+		return status.Error(codes.PermissionDenied,
+			"entity_id does not match player's controlled entity")
 	case errors.Is(err, tkenc.ErrEncounterEnded):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, tkenc.ErrNotTurnBased):
@@ -346,6 +83,8 @@ func endTurnStatusError(err error) error {
 	case errors.Is(err, tkenc.ErrNotYourTurn):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, tkenc.ErrNoCombatants):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, encounterorch.ErrNPCChainExhausted):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return status.Errorf(codes.Internal, "end turn: %v", err)

--- a/internal/orchestrators/encounter/v2/end_turn.go
+++ b/internal/orchestrators/encounter/v2/end_turn.go
@@ -1,0 +1,322 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// npcChainSafetyMargin is added to the initiative roster size to derive the
+// per-call NPC dispatch cap. The cap (initiative_len + margin) lets the loop
+// cycle past every combatant once and absorb a few extra rounds of pure-NPC
+// initiative without deadlocking, while still bounding the worst case.
+//
+// Why "len(Initiative) + margin" instead of a fixed value: with a fixed cap
+// of N, an all-NPC encounter (initiative larger than N — degenerate but
+// possible if a future scenario seeds 20 monsters and 0 players) would exit
+// the loop with an NPC still active. Since EndTurn requires a player-owned
+// entity_id, the RPC would deadlock — players couldn't progress past the
+// NPC chain.
+//
+// With the size-derived cap, the loop is guaranteed to either reach a player
+// or exhaust the entire roster (in which case the encounter genuinely has no
+// players and the deadlock is the encounter's own design, not the
+// orchestrator's). We still surface ErrNPCChainExhausted if the cap is hit
+// while isNPC is true (see the post-loop check below) so operators can spot
+// misconfigured encounters rather than seeing them silently freeze.
+const npcChainSafetyMargin = 4
+
+// ErrNPCChainExhausted means the NPC dispatch loop hit its roster-derived cap
+// with an NPC still active — the encounter has more consecutive NPC turns than
+// the cap allows, which only happens when the encounter has no players in
+// initiative (the cap-by-roster math reaches a player whenever one exists). The
+// handler maps this to codes.FailedPrecondition so the misconfiguration shows
+// up rather than the RPC silently freezing.
+var ErrNPCChainExhausted = errors.New("npc dispatch loop exhausted with an npc still active")
+
+// ErrNPCAct wraps a system-shaped failure from the toolkit's NPCAct verb
+// (rehydration / bus / publish failure or an unexpected state mismatch). The
+// handler maps it to codes.Internal. A paused-for-reaction NPCAct is NOT an
+// error on this sentinel — it is handled in-loop (see EndTurn) and returns a
+// successful pause.
+var ErrNPCAct = errors.New("npc act failed")
+
+// EndTurnInput carries the entity-typed EndTurn request. The handler builds it
+// from the proto request after envelope validation (auth, empty-id). Membership
+// + entity ownership are verified by load — a player may only end their own
+// controlled entity's turn.
+type EndTurnInput struct {
+	// EncounterID identifies the encounter.
+	EncounterID string
+
+	// PlayerID is the authenticated player ending the turn. load verifies
+	// membership and returns ErrPlayerNotInEncounter otherwise.
+	PlayerID core.PlayerID
+
+	// EntityID is the entity the player controls and whose turn is ending. load
+	// verifies the encounter maps PlayerID -> EntityID and returns
+	// ErrEntityOwnershipMismatch otherwise. The toolkit's EndTurn separately
+	// enforces "is the active actor" via ErrNotYourTurn.
+	EntityID core.EntityID
+}
+
+// EndTurnOutput is the lean result of an EndTurn. Initiative advancement and any
+// NPC-turn outcomes (the dispatched NPCAct attack, condition resets) flow to
+// clients as broker events, not in this output — so the empty output is
+// intentional, matching the empty proto EndTurnResponse.
+type EndTurnOutput struct{}
+
+// EndTurn ends the active actor's turn, advances initiative, and — when the new
+// active actor is an NPC — dispatches the toolkit's NPCAct verb on behalf of the
+// server. The NPC dispatch loop continues cycling through any chain of
+// consecutive NPC turns until the active actor is a player, the encounter ends,
+// or the chain depth cap is reached.
+//
+// This is the orchestrator-side half of pat-v2-npc-turn-dispatch: the toolkit's
+// EndTurn returns (newActiveID, isNPC, err) so the orchestrator knows whether to
+// call NPCAct without re-querying state. After NPCAct returns, the orchestrator
+// calls EndTurn again to advance the NPC's turn — NPCAct itself is
+// single-purpose (resolve the NPC's action) and does not touch turn state.
+//
+// The turn-end reset is clean post-#689: enc.EndTurn(ctx, ...) emits the dnd5e
+// TurnEndTopic on the encounter bus itself, so held conditions (e.g.
+// SneakAttack) reset their per-turn state in place with no host-side publish and
+// no character re-load. ToData persists the reset state back; the TurnEndTopic
+// publish error is propagated by the SDK (it is the ONLY thing that resets
+// per-turn state), so a failure surfaces here rather than being swallowed.
+//
+// Pause-for-reaction (Wave 2.11d): when a dispatched NPC attack pauses for a
+// player reaction, the SDK has already persisted the pending reaction prompt +
+// published InputRequiredDelivered from inside NPCAct. The orchestrator drops
+// all-but-one prompt (single-reactor enforcement), marshals the cached
+// PhasedAttackContext into the prompt's AttackContextJSON via the injected
+// ReactionResume.MarshalAttackContext (so the orchestrator never touches the
+// rulebook *combat.AttackContext shape), persists, and returns success — the
+// player must respond (via SubmitReactionCheck) before the NPC's turn and the
+// rest of the dispatch loop continue.
+//
+// INTERNAL: the pause resolves through the already-carved SubmitReactionCheck
+// single-RPC; there is NO cross-RPC wire-pause built here (that is the deferred
+// EndTurn concern — explicitly out of scope).
+//
+// Mode-gating, turn-violation, and no-combatants errors are surfaced by the
+// toolkit UNWRAPPED so the handler maps each distinctly per
+// pat-v2-status-code-mapping.
+func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: EndTurnInput is required")
+	}
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		EntityID:    string(in.EntityID),
+		// #689: combat-capable verb — attach the player character blobs so the
+		// hydration cascade holds each combatant; the held conditions reset on the
+		// SDK's TurnEndTopic publish below — no separate character re-load.
+		WithCharacterData: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// #689: EndTurn(ctx, ...) emits dnd5e TurnEndTopic on the encounter bus
+	// itself, so held conditions reset their per-turn state in place. Toolkit
+	// gate sentinels (ErrEncounterEnded / ErrNotTurnBased / ErrNotYourTurn /
+	// ErrNoCombatants) surface UNWRAPPED so the handler maps each distinctly.
+	newActive, isNPC, err := enc.EndTurn(ctx, in.EntityID)
+	if err != nil {
+		return nil, err
+	}
+
+	// NPC dispatch loop. After the toolkit's EndTurn advances initiative, if the
+	// new active actor is an NPC the orchestrator runs its turn server-side and
+	// ends it, then re-checks. The cap is initiative-size + margin so an all-NPC
+	// roster cycles all the way through rather than freezing the RPC. The roster
+	// is read from the synced snapshot (enc.ToData().Initiative) — no parallel
+	// *Data handle, consistent with load's single-state rule.
+	//
+	// Wave 2.10: after each NPCAct / EndTurn cycle, if the encounter has
+	// transitioned to ModeEnded (e.g., an NPC attack killed the last hostile —
+	// not possible today since killEntity only runs in TakeAction's player-attack
+	// path, but cheap insurance for future paths like faction-on-faction NPC
+	// kills, environmental damage, etc.), break out of the loop. The post-loop
+	// persist saves the terminal state and the RPC returns success — the
+	// EncounterEnded event already fired through the broker, and the next combat
+	// verb will get ErrEncounterEnded.
+	npcChainCap := len(enc.ToData().Initiative) + npcChainSafetyMargin
+	for depth := 0; isNPC && depth < npcChainCap; depth++ {
+		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
+			// Wave 2.11d: NPC turn paused for a player reaction. The encounter has
+			// the pending reaction prompt + the InputRequiredDelivered event already
+			// published BY THE SDK from inside NPCAct (encounter/npc.go at the
+			// player-trigger loop). Drop all-but-one prompt, marshal the cached
+			// PhasedAttackContext into the prompt's AttackContextJSON via the
+			// injected adapter so SubmitReactionCheck can rebuild phase 2 on resume,
+			// then persist and return success — the player must respond before the
+			// NPC's turn (and the rest of the dispatch loop) continues.
+			//
+			// Wave 2.11d closeout (#538 B): the SDK-side publish-then-host-serialize
+			// ordering creates a race window where a fast stream subscriber reloads
+			// from repo BEFORE the serialize + Save below. The subscriber could see
+			// either the old snapshot (no prompt) or a snapshot with a prompt but
+			// AttackContextJSON=nil. The proper fix lives in the SDK: a
+			// resolver-supplied serializer callback that lets the SDK populate
+			// AttackContextJSON itself BEFORE publishing the event. Tracked in
+			// rpg-toolkit#657 (implicit in rpg-toolkit#658 for movement-paused
+			// reactions). We cannot fix this at the rpg-api layer without changing
+			// the SDK contract — the publish happens inside NPCAct, before we return
+			// here.
+			if tkenc.IsNPCPausedForReaction(actErr) {
+				// Single-reactor enforcement (Wave 2.11d closeout #538 C, Option 1):
+				// if the SDK persisted multiple prompts for this pause, drop all but
+				// the first. Orphan InputRequiredDelivered events already went out
+				// from inside NPCAct; subscribers reloading from repo will find no
+				// matching prompt and drop silently — acceptable under single-reactor
+				// semantics. See TakeAction's persistPendingReactions for the design
+				// rationale + rpg-api#540 for the proper aggregate-then-complete fix.
+				o.enforceSingleReactor(enc)
+				if serErr := o.serializeNPCPendingReactions(enc); serErr != nil {
+					return nil, fmt.Errorf("serialize npc pending reactions %q: %w", in.EncounterID, serErr)
+				}
+				if persistErr := o.persistWithCharacterData(ctx, enc, in.EncounterID); persistErr != nil {
+					return nil, persistErr
+				}
+				return &EndTurnOutput{}, nil
+			}
+			// NPCAct errors are system-shaped (rehydration / bus / publish failure
+			// or unexpected state mismatch). Save what state we have first so the
+			// player isn't stuck on the NPC's turn forever; the next manual EndTurn
+			// picks up. Surface the wrapped sentinel so the handler maps to Internal.
+			if persistErr := o.persistWithCharacterData(ctx, enc, in.EncounterID); persistErr != nil {
+				return nil, fmt.Errorf("%w (%v) and persist failed: %w", ErrNPCAct, actErr, persistErr)
+			}
+			return nil, fmt.Errorf("%w %q: %w", ErrNPCAct, string(newActive), actErr)
+		}
+		// Post-NPCAct end-of-encounter check (Wave 2.10 guard).
+		if enc.Mode() == core.ModeEnded {
+			isNPC = false
+			break
+		}
+		var endErr error
+		// #689: enc.EndTurn(ctx, ...) emits the dnd5e TurnEndTopic on the encounter
+		// bus itself for the NPC whose turn is ending — held conditions reset in
+		// place, no host-side publish needed.
+		newActive, isNPC, endErr = enc.EndTurn(ctx, newActive)
+		if endErr != nil {
+			// ErrEncounterEnded here means the NPC's action ended the encounter and
+			// the subsequent EndTurn rejected the call. Treat as success — the
+			// encounter has terminated, the events already fired, and we just need to
+			// persist the terminal state. Fall through to the post-loop persist by
+			// clearing isNPC.
+			if errors.Is(endErr, tkenc.ErrEncounterEnded) {
+				isNPC = false
+				break
+			}
+			return nil, endErr
+		}
+		// Post-EndTurn end-of-encounter check (Wave 2.10 guard, defensive — EndTurn
+		// doesn't mutate liveness today, but stays robust to future paths that fold
+		// post-turn cleanup into EndTurn).
+		if enc.Mode() == core.ModeEnded {
+			isNPC = false
+			break
+		}
+	}
+
+	// Defensive: if the cap was reached while isNPC is still true, the encounter
+	// has more consecutive NPCs than the cap allows. Persist what we have and
+	// surface ErrNPCChainExhausted so the caller (and any operator watching logs)
+	// sees the misconfiguration rather than a silent freeze. This shouldn't happen
+	// with valid encounter setups; the cap-by-roster math above guarantees the
+	// loop reaches a player whenever one exists.
+	if isNPC {
+		if persistErr := o.persistWithCharacterData(ctx, enc, in.EncounterID); persistErr != nil {
+			return nil, persistErr
+		}
+		return nil, fmt.Errorf("%w: npc %q still active; encounter may have no players in initiative",
+			ErrNPCChainExhausted, string(newActive))
+	}
+
+	if err := o.persistWithCharacterData(ctx, enc, in.EncounterID); err != nil {
+		return nil, err
+	}
+
+	return &EndTurnOutput{}, nil
+}
+
+// enforceSingleReactor drops all but the first PendingReactionPrompt on the
+// encounter. Used after the SDK's NPCAct path persists multiple reactor prompts
+// during a single paused attack (npc.go's playerTriggers loop) —
+// CompleteTakeAction is destructive per call, so multiple persisted prompts risk
+// double-resolution.
+//
+// Wave 2.11d closeout (#538 C, Option 1): single-reactor enforcement.
+// Wave 2.11e (rpg-api#540) replaces this with aggregate-then-complete once a
+// second post-hit reaction ships (Counterspell, etc.). Until then,
+// first-eligible-wins.
+//
+// Map iteration order in Go is unspecified, so "first" here means "any one" —
+// acceptable for the Wave 2.11d Shield-only scope where the only multi-reactor
+// case is two wizards both having Shield ready against the same target
+// (1-target-per-attack scenario; both wouldn't both be the target of the same
+// attack).
+func (o *Orchestrator) enforceSingleReactor(enc *tkenc.Encounter) {
+	prompts := enc.ToData().PendingReactionPrompts
+	if len(prompts) <= 1 {
+		return
+	}
+	var kept core.PlayerID
+	for pid := range prompts {
+		kept = pid
+		break
+	}
+	for pid := range prompts {
+		if pid != kept {
+			enc.ClearPendingReactionPrompt(pid)
+		}
+	}
+}
+
+// serializeNPCPendingReactions marshals each in-process PhasedAttackContext
+// (from NPC attacks that paused for a player reaction) into the corresponding
+// PendingReactionPrompt.AttackContextJSON. Without this, the encounter snapshot
+// would persist the prompt metadata but not the rulebook-specific AttackContext,
+// so SubmitReactionCheck on the resume path could not rebuild phase 2.
+//
+// The single rulebook-touching piece — interpreting the opaque
+// *combat.AttackContext payload — is delegated to the injected
+// ReactionResume.MarshalAttackContext (the SAME func TakeAction's phase-1 pause
+// uses), so the orchestrator never type-asserts the rulebook shape and stays
+// free of the rulebooks/dnd5e/combat import. The marshal seam is only needed on
+// this pause path, so it is required lazily here (not up-front in EndTurn) — a
+// clear error if we reach the pause path without it beats a nil dereference.
+func (o *Orchestrator) serializeNPCPendingReactions(enc *tkenc.Encounter) error {
+	for pid, prompt := range enc.ToData().PendingReactionPrompts {
+		if len(prompt.AttackContextJSON) > 0 {
+			continue // already serialized (player-attack path filled this in)
+		}
+		phasedCtx := enc.PendingPhasedAttackContext(pid)
+		if phasedCtx == nil {
+			continue
+		}
+		// The marshal seam is only consulted here — when a prompt genuinely needs
+		// its cached phased context serialized. Required lazily at the point of use
+		// (not up-front) so a prompt that is already serialized or has no cached
+		// context needs no marshal func wired, matching TakeAction's lazy-required
+		// pattern. A clear error if we reach the marshal without it beats a nil
+		// dereference.
+		if o.reactionResume.MarshalAttackContext == nil {
+			return errors.New("encounter orchestrator: ReactionResume.MarshalAttackContext is required to persist an npc reaction prompt")
+		}
+		ctxJSON, err := o.reactionResume.MarshalAttackContext(phasedCtx)
+		if err != nil {
+			return fmt.Errorf("marshal pending attack context: %w", err)
+		}
+		prompt.AttackContextJSON = ctxJSON
+	}
+	return nil
+}

--- a/internal/orchestrators/encounter/v2/end_turn_npc_pause_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_npc_pause_test.go
@@ -1,0 +1,201 @@
+package encounter_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+)
+
+// NPC-pause-persists-prompt test (#582 step 7). This drives a GENUINE SDK NPC
+// reaction pause through Orchestrator.EndTurn and asserts the orchestrator's
+// pause branch ran end-to-end:
+//   - enforceSingleReactor + serializeNPCPendingReactions fire;
+//   - the injected ReactionResume.MarshalAttackContext is consulted to fill the
+//     persisted prompt's AttackContextJSON (the branch Copilot flagged as
+//     uncovered);
+//   - EndTurn returns success (the player must respond before the dispatch loop
+//     continues) and the prompt is persisted on the saved snapshot.
+//
+// The pause is real: a rehydratable goblin (monster.NewGoblin().ToData()) takes
+// its turn through the rulebook, publishes an AttackEvent against the adjacent
+// player, and the wired PHASED combat resolver returns a player-reactor trigger
+// from ResolveAttackHit — which the SDK partitions to the player, persists as a
+// pending prompt, and signals via errNPCPausedForReaction. The fake resolver
+// bypasses all combat math (it just returns the trigger), and the injected
+// marshal is a stub returning known bytes, so this stays rulebook-light while
+// exercising the orchestrator's real pause-handling path.
+
+const (
+	npEncID     = "enc-npc-pause"
+	npPlayerWiz = "wendy"
+	npEntityWiz = "char-wendy"
+	npGoblinID  = "goblin-np"
+	npShieldRef = "dnd5e:spells:shield"
+)
+
+// fakePhasedResolver implements tkenc.PhasedCombatResolver. ResolveAttackHit
+// returns a single player-reactor trigger (so the SDK pauses the NPC turn);
+// ApplyAttackOutcome is never reached on the pause path. ResolveAttack (the
+// single-phase fallback) is present to satisfy the embedded CombatResolver but
+// is not used because the SDK routes NPC attacks through the phased path when
+// the resolver implements PhasedCombatResolver.
+type fakePhasedResolver struct {
+	reactorEntityID core.EntityID
+}
+
+func (r fakePhasedResolver) ResolveAttack(input tkenc.AttackInput) (*tkenc.AttackOutcome, error) {
+	return &tkenc.AttackOutcome{Hit: false, TargetAC: input.TargetAC}, nil
+}
+
+func (r fakePhasedResolver) ResolveAttackHit(input tkenc.AttackInput) (*tkenc.PhasedAttackContext, []tkenc.ReactionTrigger, error) {
+	ctx := &tkenc.PhasedAttackContext{
+		// Rulebook is opaque to the SDK; the orchestrator never inspects it —
+		// only the injected MarshalAttackContext does, and our stub ignores it.
+		Rulebook:   map[string]any{"fake": "attack-context"},
+		AttackerID: input.AttackerID,
+		TargetID:   input.TargetID,
+	}
+	triggers := []tkenc.ReactionTrigger{{
+		ReactorID:    r.reactorEntityID,
+		ConditionRef: npShieldRef,
+		TriggerKind:  "post_hit",
+		SourceEntity: input.AttackerID,
+	}}
+	return ctx, triggers, nil
+}
+
+func (r fakePhasedResolver) ApplyAttackOutcome(_ *tkenc.PhasedAttackContext, _ []tkenc.ReactionModifier) (*tkenc.AttackOutcome, error) {
+	return &tkenc.AttackOutcome{Hit: false}, nil
+}
+
+type EndTurnNPCPauseSuite struct {
+	suite.Suite
+
+	ctx          context.Context
+	broker       *tkenc.Broker
+	repo         encountersv2.Repository
+	orch         *encounterorch.Orchestrator
+	marshalCalls int
+}
+
+func (s *EndTurnNPCPauseSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+	s.marshalCalls = 0
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return fakePhasedResolver{reactorEntityID: npEntityWiz}
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		ReactionResume: encounterorch.ReactionResume{
+			// Stub marshal: records that the orchestrator consulted the injected
+			// seam on the pause path and returns known bytes so the test can assert
+			// they landed on the persisted prompt. The real adapter type-asserts the
+			// rulebook *combat.AttackContext; this stub ignores the opaque payload.
+			MarshalAttackContext: func(_ *tkenc.PhasedAttackContext) ([]byte, error) {
+				s.marshalCalls++
+				return []byte(`{"npc":"marshaled"}`), nil
+			},
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedGoblinAdjacentToWizard persists a turn-based encounter with wendy (player)
+// and a rehydratable goblin positioned adjacent to her, with the goblin active.
+// Ending wendy's turn would advance to the goblin, but the seed makes the goblin
+// active and wendy second, so the FIRST toolkit EndTurn (ending wendy's prior
+// turn) is not what we call — instead wendy ends her own turn (she is active),
+// the loop reaches the goblin, and the goblin's scimitar attack against adjacent
+// wendy pauses for her Shield reaction via the fake phased resolver.
+func (s *EndTurnNPCPauseSuite) seedGoblinAdjacentToWizard() {
+	enc := tkenc.New(s.ctx, npEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   npPlayerWiz,
+		EntityID:   npEntityWiz,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		HP:         12,
+		MaxHP:      12,
+		AC:         12,
+		// Combat fields so wendy is a valid combatant (EndTurn / NPC targeting).
+		AttackBonus: 2,
+		DamageDice:  "1d4",
+		DamageType:  "bludgeoning",
+	}))
+	// Rehydratable goblin adjacent to wendy (axial distance 1) so its scimitar
+	// (5ft reach) can attack without needing a long move. DataJSON makes NPCAct
+	// take the rulebook TakeTurn path (not the scripted single-phase fallback),
+	// so the attack routes through the wired PHASED resolver.
+	goblinData := monster.NewGoblin(npGoblinID).ToData()
+	rawData, err := json.Marshal(goblinData)
+	s.Require().NoError(err)
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID:          npGoblinID,
+		Position:    core.Hex{Q: 1, R: 0, S: -1},
+		HP:          7,
+		MaxHP:       7,
+		AC:          15,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+		DataJSON:    rawData,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	data := enc.ToData()
+	// wendy active (idx 0), goblin next (idx 1): ending wendy's turn advances to
+	// the goblin and the NPC dispatch loop runs the goblin's turn.
+	data.Initiative = []core.EntityID{npEntityWiz, npGoblinID}
+	data.ActiveIdx = 0
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+}
+
+func (s *EndTurnNPCPauseSuite) TestEndTurn_NPCAttackPauses_PersistsPromptWithMarshaledContext() {
+	s.seedGoblinAdjacentToWizard()
+
+	out, err := s.orch.EndTurn(s.ctx, &encounterorch.EndTurnInput{
+		EncounterID: npEncID,
+		PlayerID:    npPlayerWiz,
+		EntityID:    npEntityWiz,
+	})
+	s.Require().NoError(err, "EndTurn must succeed (return) when the NPC turn pauses for a player reaction")
+	s.Require().NotNil(out)
+
+	// The injected marshal seam must have been consulted on the pause path —
+	// this is the branch Copilot flagged as previously uncovered.
+	s.Require().Positive(s.marshalCalls,
+		"the orchestrator must consult the injected MarshalAttackContext on the NPC pause path")
+
+	loaded, getErr := s.repo.Get(s.ctx, npEncID)
+	s.Require().NoError(getErr)
+	prompt, ok := loaded.PendingReactionPrompts[core.PlayerID(npPlayerWiz)]
+	s.Require().True(ok, "wendy's pending reaction prompt must be persisted on the snapshot")
+	s.Require().NotNil(prompt)
+	s.Equal([]byte(`{"npc":"marshaled"}`), prompt.AttackContextJSON,
+		"the prompt's AttackContextJSON must carry the bytes from the injected marshal so SubmitReactionCheck can rebuild phase 2")
+	s.Equal(npShieldRef, prompt.ConditionRef, "the persisted prompt must carry the reaction's condition ref")
+}
+
+func TestEndTurnNPCPauseSuite(t *testing.T) {
+	suite.Run(t, new(EndTurnNPCPauseSuite))
+}

--- a/internal/orchestrators/encounter/v2/end_turn_pause_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_pause_test.go
@@ -13,10 +13,11 @@ package encounter
 //     enforcement) — fully exercisable via the public SetPendingReactionPrompt;
 //   - serializeNPCPendingReactions's skip branches: it skips prompts that are
 //     already serialized (player-attack path filled them in) or carry no cached
-//     phased context — neither consults the injected marshal seam. The
-//     consult-the-marshal branch needs a cached phased context (set only by the
-//     SDK's unexported cachePhasedAttackContext on a genuine pause), so it is
-//     covered by the Shield integration suite, not here.
+//     phased context — neither consults the injected marshal seam.
+//
+// The consult-the-marshal branch (a genuine SDK pause that caches a phased
+// context, then the injected marshal fills AttackContextJSON) is driven
+// end-to-end through Orchestrator.EndTurn in end_turn_npc_pause_test.go.
 //
 // The end-to-end NPC-attack reaction path (a genuine SDK pause populating the
 // phased context, then the injected marshal filling AttackContextJSON) is

--- a/internal/orchestrators/encounter/v2/end_turn_pause_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_pause_test.go
@@ -1,0 +1,180 @@
+package encounter
+
+// White-box tests (package encounter) for the EndTurn NPC pause-for-reaction
+// handling helpers: enforceSingleReactor + serializeNPCPendingReactions.
+//
+// These are white-box (same package) because the helpers are unexported
+// orchestrator methods and because the pending PHASED attack context they read
+// (enc.PendingPhasedAttackContext) can only be populated by the SDK's unexported
+// cachePhasedAttackContext — set from inside NPCAct on a genuine reaction pause,
+// which needs full rulebook monster DataJSON rehydration. So these tests cover
+// the orchestrator-owned logic reachable without that machinery:
+//   - enforceSingleReactor drops all-but-one prompt (the #538 C single-reactor
+//     enforcement) — fully exercisable via the public SetPendingReactionPrompt;
+//   - serializeNPCPendingReactions's skip branches: it skips prompts that are
+//     already serialized (player-attack path filled them in) or carry no cached
+//     phased context — neither consults the injected marshal seam. The
+//     consult-the-marshal branch needs a cached phased context (set only by the
+//     SDK's unexported cachePhasedAttackContext on a genuine pause), so it is
+//     covered by the Shield integration suite, not here.
+//
+// The end-to-end NPC-attack reaction path (a genuine SDK pause populating the
+// phased context, then the injected marshal filling AttackContextJSON) is
+// exercised through the handler by the Shield integration suite.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// pauseStubResolver is a zero-modifier CharacterResolver for orchestrator
+// construction in these helper tests (no skill checks run).
+type pauseStubCharResolver struct{}
+
+func (pauseStubCharResolver) AbilityModifier(_ core.PlayerID, _ string) (int, bool) { return 0, true }
+func (pauseStubCharResolver) ToolProficiencyBonus(_ core.PlayerID, _ string) (int, bool) {
+	return 0, true
+}
+
+type EndTurnPauseSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+}
+
+func (s *EndTurnPauseSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+}
+
+// newOrch builds an Orchestrator with the supplied ReactionResume. Construction
+// is in-package so the tests can call the unexported helpers directly.
+func (s *EndTurnPauseSuite) newOrch(rr ReactionResume) *Orchestrator {
+	o, err := New(&Config{
+		Broker:        s.broker,
+		EncounterRepo: encountersv2.NewInMemory(),
+		Resolver:      pauseStubCharResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		ReactionResume: rr,
+	})
+	s.Require().NoError(err)
+	return o
+}
+
+// encWithPrompts builds a fresh encounter with the named players and sets a
+// pending reaction prompt (with the supplied pre-filled AttackContextJSON) for
+// each. Used to drive the prompt-bookkeeping helpers.
+func (s *EndTurnPauseSuite) encWithPrompts(prompts map[core.PlayerID][]byte) *tkenc.Encounter {
+	enc := tkenc.New(s.ctx, "enc-pause", s.broker)
+	for pid, ctxJSON := range prompts {
+		entityID := core.EntityID("char-" + string(pid))
+		s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+			PlayerID: pid, EntityID: entityID, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+			HP: 10, MaxHP: 10, AC: 12,
+		}))
+		enc.SetPendingReactionPrompt(pid, &tkenc.PendingReactionPrompt{
+			ReactorEntityID:   entityID,
+			ConditionRef:      "dnd5e:spells:shield",
+			TriggerKind:       "post_hit",
+			SourceEntity:      "goblin-x",
+			AttackContextJSON: ctxJSON,
+		})
+	}
+	return enc
+}
+
+// --- enforceSingleReactor ---
+
+func (s *EndTurnPauseSuite) TestEnforceSingleReactor_DropsAllButOne() {
+	o := s.newOrch(ReactionResume{})
+	enc := s.encWithPrompts(map[core.PlayerID][]byte{
+		"amy": []byte(`{"a":1}`),
+		"bob": []byte(`{"b":2}`),
+		"cat": []byte(`{"c":3}`),
+	})
+
+	o.enforceSingleReactor(enc)
+
+	prompts := enc.ToData().PendingReactionPrompts
+	s.Require().Len(prompts, 1, "single-reactor enforcement must drop all but one prompt")
+}
+
+func (s *EndTurnPauseSuite) TestEnforceSingleReactor_SinglePrompt_NoOp() {
+	o := s.newOrch(ReactionResume{})
+	enc := s.encWithPrompts(map[core.PlayerID][]byte{
+		"amy": []byte(`{"a":1}`),
+	})
+
+	o.enforceSingleReactor(enc)
+
+	prompts := enc.ToData().PendingReactionPrompts
+	s.Require().Len(prompts, 1, "a single prompt must be left untouched")
+	s.Require().Contains(prompts, core.PlayerID("amy"))
+}
+
+func (s *EndTurnPauseSuite) TestEnforceSingleReactor_NoPrompts_NoOp() {
+	o := s.newOrch(ReactionResume{})
+	enc := tkenc.New(s.ctx, "enc-empty", s.broker)
+
+	o.enforceSingleReactor(enc) // must not panic
+
+	s.Require().Empty(enc.ToData().PendingReactionPrompts)
+}
+
+// --- serializeNPCPendingReactions ---
+
+// A prompt that already carries AttackContextJSON (the player-attack path filled
+// it in) is skipped — the marshal seam is never consulted, so even a nil marshal
+// is fine.
+func (s *EndTurnPauseSuite) TestSerializeNPCPendingReactions_AlreadySerialized_Skips() {
+	o := s.newOrch(ReactionResume{MarshalAttackContext: nil})
+	enc := s.encWithPrompts(map[core.PlayerID][]byte{
+		"amy": []byte(`{"already":"serialized"}`),
+	})
+
+	err := o.serializeNPCPendingReactions(enc)
+	s.Require().NoError(err, "an already-serialized prompt must be skipped without consulting the marshal seam")
+
+	s.Require().Equal([]byte(`{"already":"serialized"}`),
+		enc.ToData().PendingReactionPrompts["amy"].AttackContextJSON,
+		"the pre-filled AttackContextJSON must be left untouched")
+}
+
+// A prompt with empty JSON but NO cached phased context (PendingPhasedAttackContext
+// returns nil) is skipped — there is nothing to marshal. Proves the helper does
+// not error on a prompt the SDK pause did not cache a context for.
+func (s *EndTurnPauseSuite) TestSerializeNPCPendingReactions_NoCachedContext_Skips() {
+	marshalCalled := false
+	o := s.newOrch(ReactionResume{
+		MarshalAttackContext: func(_ *tkenc.PhasedAttackContext) ([]byte, error) {
+			marshalCalled = true
+			return []byte(`{}`), nil
+		},
+	})
+	enc := s.encWithPrompts(map[core.PlayerID][]byte{
+		"amy": nil, // empty JSON, but no cached phased context exists for amy
+	})
+
+	err := o.serializeNPCPendingReactions(enc)
+	s.Require().NoError(err, "a prompt with no cached phased context must be skipped")
+	s.Require().False(marshalCalled,
+		"the injected marshal must not be consulted when there is no cached phased context")
+	s.Require().Empty(enc.ToData().PendingReactionPrompts["amy"].AttackContextJSON,
+		"the prompt's AttackContextJSON must stay empty when there is nothing to marshal")
+}
+
+func TestEndTurnPauseSuite(t *testing.T) {
+	suite.Run(t, new(EndTurnPauseSuite))
+}

--- a/internal/orchestrators/encounter/v2/end_turn_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_test.go
@@ -1,0 +1,263 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EndTurn orchestrator tests (#582 step 7 — the final verb carve). These
+// exercise the orchestrator's load → EndTurn verb → NPC dispatch loop → persist
+// core directly, proving:
+//   - the shared load preconditions (membership + entity ownership) classify as
+//     the orchestrator sentinels the handler maps to gRPC codes;
+//   - toolkit EndTurn gate sentinels (ErrEncounterEnded, etc.) surface UNWRAPPED
+//     so the handler maps each distinctly;
+//   - the happy path advances initiative and persists;
+//   - the NPC dispatch loop cycles past consecutive NPC turns (NPCAct +
+//     EndTurn-the-NPC server-side) until a player is active.
+//
+// ErrNPCChainExhausted is a defensive guard not reachable through this
+// player-gated entrypoint: the toolkit's first EndTurn requires the player to be
+// the active actor (so the player is always in initiative), and the loop's
+// roster-derived cap (len + margin) always re-reaches the player on wrap. It is
+// only hit by a corrupt no-player snapshot, so it is documented (see its godoc)
+// rather than unit-tested through a fabricated invalid fixture.
+//
+// The NPC pause-for-reaction handling (enforceSingleReactor +
+// serializeNPCPendingReactions via the injected MarshalAttackContext) is
+// white-box unit-tested in end_turn_pause_test.go (same package) because driving
+// a genuine SDK NPC pause needs full rulebook monster DataJSON rehydration — the
+// heavy machinery these load/verb/persist unit tests deliberately avoid (mirrors
+// take_action_test.go's reaction-pause note). The NPC-attack reaction path is
+// exercised end-to-end through the handler by the Shield integration suite.
+
+const (
+	etEncID     = "enc-end-turn"
+	etPlayerBob = "bob"
+	etEntityBob = "char-bob"
+	etGoblinID  = "goblin-et"
+)
+
+type EndTurnSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *EndTurnSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		// Stand-in combat resolver: the NPC dispatch loop's scripted goblin
+		// attack runs through this (single-phase ResolveAttack), advancing
+		// initiative deterministically without a rulebook. No DataJSON is seeded
+		// on the goblin, so NPCAct takes the scripted single-phase path — no
+		// reaction triggers, isolating the load → EndTurn → dispatch → persist
+		// contract.
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return v2encounter.NewStandInCombatResolver(nil)
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		// MarshalAttackContext is wired for completeness; the scripted NPC path
+		// never pauses, so it is never invoked in these tests.
+		ReactionResume: encounterorch.ReactionResume{
+			MarshalAttackContext: func(_ *tkenc.PhasedAttackContext) ([]byte, error) {
+				return []byte(`{}`), nil
+			},
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedTurnBased persists a turn-based encounter with bob (player) and a goblin
+// (monster), forcing the supplied initiative order + active index so the
+// active-actor gate passes deterministically.
+func (s *EndTurnSuite) seedTurnBased(encID string, initiative []core.EntityID, activeIdx int) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    etPlayerBob,
+		EntityID:    etEntityBob,
+		Position:    core.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID:          etGoblinID,
+		Position:    core.Hex{Q: 1, R: 0, S: -1},
+		HP:          7,
+		MaxHP:       7,
+		AC:          15,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	data := enc.ToData()
+	data.Initiative = initiative
+	data.ActiveIdx = activeIdx
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+}
+
+func (s *EndTurnSuite) endTurn(encID, entity string) (*encounterorch.EndTurnOutput, error) {
+	return s.orch.EndTurn(s.ctx, &encounterorch.EndTurnInput{
+		EncounterID: encID,
+		PlayerID:    etPlayerBob,
+		EntityID:    core.EntityID(entity),
+	})
+}
+
+// --- nil input ---
+
+func (s *EndTurnSuite) TestEndTurn_NilInput_Error() {
+	_, err := s.orch.EndTurn(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+// --- load preconditions ---
+
+func (s *EndTurnSuite) TestEndTurn_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.endTurn("nope", etEntityBob)
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *EndTurnSuite) TestEndTurn_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-no-player", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other", EntityID: "other-char", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.endTurn("enc-no-player", etEntityBob)
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+func (s *EndTurnSuite) TestEndTurn_EntityMismatch_ErrEntityOwnershipMismatch() {
+	s.seedTurnBased("enc-mismatch", []core.EntityID{etEntityBob, etGoblinID}, 0)
+	_, err := s.endTurn("enc-mismatch", "char-someone-else")
+	s.Require().ErrorIs(err, encounterorch.ErrEntityOwnershipMismatch)
+}
+
+// --- toolkit gate sentinels surface UNWRAPPED so the handler maps distinctly ---
+
+func (s *EndTurnSuite) TestEndTurn_EncounterEnded_ErrEncounterEnded() {
+	s.seedTurnBased("enc-ended", []core.EntityID{etEntityBob, etGoblinID}, 0)
+	data, err := s.repo.Get(s.ctx, "enc-ended")
+	s.Require().NoError(err)
+	data.Mode = core.ModeEnded
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+
+	_, err = s.endTurn("enc-ended", etEntityBob)
+	s.Require().ErrorIs(err, tkenc.ErrEncounterEnded)
+}
+
+func (s *EndTurnSuite) TestEndTurn_NotTurnBased_ErrNotTurnBased() {
+	// Free-roam encounter: EndTurn gates on ModeTurnBased.
+	enc := tkenc.New(s.ctx, "enc-free-roam", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: etPlayerBob, EntityID: etEntityBob, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+		HP: 14, MaxHP: 14, AC: 14,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.endTurn("enc-free-roam", etEntityBob)
+	s.Require().ErrorIs(err, tkenc.ErrNotTurnBased)
+}
+
+func (s *EndTurnSuite) TestEndTurn_NotActiveActor_ErrNotYourTurn() {
+	// Goblin is active (idx 1), bob tries to end his turn — not the active actor.
+	s.seedTurnBased("enc-not-turn", []core.EntityID{etGoblinID, etEntityBob}, 0)
+	_, err := s.endTurn("enc-not-turn", etEntityBob)
+	s.Require().ErrorIs(err, tkenc.ErrNotYourTurn)
+}
+
+// --- happy path: advances initiative + persists ---
+//
+// bob is active (idx 0) with the goblin AFTER him in initiative. Ending bob's
+// turn advances to the goblin; the NPC dispatch loop runs the goblin's scripted
+// turn (StandIn resolver) and ends it, cycling back to bob. The post-state must
+// be persisted and the active actor must be a player (bob).
+func (s *EndTurnSuite) TestEndTurn_HappyPath_AdvancesAndPersists() {
+	s.seedTurnBased(etEncID, []core.EntityID{etEntityBob, etGoblinID}, 0)
+
+	out, err := s.endTurn(etEncID, etEntityBob)
+	s.Require().NoError(err, "ending the active player's turn must succeed via the toolkit verb")
+	s.Require().NotNil(out)
+
+	loaded, getErr := s.repo.Get(s.ctx, etEncID)
+	s.Require().NoError(getErr)
+	s.Require().NotNil(loaded)
+
+	postActive := loaded.Initiative[loaded.ActiveIdx]
+	// After the NPC dispatch loop the active actor must be the player again
+	// (the goblin's turn was run + ended server-side).
+	s.Equal(core.EntityID(etEntityBob), postActive,
+		"after EndTurn + NPC dispatch loop, active actor must be the player")
+}
+
+// --- NPC dispatch loop cycles past a consecutive NPC ---
+//
+// Two goblins between bob and his next turn. Ending bob's turn must dispatch
+// both goblins' scripted turns server-side, cycling initiative all the way back
+// to bob without a second EndTurn call.
+func (s *EndTurnSuite) TestEndTurn_NPCDispatchLoop_CyclesPastConsecutiveNPCs() {
+	const goblin2 = "goblin-et-2"
+	enc := tkenc.New(s.ctx, "enc-npc-chain", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: etPlayerBob, EntityID: etEntityBob, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 14, MaxHP: 14, AC: 14, AttackBonus: 5, DamageDice: "1d12+3", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: etGoblinID, Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef: "dnd5e:monsters:goblin", AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: goblin2, Position: core.Hex{Q: 2, R: 0, S: -2}, HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef: "dnd5e:monsters:goblin", AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	data := enc.ToData()
+	data.Initiative = []core.EntityID{etEntityBob, etGoblinID, goblin2}
+	data.ActiveIdx = 0
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+
+	_, err := s.endTurn("enc-npc-chain", etEntityBob)
+	s.Require().NoError(err, "ending bob's turn must dispatch both goblins server-side")
+
+	loaded, getErr := s.repo.Get(s.ctx, "enc-npc-chain")
+	s.Require().NoError(getErr)
+	postActive := loaded.Initiative[loaded.ActiveIdx]
+	s.Equal(core.EntityID(etEntityBob), postActive,
+		"NPC dispatch loop must cycle past both goblins back to the player")
+}
+
+func TestEndTurnSuite(t *testing.T) {
+	suite.Run(t, new(EndTurnSuite))
+}

--- a/internal/orchestrators/encounter/v2/end_turn_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_test.go
@@ -32,13 +32,13 @@ import (
 // only hit by a corrupt no-player snapshot, so it is documented (see its godoc)
 // rather than unit-tested through a fabricated invalid fixture.
 //
-// The NPC pause-for-reaction handling (enforceSingleReactor +
-// serializeNPCPendingReactions via the injected MarshalAttackContext) is
-// white-box unit-tested in end_turn_pause_test.go (same package) because driving
-// a genuine SDK NPC pause needs full rulebook monster DataJSON rehydration — the
-// heavy machinery these load/verb/persist unit tests deliberately avoid (mirrors
-// take_action_test.go's reaction-pause note). The NPC-attack reaction path is
-// exercised end-to-end through the handler by the Shield integration suite.
+// The NPC pause-for-reaction handling is covered in two places: the
+// prompt-bookkeeping helper branches (enforceSingleReactor + the skip paths of
+// serializeNPCPendingReactions) are white-box unit-tested in
+// end_turn_pause_test.go, and the full pause path — a genuine SDK pause that
+// consults the injected MarshalAttackContext and persists AttackContextJSON — is
+// driven end-to-end through Orchestrator.EndTurn in end_turn_npc_pause_test.go
+// (rehydratable goblin + fake phased resolver).
 
 const (
 	etEncID     = "enc-end-turn"


### PR DESCRIPTION
## Part of #582

The **final verb** of the #582 encounter-orchestrator carve (Chapter 1, Architecture Honesty). Relocates the `EndTurn` verb body from the handler package onto `Orchestrator.EndTurn`, completing the `load → toolkit-verb → persist` pattern across every v2 encounter RPC. #582 closes after the playtest sign-off.

## What changed

**New `internal/orchestrators/encounter/v2/end_turn.go` — `Orchestrator.EndTurn`** owns the three concerns:

1. **NPC-dispatch loop** — `NPCAct` + `EndTurn`-the-NPC server-side until a player is active, the encounter ends, or the roster-derived cap (`len(enc.ToData().Initiative) + npcChainSafetyMargin`) is hit. Cap read from the synced snapshot — no parallel `*Data` handle.
2. **Turn-end reset** — clean post-#689: `enc.EndTurn` emits `TurnEndTopic` on the bus itself, so held conditions reset in place.
3. **Pause-for-reaction bookkeeping** — `enforceSingleReactor` (moved as-is) + `serializeNPCPendingReactions`, which marshals the opaque `*combat.AttackContext` via the **existing injected `ReactionResume.MarshalAttackContext`** adapter (the same seam TakeAction phase-1 uses) — so the orchestrator stays rulebook-free.

**Sentinels:** reuse `load`'s auth sentinels, surface `tkenc` gate sentinels unwrapped, add `ErrNPCChainExhausted` (defensive no-players guard) + `ErrNPCAct` (system-shaped NPCAct failure).

**Thinned handler `end_turn.go`** to the ~25-line canonical shape (auth + envelope + `EndTurnInput` + delegate + `endTurnStatusError`). **Deleted** `serializePendingPhasedAttacks` + `enforceSingleReactor` + the `combat`/`json`/`fmt` imports (the duplicate marshal).

**depguard (two changes):** add `end_turn.go` to the guarded set; **deny `rulebooks/dnd5e/combat`** — the carve moved the last `combat.AttackContext` marshal out of the guarded handler into the injected adapter, so no guarded file imports `combat`; the boundary is locked shut. Verified: `golangci-lint run` on the guarded packages = 0 issues.

## Deferred (per ratified constraint)

The cross-RPC reaction **wire-pause is NOT built**. NPC reaction pauses resolve through the already-carved `SubmitReactionCheck` single-RPC; the reaction step stays internal.

## Tests

- Existing handler `TestEndTurn_*` suite unchanged and green — **behavior parity proof**.
- New `EndTurnSuite` (orchestrator-level: load preconditions, unwrapped gate sentinels, happy-path advance + persist, NPC-loop-cycles-past-consecutive-NPCs).
- New `EndTurnPauseSuite` (white-box: `enforceSingleReactor` drop-all-but-one; `serializeNPCPendingReactions` skip branches). The genuine SDK NPC-pause path needs full rulebook monster DataJSON rehydration (covered by the Shield integration suite), so the orchestrator-owned bookkeeping is unit-tested directly.

## Verification

- `go build ./...` clean; full `go test -race` suite green (CI's exact command).
- depguard passes with `combat` now denied; no guarded file imports `combat`.

## Docs (doc-owner closeout)

- `docs/status.md` — #582 carve-complete active-work entry.
- `docs/architecture/components/encounter.md` — refreshed from the stale pre-carve "no orchestrator" description to the post-carve two-layer (handlers + orchestrator) shape, including the EndTurn anatomy and the reaction-resume seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)