### PR TITLE
feat(encounter/v2): project economy + menu in the turn-start snapshot (#601)

### DIFF
--- a/internal/handlers/dnd5e/v2/encounter/create.go
+++ b/internal/handlers/dnd5e/v2/encounter/create.go
@@ -76,7 +76,7 @@ func (h *Handler) CreateEncounter(ctx context.Context, req *encounterv2pb.Create
 		return nil, status.Errorf(codes.Internal, "save encounter: %v", err)
 	}
 
-	pbEncounter, err := ProjectFor(ctx, data, core.PlayerID(playerID), h.broker, h.now())
+	pbEncounter, err := ProjectFor(ctx, data, core.PlayerID(playerID), h.broker, h.combatResolverConfig.CharacterRepo, h.now())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "project encounter: %v", err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/get.go
+++ b/internal/handlers/dnd5e/v2/encounter/get.go
@@ -39,7 +39,7 @@ func (h *Handler) GetEncounter(ctx context.Context, req *encounterv2pb.GetEncoun
 		return nil, status.Error(codes.PermissionDenied, "player is not in this encounter")
 	}
 
-	pbEncounter, err := ProjectFor(ctx, data, core.PlayerID(playerID), h.broker, h.now())
+	pbEncounter, err := ProjectFor(ctx, data, core.PlayerID(playerID), h.broker, h.combatResolverConfig.CharacterRepo, h.now())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "project encounter: %v", err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -287,7 +287,7 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 	// ProjectFor internally rehydrates the encounter and computes the per-viewer
 	// snapshot, so we don't need a separate LoadFromData/SnapshotFor here.
 	now := h.now()
-	pbEncounter, err := ProjectFor(ctx, data, core.PlayerID(playerID), h.broker, now)
+	pbEncounter, err := ProjectFor(ctx, data, core.PlayerID(playerID), h.broker, h.combatResolverConfig.CharacterRepo, now)
 	if err != nil {
 		return status.Errorf(codes.Internal, "project encounter %q: %v", string(encID), err)
 	}

--- a/internal/handlers/dnd5e/v2/encounter/hydrate_players.go
+++ b/internal/handlers/dnd5e/v2/encounter/hydrate_players.go
@@ -80,6 +80,69 @@ func attachPlayerCharacterData(
 	return nil
 }
 
+// attachActorCharacterData attaches the transient PlayerData.DataJSON for a
+// SINGLE named actor (the snapshot's active actor) so the subsequent
+// tkenc.LoadFromData holds that one *character.Character — enough for ProjectFor
+// to compute the actor's ActorTurnState (menu + economy) for the turn-start
+// snapshot (#601). Only the active actor is hydrated: the turn-state menu is
+// that actor's private "what can I do now" view (Invariant 6), so the read-only
+// snapshot projector needs no other seat held.
+//
+// Returns true when the actor's character blob was attached (so the caller knows
+// the held character will exist after LoadFromData and ActorTurnState will be
+// populated), false when there is no stored character to attach (NPC / stand-in
+// seat — the snapshot simply carries no menu for that actor's turn, as before).
+//
+// apierr.NotFound is the stand-in/NPC case (not fatal); any other Get error is a
+// real character-store failure and surfaces (mirrors the seeding path's
+// NotFound-vs-real-error distinction). A marshal failure surfaces — a corrupt
+// blob is a real bug, not something to hide.
+func attachActorCharacterData(
+	ctx context.Context,
+	data *tkenc.Data,
+	actorID tkenccore.EntityID,
+	charRepo characterrepo.Repository,
+) (bool, error) {
+	if data == nil || charRepo == nil || actorID == "" {
+		return false, nil
+	}
+	pd, ok := data.Players[playerSeatForEntity(data, actorID)]
+	if !ok || pd == nil || pd.EntityID != actorID {
+		// Active actor is not a player seat (NPC / monster turn) — no character
+		// menu to project. Not an error.
+		return false, nil
+	}
+	out, err := charRepo.Get(ctx, characterrepo.GetInput{ID: string(actorID)})
+	if err != nil {
+		if apierr.IsNotFound(err) {
+			return false, nil // stand-in seat — no character menu to project.
+		}
+		return false, fmt.Errorf("load character %q for turn-state snapshot: %w", actorID, err)
+	}
+	if out == nil || out.Character == nil || out.Character.Data == nil {
+		return false, nil
+	}
+	blob, err := json.Marshal(out.Character.Data)
+	if err != nil {
+		return false, fmt.Errorf("marshal character data for %q: %w", actorID, err)
+	}
+	pd.DataJSON = blob
+	return true, nil
+}
+
+// playerSeatForEntity returns the player-map key whose seat has EntityID ==
+// actorID, or "" when no player seat matches (an NPC / monster actor). Player
+// seats are keyed by PlayerID, which is not necessarily the EntityID, so a
+// lookup by value is required.
+func playerSeatForEntity(data *tkenc.Data, actorID tkenccore.EntityID) tkenccore.PlayerID {
+	for pid, pd := range data.Players {
+		if pd != nil && pd.EntityID == actorID {
+			return pid
+		}
+	}
+	return ""
+}
+
 // SeedTurnEconomyForData seeds the active actor's turn-start action economy in
 // the authoritative character store for a turn-based encounter, closing the
 // "first actor is never in combat" gap (rpg-api#598).

--- a/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
@@ -378,3 +378,64 @@ func (s *MonkUnarmedIntegrationSuite) advanceToCharli() {
 	}
 	s.Fail("advanceToCharli: charli did not become active within 20 initiative steps")
 }
+
+// TestIntegration_TurnStartSnapshot_CarriesEconomyAndMenu proves the #601 fix:
+// the GetEncounter snapshot's TurnState carries the ACTIVE actor's economy +
+// available_actions at turn start — before any TakeAction / TurnStateChanged
+// push — so the client can render the menu to take its FIRST action.
+//
+// Before #601, buildTurnState emitted only initiative/active/round; economy +
+// available_actions were absent until the first action. This drives the real
+// production path: handler.GetEncounter → ProjectFor (with the char repo) →
+// active-actor hydration + ActorTurnState projection.
+func (s *MonkUnarmedIntegrationSuite) TestIntegration_TurnStartSnapshot_CarriesEconomyAndMenu() {
+	charliData := s.buildCharliMonkData()
+	s.setupCharRepoMock(charliData)
+	s.seedMonkEncounter()
+	s.advanceToCharli()
+
+	// Connect-time snapshot via the production handler path (no TakeAction yet).
+	resp, err := s.handler.GetEncounter(s.charliCtx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: monkIntegEncID,
+	})
+	s.Require().NoError(err, "GetEncounter must succeed at turn start")
+	s.Require().NotNil(resp.GetEncounter())
+
+	ts := resp.GetEncounter().GetTurnState()
+	s.Require().NotNil(ts, "turn-based snapshot must carry a TurnState")
+	s.Require().Equal(monkEntityCharli, ts.GetActiveEntityId(), "charli must be the active actor")
+
+	// #601 core assertion 1: economy is present at turn start (seeded for the
+	// first actor by ProjectFor's idempotent StartTurn). A fresh L1 turn has its
+	// standard action available.
+	econ := ts.GetEconomy()
+	s.Require().NotNil(econ, "snapshot TurnState must carry the active actor's economy at turn start")
+	s.Require().Equal(int32(1), econ.GetActionsRemaining(), "fresh turn: one standard action")
+	s.Require().Equal(int32(1), econ.GetReactionsRemaining(), "fresh turn: one reaction")
+	s.Require().Positive(econ.GetMovementRemaining(), "fresh turn: movement seeded from speed")
+
+	// #601 core assertion 2: the menu is present and toolkit-computed. The monk's
+	// menu must include an Attack ability (the actor can attack at turn start) and
+	// the beat-deferred Move marker (D17: available=false + "lands in Beat 2").
+	actions := ts.GetAvailableActions()
+	s.Require().NotEmpty(actions, "snapshot TurnState must carry available_actions at turn start")
+
+	var sawAttack, sawDeferredMove bool
+	for _, a := range actions {
+		ref := a.GetRef()
+		s.Require().NotNil(ref, "every available action carries a ref triple")
+		switch ref.GetId() {
+		case "attack":
+			sawAttack = true
+			s.True(a.GetAvailable(), "attack must be available at turn start (action economy fresh)")
+			s.Equal(encounterv2pb.EconomySlot_ECONOMY_SLOT_ACTION, a.GetEconomySlot(),
+				"attack draws from the standard action slot")
+		case "move":
+			sawDeferredMove = true
+			s.False(a.GetAvailable(), "Move is beat-deferred (D17): available=false at turn start")
+			s.NotEmpty(a.GetUnavailableReason(), "Move carries the deferral reason")
+		}
+	}
+	s.True(sawAttack, "menu must surface the Attack ability at turn start")
+	s.True(sawDeferredMove, "menu must surface the beat-deferred Move marker (D17)")
+}

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -649,3 +649,41 @@ func (s *SneakAttackIntegrationSuite) advanceToAlice() {
 	}
 	s.Fail("advanceToAlice: alice did not become active within 20 initiative steps")
 }
+
+// TestIntegration_TurnStartSnapshot_MenuIsPrivateToActiveActor proves the #601
+// audience gate (Copilot #602): the turn-start snapshot projects the active
+// actor's economy + menu ONLY into the controlling player's snapshot, never into
+// another player's view. During alice's turn, alice sees her menu; bob (a
+// non-controlling viewer) gets the menu-less initiative-only TurnState, so one
+// player's action options/economy never leak to another (Inv 6 audience-seam,
+// matching the live TurnStateChanged push).
+func (s *SneakAttackIntegrationSuite) TestIntegration_TurnStartSnapshot_MenuIsPrivateToActiveActor() {
+	aliceData := s.buildAliceRogueData()
+	s.setupCharRepoMock(aliceData)
+	s.seedSneakEncounter()
+	s.advanceToAlice()
+
+	// Alice (the active actor's controller) sees her own menu + economy.
+	aliceResp, err := s.handler.GetEncounter(s.aliceCtx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: sneakIntegEncID,
+	})
+	s.Require().NoError(err)
+	aliceTS := aliceResp.GetEncounter().GetTurnState()
+	s.Require().NotNil(aliceTS)
+	s.Require().Equal(sneakEntityAlice, aliceTS.GetActiveEntityId())
+	s.Require().NotNil(aliceTS.GetEconomy(), "alice (active actor) must see her own economy")
+	s.Require().NotEmpty(aliceTS.GetAvailableActions(), "alice must see her own menu")
+
+	// Bob (a non-controlling viewer) gets the same turn structure (initiative /
+	// active / round) but NOT alice's private menu/economy.
+	bobResp, err := s.handler.GetEncounter(s.bobCtx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: sneakIntegEncID,
+	})
+	s.Require().NoError(err)
+	bobTS := bobResp.GetEncounter().GetTurnState()
+	s.Require().NotNil(bobTS, "bob still sees the turn structure")
+	s.Require().Equal(sneakEntityAlice, bobTS.GetActiveEntityId(), "bob sees whose turn it is")
+	s.Require().NotEmpty(bobTS.GetInitiativeOrder(), "bob sees the initiative roster")
+	s.Require().Nil(bobTS.GetEconomy(), "bob must NOT see alice's economy (private to active actor)")
+	s.Require().Empty(bobTS.GetAvailableActions(), "bob must NOT see alice's menu (private to active actor)")
+}

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -13,15 +13,23 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 )
 
 // ProjectFor builds a proto *encounterv2pb.Encounter for the given viewer from
 // the encounter's persisted data. CreateEncounter calls it today; GetEncounter
-// (#500) and StreamEncounter snapshot replay (#497) will reuse it so the
-// projection logic lives in exactly one place.
+// (#500) and StreamEncounter snapshot replay (#497) reuse it so the projection
+// logic lives in exactly one place.
 //
 // The broker is required to rehydrate a live Encounter via LoadFromData
 // (needed for SnapshotFor).
+//
+// charRepo is used ONLY to hydrate the turn's ACTIVE actor so the snapshot's
+// TurnState can carry that actor's economy + available_actions menu at turn
+// start (#601: the client needs the menu to take its FIRST action, before any
+// TurnStateChanged push fires). nil disables menu hydration (tests / non-combat
+// callers): the snapshot then carries initiative/active/round only, as before.
+// The toolkit computes the menu (ActorTurnState); rpg-api projects it.
 //
 // now is passed explicitly so callers in tests can inject a fixed clock.
 func ProjectFor(
@@ -29,14 +37,50 @@ func ProjectFor(
 	data *tkenc.Data,
 	viewer core.PlayerID,
 	broker *tkenc.Broker,
+	charRepo characterrepo.Repository,
 	now time.Time,
 ) (*encounterv2pb.Encounter, error) {
-	// Read-only projection: no player DataJSON is attached here, so the SDK's
-	// #689 hydration cascade skips combatant hydration (seats without DataJSON).
-	// The snapshot reads positions/HP/mode from Data directly, not held entities.
+	// #601 turn-start menu: attach the ACTIVE actor's character blob before
+	// LoadFromData so the SDK holds that one character and ActorTurnState below
+	// returns its menu + economy. Only the active actor is hydrated — the menu is
+	// that actor's private view (Inv 6). No-op when not turn-based, no active
+	// actor, or no char store (then the snapshot carries no menu, as before).
+	// Other seats stay un-hydrated, so Space.Entities still reads positions/HP
+	// from Data directly (not held entities) exactly as before.
+	activeActor := activeActorID(data)
+	var actorHydrated bool
+	if charRepo != nil && activeActor != "" {
+		// Ensure the active actor's economy is seeded before reading its menu, so
+		// the turn-start snapshot carries economy too — not just the menu. The
+		// connect-time snapshot path (StreamEncounter/GetEncounter) does NOT go
+		// through the orchestrator's combat-load #598 seeding, so a freshly-
+		// entered turn-based encounter's first actor would otherwise be unseeded
+		// (nil economy) here. SeedTurnEconomyForData runs the toolkit's own
+		// StartTurn (idempotent; no-op once in combat) and persists it — rpg-api
+		// authors no economy values, the toolkit owns them (Invariant 2/3).
+		if seedErr := SeedTurnEconomyForData(ctx, data, charRepo); seedErr != nil {
+			return nil, seedErr
+		}
+		var attachErr error
+		actorHydrated, attachErr = attachActorCharacterData(ctx, data, activeActor, charRepo)
+		if attachErr != nil {
+			return nil, attachErr
+		}
+	}
+
 	enc, err := tkenc.LoadFromData(ctx, data, broker)
 	if err != nil {
 		return nil, err
+	}
+
+	// Compute the active actor's turn state (menu + economy) from the held
+	// character the toolkit just hydrated. Only when we actually attached the
+	// actor's blob: ActorTurnState returns a zero value for an un-held actor, and
+	// we want buildTurnState to fall back to the menu-less shape in that case.
+	var actorTurnState *tkenc.ActorTurnState
+	if actorHydrated {
+		ts := enc.ActorTurnState(activeActor)
+		actorTurnState = &ts
 	}
 
 	snap := enc.SnapshotFor(viewer)
@@ -136,7 +180,7 @@ func ProjectFor(
 	return &encounterv2pb.Encounter{
 		Id:        string(data.ID),
 		Mode:      encounterModeToProto(data.Mode),
-		TurnState: buildTurnState(data),
+		TurnState: buildTurnState(data, actorTurnState),
 		Space: &encounterv2pb.Space{
 			Hexes:    hexes,
 			Entities: entities,
@@ -144,16 +188,35 @@ func ProjectFor(
 	}, nil
 }
 
+// activeActorID returns the entity id of the actor whose turn it is, or "" when
+// the encounter is not turn-based or the active index is out of range.
+func activeActorID(data *tkenc.Data) core.EntityID {
+	if data.Mode != core.ModeTurnBased {
+		return ""
+	}
+	if data.ActiveIdx < 0 || data.ActiveIdx >= len(data.Initiative) {
+		return ""
+	}
+	return data.Initiative[data.ActiveIdx]
+}
+
 // buildTurnState returns a populated TurnState only when the encounter is in
-// turn-based mode. ActionEconomy and AvailableActions are server-only state
-// for this PR; emitting them is tracked as a follow-up.
+// turn-based mode.
 //
 // Initiative IDs (and the active entity ID) are emitted verbatim — clients
 // need them as opaque tokens to render "whose turn" even when the active
 // entity is currently outside the viewer's LOS. Per-entity rich data
 // (position, hp, monster ref) is still LOS-gated via Space.Entities; the
 // initiative roster only exposes ids, which carry no spatial information.
-func buildTurnState(data *tkenc.Data) *encounterv2pb.TurnState {
+//
+// actorTurnState is the active actor's toolkit-computed menu + economy (#601),
+// supplied by ProjectFor when it hydrated the active actor. When non-nil it
+// populates Economy + AvailableActions field-for-field so the snapshot carries
+// the menu at turn start (the client needs it to take its FIRST action, before
+// any TurnStateChanged push). nil (NPC turn / no char store / not hydrated)
+// leaves them empty — the menu-less initiative-only shape, as before. The
+// toolkit computed the menu; rpg-api only projects it.
+func buildTurnState(data *tkenc.Data, actorTurnState *tkenc.ActorTurnState) *encounterv2pb.TurnState {
 	if data.Mode != core.ModeTurnBased {
 		return nil
 	}
@@ -165,11 +228,19 @@ func buildTurnState(data *tkenc.Data) *encounterv2pb.TurnState {
 	if data.ActiveIdx >= 0 && data.ActiveIdx < len(data.Initiative) {
 		active = string(data.Initiative[data.ActiveIdx])
 	}
-	return &encounterv2pb.TurnState{
+	ts := &encounterv2pb.TurnState{
 		InitiativeOrder: order,
 		ActiveEntityId:  active,
 		Round:           int32(data.Round),
 	}
+	// #601: project the active actor's economy + menu when available. The
+	// rulebook-touching projection lives in turn_state_project.go (the toolkit
+	// computes ActorTurnState; this only maps its fields onto the wire).
+	if actorTurnState != nil {
+		ts.Economy = actorEconomyToProto(actorTurnState.Economy)
+		ts.AvailableActions = actorMenuToProto(actorTurnState)
+	}
+	return ts
 }
 
 // playerEntity builds the wire-shape proto Entity for a player seat. The

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -47,9 +47,18 @@ func ProjectFor(
 	// actor, or no char store (then the snapshot carries no menu, as before).
 	// Other seats stay un-hydrated, so Space.Entities still reads positions/HP
 	// from Data directly (not held entities) exactly as before.
+	//
+	// Audience gate (Copilot #602): the menu/economy is the active actor's PRIVATE
+	// view — the same audience-seam the live TurnStateChanged push uses (its
+	// audience is the controlling player only). So project it ONLY when this
+	// viewer controls the active actor; every other viewer gets the menu-less
+	// initiative-only TurnState, so we never leak one player's options/economy to
+	// another. The controlling player's own connect/stream is what seeds + shows
+	// the menu.
 	activeActor := activeActorID(data)
+	viewerControlsActiveActor := activeActor != "" && playerSeatForEntity(data, activeActor) == viewer
 	var actorHydrated bool
-	if charRepo != nil && activeActor != "" {
+	if charRepo != nil && viewerControlsActiveActor {
 		// Ensure the active actor's economy is seeded before reading its menu, so
 		// the turn-start snapshot carries economy too — not just the menu. The
 		// connect-time snapshot path (StreamEncounter/GetEncounter) does NOT go

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -78,7 +78,7 @@ func (s *ProjectSuite) TestProjectFor_TurnBased_EmitsModeTurnStateAndMonsters() 
 		},
 	}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	s.Require().NotNil(pb)
 	s.Require().Equal("enc-turnbased", pb.GetId())
@@ -156,7 +156,7 @@ func (s *ProjectSuite) TestProjectFor_TurnBased_SkipsMonsterOutsideLOS() {
 		},
 	}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	for _, e := range pb.GetSpace().GetEntities() {
 		s.Require().NotEqual("goblin-far", e.GetId(), "out-of-sight monster must not be emitted")
@@ -173,7 +173,7 @@ func (s *ProjectSuite) TestProjectFor_FreeRoam_NoTurnState() {
 	alice := newPlayerData("player-alice", "char-alice", originHex, 2)
 	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	s.Require().Equal(
 		encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
@@ -206,7 +206,7 @@ func (s *ProjectSuite) TestProjectFor_ModeEnded_NoTurnStateAndOmitsRemovedMonste
 	// data.Monsters intentionally empty — killEntity removed the last hostile
 	// before flipping mode to ModeEnded. Snapshot must not synthesize one.
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 
 	// Mode maps to FREE_ROAM because the proto has no _ENDED variant; the
@@ -241,7 +241,7 @@ func (s *ProjectSuite) TestProjectFor_Unspecified_TreatedAsFreeRoam() {
 	alice := newPlayerData("player-alice", "char-alice", originHex, 2)
 	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	s.Require().Equal(
 		encounterv2pb.EncounterMode_ENCOUNTER_MODE_FREE_ROAM,
@@ -262,7 +262,7 @@ func (s *ProjectSuite) TestProjectFor_TurnBased_ActiveIdxOutOfRange_NoActive() {
 	alice := newPlayerData("player-alice", "char-alice", originHex, 2)
 	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	ts := pb.GetTurnState()
 	s.Require().NotNil(ts)
@@ -289,7 +289,7 @@ func (s *ProjectSuite) TestProjectFor_MonsterRef_MalformedFallsBackToDefaults() 
 		},
 	}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	var found bool
 	for _, e := range pb.GetSpace().GetEntities() {
@@ -331,7 +331,7 @@ func (s *ProjectSuite) TestProjectFor_PlayerEntitiesCarryTypeHpAndCharacterData(
 		"player-bob":   bob,
 	}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 
 	byID := make(map[string]*encounterv2pb.Entity)
@@ -387,7 +387,7 @@ func (s *ProjectSuite) TestProjectFor_PlayerEntityCarriesArmorClass() {
 	charli.AC = 15
 	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-charli": charli}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-charli", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-charli", s.broker, nil, s.now)
 	s.Require().NoError(err)
 
 	var found *encounterv2pb.Entity
@@ -421,7 +421,7 @@ func (s *ProjectSuite) TestProjectFor_MonsterRef_TooManyColonsTreatedAsMalformed
 		},
 	}
 
-	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.now)
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	for _, e := range pb.GetSpace().GetEntities() {
 		if e.GetId() != "long-1" {

--- a/internal/handlers/dnd5e/v2/encounter/turn_state_project.go
+++ b/internal/handlers/dnd5e/v2/encounter/turn_state_project.go
@@ -1,0 +1,103 @@
+package encounter
+
+// turn_state_project.go projects the toolkit's per-actor turn state
+// (encounter.ActorTurnState — economy + the abilities/actions menu) onto the
+// proto TurnState for the turn-START snapshot (#601).
+//
+// This is the SNAPSHOT-path counterpart to translate.go's turnStateSnapshotToProto
+// (the LIVE TurnStateChanged push). The live path consumes the toolkit's already-
+// flattened, rulebook-agnostic events.TurnStateSnapshot; the snapshot path reads
+// encounter.ActorTurnState directly, whose fields are the rulebook's own
+// character.{ActionEconomyData,AvailableAbility,AvailableAction} types. The
+// toolkit's ActorTurnState is the read surface it built FOR rpg-api to project
+// (turn_state.go: "The caller (rpg-api) projects the returned domain types onto
+// the wire TurnState"); rpg-api computes nothing here — it copies fields and maps
+// the toolkit's string enums onto the proto enums.
+//
+// This file is the single rulebook-touching spot in the projection path, kept out
+// of the depguard-guarded action-handler files. Follow-up (surface to director):
+// the toolkit could export its buildTurnStateSnapshot flattener (or an
+// Encounter.ActorTurnStateSnapshot method) so BOTH paths consume the agnostic
+// events.TurnStateSnapshot and this rulebook import goes away entirely.
+
+import (
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	tkcore "github.com/KirkDiggler/rpg-toolkit/core"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	tkcharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+// actorEconomyToProto projects the toolkit's ActionEconomyData (the actor's
+// current turn economy) onto the proto ActionEconomy field-for-field. nil
+// economy (actor not in combat / no held character) projects to nil so the
+// snapshot omits it. The toolkit owns these counters (Invariants 2/3); this is
+// a faithful copy, no math.
+func actorEconomyToProto(econ *tkcharacter.ActionEconomyData) *encounterv2pb.ActionEconomy {
+	if econ == nil {
+		return nil
+	}
+	out := &encounterv2pb.ActionEconomy{
+		ActionsRemaining:      int32(econ.ActionsRemaining),      //nolint:gosec // bounded turn-economy counters fit int32
+		BonusActionsRemaining: int32(econ.BonusActionsRemaining), //nolint:gosec // bounded turn-economy counters fit int32
+		ReactionsRemaining:    int32(econ.ReactionsRemaining),    //nolint:gosec // bounded turn-economy counters fit int32
+		MovementRemaining:     int32(econ.MovementRemaining),     //nolint:gosec // movement in feet fits int32
+	}
+	if len(econ.Granted) > 0 {
+		out.Capacities = make(map[string]int32, len(econ.Granted))
+		for k, v := range econ.Granted {
+			out.Capacities[string(k)] = int32(v) //nolint:gosec // granted-capacity counts fit int32
+		}
+	}
+	return out
+}
+
+// actorMenuToProto projects the actor's available menu — abilities (primary
+// economy slots) first, then granted-capacity actions, matching the live path's
+// ordering (buildTurnStateSnapshot) and the dnd5e two-level model — onto proto
+// AvailableActions. Each entry is mapped field-for-field: ref (split via the
+// shared actionRefToProto guard), display name, effective availability + reason,
+// economy slot enum, target kind enum. The toolkit authored every field
+// (including the CanUse verdict and the reason string, and the D17 Move deferral
+// baked into ActorTurnState); rpg-api never recomputes availability.
+func actorMenuToProto(ts *tkenc.ActorTurnState) []*encounterv2pb.AvailableAction {
+	if ts == nil {
+		return nil
+	}
+	total := len(ts.Abilities) + len(ts.Actions)
+	if total == 0 {
+		return nil
+	}
+	out := make([]*encounterv2pb.AvailableAction, 0, total)
+	for _, a := range ts.Abilities {
+		out = append(out, &encounterv2pb.AvailableAction{
+			Ref:               actionRefToProto(refOrEmpty(a.Ref)),
+			DisplayName:       a.Name,
+			Available:         a.CanUse,
+			UnavailableReason: a.Reason,
+			EconomySlot:       economySlotToProto(string(a.EconomySlot)),
+			TargetKind:        targetKindToProto(string(a.TargetKind)),
+		})
+	}
+	for _, a := range ts.Actions {
+		out = append(out, &encounterv2pb.AvailableAction{
+			Ref:               actionRefToProto(refOrEmpty(a.Ref)),
+			DisplayName:       a.Name,
+			Available:         a.CanUse,
+			UnavailableReason: a.Reason,
+			EconomySlot:       economySlotToProto(string(a.EconomySlot)),
+			TargetKind:        targetKindToProto(string(a.TargetKind)),
+		})
+	}
+	return out
+}
+
+// refOrEmpty renders a toolkit *core.Ref to its canonical "module:type:id"
+// string, or "" when nil. (*core.Ref).String() dereferences without a nil check,
+// so the explicit guard is required. The shared actionRefToProto then splits the
+// string, guarding degenerate input (protos disc-014).
+func refOrEmpty(ref *tkcore.Ref) string {
+	if ref == nil {
+		return ""
+	}
+	return ref.String()
+}


### PR DESCRIPTION
## What

Closes the **last TakeAction done-bar gap** (playtest-verified blocker). The connect-time snapshot's `TurnState` carried only initiative/active/round — `economy` + `available_actions` were absent — so the menu was empty until the first action, and the player couldn't see the menu to take its **FIRST** action. Traced to the deferral note at `project.go` ("server-only state for this PR; tracked as a follow-up").

`Part of #54` · `Closes #601`. Pure projection — the toolkit computes the menu; rpg-api projects it.

## How

`ProjectFor` now hydrates the turn's **active actor** (only that actor — the menu is its private view, Inv 6) and projects its toolkit-computed `ActorTurnState` (encounter v0.21.0) field-for-field onto the snapshot `TurnState`:

- **`attachActorCharacterData`** attaches the active actor's stored character blob before `LoadFromData`, so the SDK holds it and `ActorTurnState` returns its menu + economy. NotFound = stand-in seat (no menu, not fatal); other Get errors surface.
- **`SeedTurnEconomyForData`** (the #598 helper) ensures the active actor's economy is seeded first — the connect-time path (`StreamEncounter`/`GetEncounter`) doesn't go through the orchestrator's combat-load #598 seeding, so a freshly-entered turn-based encounter's first actor would otherwise be unseeded (nil economy) here. Idempotent; runs the toolkit's own `StartTurn`; rpg-api authors no economy values (Inv 2/3).
- **`buildTurnState`** projects `Economy` + `AvailableActions` from the `ActorTurnState`; nil (NPC turn / no char store / not hydrated) keeps the menu-less initiative-only shape.
- **`turn_state_project.go`** holds the one rulebook-touching projection (`character.{ActionEconomyData,AvailableAbility,AvailableAction}` → proto), kept out of the depguard-guarded handler files. It reuses the shared `actionRefToProto`/`economySlotToProto`/`targetKindToProto` mappers (same as the live `TurnStateChanged` path). The toolkit computed every field incl. the D17 Move deferral and each `CanUse`/reason; rpg-api only maps fields + string enums.
- `ProjectFor` gains a `charRepo` param (nil = no menu hydration; tests pass nil → unchanged behavior).

## Proof

`TestIntegration_TurnStartSnapshot_CarriesEconomyAndMenu` drives the **real** production path (`handler.GetEncounter → ProjectFor`) and asserts the snapshot carries, BEFORE any TakeAction:
- `TurnState.Economy`: `actions_remaining=1`, `reactions_remaining=1`, `movement_remaining>0`
- `TurnState.AvailableActions`: non-empty; **Attack** present + available (`ECONOMY_SLOT_ACTION`), **Move** present + `available=false` with the beat-2 deferral reason (D17).

`go test -race ./...` green repo-wide; the existing Project/Translate/integration suites unchanged (nil-charRepo path identical to before).

## Boundary

The lone rulebook import lives in `turn_state_project.go` (the projection adapter, not a guarded handler file) — consistent with how the resolver adapters import the rulebook as a translation seam, and with the toolkit's `ActorTurnState` doc ("the caller (rpg-api) projects the returned domain types onto the wire TurnState"). depguard-clean; lint count unchanged (no new issues).

**Follow-up surfaced (director's call):** the toolkit could export its `buildTurnStateSnapshot` flattener (or an `Encounter.ActorTurnStateSnapshot` method) so BOTH the live and snapshot paths consume the agnostic `events.TurnStateSnapshot` and this one rulebook import in the projection layer goes away. Happy to file under #54.

Closes #601
Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)