### PR TITLE
fix(encounter/v2): accept SELF/NONE targets the pushed menu advertises (#605)

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -30,10 +30,13 @@ streaming handler — disconnect events do not clean up encounter state.
 
 ### Encounter v2 handler — B (Wave 2.11e update)
 
-`internal/handlers/dnd5e/v2/encounter/` — the v1alpha2 encounter stack
-that orchestrates against the toolkit encounter SDK directly (no
-intermediate orchestrator layer). Wave 2.11e adds the MovementResolver
-wiring, bringing OA-class reactions end-to-end for both movement directions.
+`internal/handlers/dnd5e/v2/encounter/` — the v1alpha2 encounter stack.
+Since the #582 carve-out the RPCs delegate load → verb → persist to the v2
+orchestrator (`internal/orchestrators/encounter/v2`), leaving the handler as
+proto↔input + sentinel→status mapping; the resolvers below stay handler-side
+(depguard-excluded) because they touch the rulebook. Wave 2.11e adds the
+MovementResolver wiring, bringing OA-class reactions end-to-end for both
+movement directions.
 
 What's here as of Wave 2.11e:
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -46,8 +46,11 @@ What's here as of Wave 2.11e:
   `tkenc.MovementResolver`; delegates to `combat.MoveEntity` per hex step.
   Builds spatial room + combatant registry + gamectx per step so OA chain
   fires correctly (see `encounter.md` MovementResolver wiring section).
-- `TakeAction` (`take_action.go`) — RPC for player-initiated combat actions
-  (Wave 2.8: only the "attack" action ref). Carved onto the v2 orchestrator
+- `TakeAction` (`take_action.go`) — RPC for player-initiated combat actions.
+  Any menu ref routes through the toolkit dispatch (encounter v0.20+); the
+  handler translates the target oneof per the advertised TargetKind contract —
+  entity_id, self (→ actor's own id), unset oneof (untargeted NONE) — and
+  rejects reserved position/area (#605). Carved onto the v2 orchestrator
   (`internal/orchestrators/encounter/v2/take_action.go`, #582 step 5): the
   handler is now proto↔input + sentinel→status mapping; the orchestrator owns
   load (with the #689 hydration cascade so the resolver reads the held

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -191,9 +191,92 @@ func (s *HandlerSuite) TestTakeAction_NilTarget_InvalidArgument() {
 	s.Require().Equal(codes.InvalidArgument, st.Code())
 }
 
-func (s *HandlerSuite) TestTakeAction_TargetMissingKind_InvalidArgument() {
+// TestTakeAction_NoneTarget_EmptyKind_Forwarded verifies that an ActionTarget
+// with the oneof UNSET — the wire shape the web sends for a TARGET_KIND_NONE
+// action (Dash), per the TargetKind enum contract ("NONE has no oneof arm; fire
+// with an empty ActionTarget") — is no longer rejected as InvalidArgument
+// (rpg-api#605). It must be forwarded to the toolkit untargeted. This suite's
+// flat stat-snapshot seats have no hydrated character, so the toolkit refuses
+// the non-attack ref with ErrNonCombatant → FailedPrecondition; the assertion
+// that matters is that the refusal is state-shaped, not request-shaped.
+func (s *HandlerSuite) TestTakeAction_NoneTarget_EmptyKind_Forwarded() {
+	s.seedCombatEncounter()
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	req := &encounterv2pb.TakeActionRequest{
+		EncounterId:   combatEncID,
+		ActorEntityId: string(s.activeEntityID()),
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "combat_abilities", Id: "dash"},
+		Target:        &encounterv2pb.ActionTarget{}, // NONE: oneof deliberately unset
+	}
+	_, err := s.handler.TakeAction(ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().NotEqual(codes.InvalidArgument, st.Code(),
+		"untargeted (NONE) shape must not be rejected at the envelope — the menu advertises it")
+	s.Require().Equal(codes.FailedPrecondition, st.Code(),
+		"flat seat has no hydrated character; toolkit refuses with ErrNonCombatant")
+}
+
+// TestTakeAction_SelfTarget_Forwarded verifies that the self oneof arm — the
+// wire shape the web sends for a TARGET_KIND_SELF action (Dodge/Hide/
+// Disengage) — is no longer rejected as InvalidArgument (rpg-api#605). The
+// handler translates self → the actor's own entity id and forwards; the flat
+// seat then fails state-shaped (ErrNonCombatant → FailedPrecondition).
+func (s *HandlerSuite) TestTakeAction_SelfTarget_Forwarded() {
+	s.seedCombatEncounter()
+	s.advanceToActivePlayer()
+	ctx := s.activePlayerCtx()
+	req := &encounterv2pb.TakeActionRequest{
+		EncounterId:   combatEncID,
+		ActorEntityId: string(s.activeEntityID()),
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "combat_abilities", Id: "dodge"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_Self{Self: &encounterv2pb.SelfTarget{}},
+		},
+	}
+	_, err := s.handler.TakeAction(ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().NotEqual(codes.InvalidArgument, st.Code(),
+		"self-targeted shape must not be rejected at the envelope — the menu advertises it")
+	s.Require().Equal(codes.FailedPrecondition, st.Code(),
+		"flat seat has no hydrated character; toolkit refuses with ErrNonCombatant")
+}
+
+// TestTakeAction_EmptyEntityID_InvalidArgument: the entity_id oneof arm SET but
+// carrying an empty string is a malformed request (a defect, distinct from the
+// unset-oneof NONE shape) and stays InvalidArgument.
+func (s *HandlerSuite) TestTakeAction_EmptyEntityID_InvalidArgument() {
+	req := makeAttackRequest(entityAliceID, "")
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+// TestTakeAction_PositionTarget_InvalidArgument: position targeting is reserved
+// for future waves and never advertised — still rejected request-shaped.
+func (s *HandlerSuite) TestTakeAction_PositionTarget_InvalidArgument() {
 	req := makeAttackRequest(entityAliceID, monsterGoblin1)
-	req.Target = &encounterv2pb.ActionTarget{} // no oneof set
+	req.Target = &encounterv2pb.ActionTarget{
+		Kind: &encounterv2pb.ActionTarget_Position{Position: &encounterv2pb.Position{X: 1, Y: 0, Z: -1}},
+	}
+	_, err := s.handler.TakeAction(s.ctx, req)
+	s.Require().Error(err)
+	st, _ := status.FromError(err)
+	s.Require().Equal(codes.InvalidArgument, st.Code())
+}
+
+// TestTakeAction_AreaTarget_InvalidArgument: area targeting is reserved for
+// future waves and never advertised — still rejected request-shaped.
+func (s *HandlerSuite) TestTakeAction_AreaTarget_InvalidArgument() {
+	req := makeAttackRequest(entityAliceID, monsterGoblin1)
+	req.Target = &encounterv2pb.ActionTarget{
+		Kind: &encounterv2pb.ActionTarget_Area{Area: &encounterv2pb.AreaTarget{
+			Center: &encounterv2pb.Position{X: 1, Y: 0, Z: -1},
+		}},
+	}
 	_, err := s.handler.TakeAction(s.ctx, req)
 	s.Require().Error(err)
 	st, _ := status.FromError(err)

--- a/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
@@ -206,9 +206,72 @@ func (s *MonkUnarmedIntegrationSuite) TestIntegration_MartialArts_DoesNotCrashWi
 		"unarmed strike with Martial Arts condition must not crash from missing ability scores in gamectx registry")
 }
 
+// TestIntegration_TakeAction_DodgeSelfTarget_Resolves is the rpg-api#605 live
+// repro: the pushed menu advertises Dodge with TARGET_KIND_SELF and the web
+// dispatches `target:{self:{}}`; the handler must accept the advertised shape,
+// translate self → the actor's own entity id, and let the toolkit resolve it.
+// Success is observable as consumed action economy (Dodge draws the standard
+// action) via the production GetEncounter snapshot path.
+func (s *MonkUnarmedIntegrationSuite) TestIntegration_TakeAction_DodgeSelfTarget_Resolves() {
+	charliData := s.buildCharliMonkData()
+	s.setupCharRepoMock(charliData)
+	s.seedMonkEncounter()
+	s.advanceToCharli()
+
+	_, err := s.handler.TakeAction(s.charliCtx, &encounterv2pb.TakeActionRequest{
+		EncounterId:   monkIntegEncID,
+		ActorEntityId: monkEntityCharli,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "combat_abilities", Id: "dodge"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_Self{Self: &encounterv2pb.SelfTarget{}},
+		},
+	})
+	s.Require().NoError(err, "Dodge with the advertised self target shape must resolve")
+
+	s.Require().Equal(int32(0), s.charliActionsRemaining(),
+		"Dodge must consume charli's standard action")
+}
+
+// TestIntegration_TakeAction_DashNoneTarget_Resolves is the rpg-api#605 live
+// repro for TARGET_KIND_NONE: Dash is advertised untargeted; NONE has no
+// ActionTarget oneof arm, so the web sends an ActionTarget with the oneof
+// unset. The handler must accept that shape and forward the action untargeted.
+func (s *MonkUnarmedIntegrationSuite) TestIntegration_TakeAction_DashNoneTarget_Resolves() {
+	charliData := s.buildCharliMonkData()
+	s.setupCharRepoMock(charliData)
+	s.seedMonkEncounter()
+	s.advanceToCharli()
+
+	_, err := s.handler.TakeAction(s.charliCtx, &encounterv2pb.TakeActionRequest{
+		EncounterId:   monkIntegEncID,
+		ActorEntityId: monkEntityCharli,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "combat_abilities", Id: "dash"},
+		Target:        &encounterv2pb.ActionTarget{}, // NONE: oneof deliberately unset
+	})
+	s.Require().NoError(err, "Dash with the advertised untargeted (NONE) shape must resolve")
+
+	s.Require().Equal(int32(0), s.charliActionsRemaining(),
+		"Dash must consume charli's standard action")
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// charliActionsRemaining reads the active actor's standard-actions-remaining
+// through the production GetEncounter snapshot path (charli must be active).
+func (s *MonkUnarmedIntegrationSuite) charliActionsRemaining() int32 {
+	resp, err := s.handler.GetEncounter(s.charliCtx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: monkIntegEncID,
+	})
+	s.Require().NoError(err, "GetEncounter must succeed")
+	ts := resp.GetEncounter().GetTurnState()
+	s.Require().NotNil(ts, "turn-based snapshot must carry a TurnState")
+	s.Require().Equal(monkEntityCharli, ts.GetActiveEntityId(), "charli must still be the active actor")
+	econ := ts.GetEconomy()
+	s.Require().NotNil(econ, "snapshot TurnState must carry the active actor's economy")
+	return econ.GetActionsRemaining()
+}
 
 // buildCharliMonkData constructs character.Data for charli — a L1 monk with
 // DEX 16 > STR 10, no weapon equipped, and MartialArts + UnarmoredDefense conditions

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -16,10 +16,12 @@ package encounter
 // +2 + physical resistance, Sneak Attack, the reaction-trigger pause). rpg-api
 // passes the action ref + target through by reference and persists the result.
 //
-// Wave 2.8 only wires the "attack" action ref; other refs the toolkit refuses
-// with ErrUnsupportedAction (→ Unimplemented). Only entity-id targeting is wired
-// (position / area / self oneofs are reserved for future waves and rejected here
-// with InvalidArgument because the request shape is wrong, not the world state).
+// Targeting mirrors the pushed menu's TargetKind contract (rpg-api#605):
+// entity-id, self (translated to the actor's own entity id), and untargeted
+// NONE (oneof unset) are accepted; position / area oneofs are reserved for
+// future waves and rejected with InvalidArgument because the request shape is
+// wrong, not the world state. Which refs require a target is the toolkit's
+// call, never the handler's.
 
 import (
 	"context"
@@ -60,20 +62,16 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 	if req.GetActionRef() == nil {
 		return nil, status.Error(codes.InvalidArgument, "action_ref is required")
 	}
-	if req.GetTarget() == nil || req.GetTarget().GetKind() == nil {
+	if req.GetTarget() == nil {
 		return nil, status.Error(codes.InvalidArgument, "target is required")
 	}
 
-	// Wave 2.8 only supports entity-id targeting. Other oneof variants are
-	// reserved for future waves (position for AoEs, area for spells, self
-	// for buffs). InvalidArgument because the request shape is wrong, not
-	// the world state.
-	entityID := req.GetTarget().GetEntityId()
-	if entityID == "" {
-		return nil, status.Error(codes.InvalidArgument, "target.entity_id is required (only entity-id targeting is supported in this wave)")
+	entityID, err := translateActionTarget(req.GetTarget(), req.GetActorEntityId())
+	if err != nil {
+		return nil, err
 	}
 
-	_, err := h.orch.TakeAction(ctx, &encounterorch.TakeActionInput{
+	_, err = h.orch.TakeAction(ctx, &encounterorch.TakeActionInput{
 		EncounterID: req.GetEncounterId(),
 		PlayerID:    core.PlayerID(playerID),
 		ActorID:     core.EntityID(req.GetActorEntityId()),
@@ -89,6 +87,39 @@ func (h *Handler) TakeAction(ctx context.Context, req *encounterv2pb.TakeActionR
 	}
 
 	return &encounterv2pb.TakeActionResponse{}, nil
+}
+
+// translateActionTarget maps the proto ActionTarget oneof onto the toolkit's
+// entity-id target representation (encounter.ActionTarget carries only an
+// EntityID). Pure shape translation — the handler never knows which refs need
+// a target; the toolkit enforces that (e.g. an untargeted attack fails with
+// ErrUnknownTarget → FailedPrecondition).
+//
+// The advertised TargetKind contract (rpg-api#605):
+//   - entity_id arm → that entity (empty string is a malformed request)
+//   - self arm (TARGET_KIND_SELF: Dodge/Hide/Disengage) → the actor's own
+//     entity id
+//   - oneof unset (TARGET_KIND_NONE: Dash — deliberately has no arm) → empty
+//     id, the action is untargeted
+//   - position / area arms → reserved for future waves (AoEs, spells), never
+//     advertised, rejected request-shaped with InvalidArgument
+func translateActionTarget(target *encounterv2pb.ActionTarget, actorEntityID string) (string, error) {
+	switch kind := target.GetKind().(type) {
+	case *encounterv2pb.ActionTarget_EntityId:
+		if kind.EntityId == "" {
+			return "", status.Error(codes.InvalidArgument, "target.entity_id must not be empty")
+		}
+		return kind.EntityId, nil
+	case *encounterv2pb.ActionTarget_Self:
+		return actorEntityID, nil
+	case nil:
+		// TARGET_KIND_NONE: an untargeted action sends an ActionTarget with
+		// the oneof unset.
+		return "", nil
+	default:
+		return "", status.Error(codes.InvalidArgument,
+			"target kind is not supported (position/area targeting is reserved for future waves)")
+	}
 }
 
 // takeActionStatusError maps the orchestrator's TakeAction errors onto gRPC

--- a/internal/orchestrators/encounter/v2/take_action.go
+++ b/internal/orchestrators/encounter/v2/take_action.go
@@ -34,10 +34,13 @@ type TakeActionInput struct {
 	// through by reference, never inspecting which action it is.
 	ActionRef tkenc.ActionRef
 
-	// TargetEntityID is the entity-id target of the action (Wave 2.8: only
-	// entity-id targeting is wired; position / area / self oneofs are reserved
-	// for future waves and validated handler-side). The orchestrator passes it
-	// through to the toolkit verb.
+	// TargetEntityID is the entity-id target of the action. The handler
+	// translates the proto oneof onto it (rpg-api#605): entity_id arm → that
+	// entity; self arm → the actor's own entity id; unset oneof (untargeted
+	// NONE, e.g. Dash) → empty. position / area arms are reserved for future
+	// waves and rejected handler-side. The orchestrator passes it through to
+	// the toolkit verb; whether the action requires a target is the toolkit's
+	// call (an untargeted attack fails with ErrUnknownTarget).
 	TargetEntityID core.EntityID
 }
 


### PR DESCRIPTION
## Problem

Live playtest (Chapter 2 TakeAction wave): the server-pushed menu advertises Hide/Dodge/Disengage with `TARGET_KIND_SELF` and Dash with `TARGET_KIND_NONE` as `available: true`. The web dispatches exactly the advertised shape (`target:{self:{}}` for SELF; ActionTarget with the oneof unset for NONE — NONE deliberately has no arm per the TargetKind enum contract). The handler's Wave-2.8 guard rejected everything but the `entity_id` arm with `InvalidArgument: target.entity_id is required`, making the entire non-attack half of the live menu unusable through the UI.

**Evidence:** clicking Hide in the UI → InvalidArgument; the same ref via grpcurl with `target.entity_id=char-charli` (the actor's own id) resolves fine — ActionResolved published, economy consumed. The toolkit path works; the handler guard was the only blocker.

## Fix — translation layer only

`translateActionTarget` maps the proto oneof onto the toolkit's entity-id target representation (`encounter.ActionTarget` at v0.21.0 carries only `EntityID`; its non-attack path never requires one — it is only echoed into the ActionResolved event; the attack path enforces its own target via `ErrUnknownTarget`):

| advertised kind | wire shape | translation |
|---|---|---|
| SINGLE_ENTITY | `entity_id` arm | that entity (empty string still InvalidArgument) |
| SELF | `self` arm | the actor's own entity id |
| NONE | oneof unset | untargeted (empty id) |
| POSITION / AREA | reserved arms | still InvalidArgument (never advertised) |

No per-ref knowledge in the handler — which refs require a target stays the toolkit's call (an untargeted attack fails there with `ErrUnknownTarget` → FailedPrecondition, state-shaped not request-shaped).

## Tests (failing-first)

- `TestIntegration_TakeAction_DodgeSelfTarget_Resolves` / `TestIntegration_TakeAction_DashNoneTarget_Resolves` — the live repro on the hydrated-monk fixture (charli): the advertised SELF/NONE wire shapes resolve end-to-end and consume the standard action (verified via the production GetEncounter snapshot path).
- `TestTakeAction_SelfTarget_Forwarded` / `TestTakeAction_NoneTarget_EmptyKind_Forwarded` — flat-seat suite: the shapes are no longer rejected request-shaped (forwarded to toolkit; refusal is state-shaped ErrNonCombatant).
- `TestTakeAction_EmptyEntityID_InvalidArgument`, `TestTakeAction_PositionTarget_InvalidArgument`, `TestTakeAction_AreaTarget_InvalidArgument` — malformed/reserved shapes still rejected.
- Replaces `TestTakeAction_TargetMissingKind_InvalidArgument`, whose expectation encoded the bug (the unset oneof IS the NONE wire shape).

All were InvalidArgument-failing before the fix; full `go test ./...` green after.

## Notes

- `docs/quality.md` TakeAction bullet updated in-PR (stale "attack ref only" claim).
- Pre-existing, out-of-scope: `make lint` reports 70 issues on clean main too (none in files touched here; CI has no lint job); ci-check's mock-regeneration signal is import-order churn from local mockgen drift across 13 untouched mocks. Also flagging: `scripts/ci-checks.sh:44` runs `git checkout -- .`, which destroys uncommitted work — commit before running `make ci-check`.

Closes #605
Part of KirkDiggler/rpg-project#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm