### PR TITLE
chore(deps): bump rpg-toolkit to consume Monk strike + DEX-swap fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260601231022-a92fb6b11f91
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.21.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.21.1
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.2
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.21.0 h1:RBpGj6Q3gXg18HdzDJqM3YfxECweDm4mahhBiNBFKX4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.21.0/go.mod h1:3OnMjbsyp7rLxmKwOQLyJEirgKZ8i/cXQ1lOsCojBAs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.21.1 h1:ioMIZppDlVFzEIjP3/vGvr4uULcr727XumpcnQrvkEs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.21.1/go.mod h1:3OnMjbsyp7rLxmKwOQLyJEirgKZ8i/cXQ1lOsCojBAs=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.1 h1:01QEE+YnMRqCpfOnVd0etORs6G6YTMrAS01fu/gMZro=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.2 h1:oRGHY5rjjN1hMq9bVLdr+7zOQY30e+/uK3cCUVtORoY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.2/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=


### PR DESCRIPTION
## What

Bump rpg-toolkit to consume the two merged Monk combat fixes:

| Module | From | To |
|--------|------|-----|
| `rpg-toolkit/encounter` | v0.21.0 | **v0.21.1** |
| `rpg-toolkit/rulebooks/dnd5e` | v0.61.1 | **v0.61.2** |

## Toolkit PRs consumed

- **#711** `fix(encounter): granted strikes resolve as real attacks, not economy no-ops` — closes toolkit **#708** (granted Martial Arts bonus strikes consumed economy but never resolved an attack).
- **#713** `fix(dnd5e): Martial Arts applies the DEX swap to the attack roll, not just damage` — closes toolkit **#709** (Martial Arts DEX swap applied to damage but not the attack roll).

## Verification

- `go build ./...` — clean
- Full test suite — all packages pass (incl. `-race` via `make ci-check`)
- `make ci-check` — the only failures are the pre-existing local golangci-lint version-skew (~70 findings, identical on pristine `main`) and cosmetic mockgen import-ordering churn; both are tooling-version drift, not bump fallout. No compile/test breakage from the bump.

### Live playtest (wave-2-monk fixture, driven end-to-end via the game UI → envoy → gRPC → toolkit)

Charli = level-1 Monk, DEX 16 (+3), proficiency +2, unarmed (Martial Arts), vs a goblin (AC 15).

**(a) Martial Arts DEX-swap on the attack roll — #713/#709**
Decoded event: `AttackResolved char-charli → goblin-1: HIT (roll 19+5 vs AC 15)` — attack bonus is **+5** (DEX +3 + prof +2). Before the fix it was +2 (DEX not applied to the roll). Confirmed across every attack this session (rolls 3+5, 12+5, 19+5, 1+5, 2+5, 6+5, 7+5).

**(b) Granted Unarmed Strike bonus action resolves as a real attack — #711/#708**
After the main action attack, the server-driven menu surfaces a `BONUS ACTION → Unarmed Strike`. Taking it emits `ActionResolved char-charli dnd5e:actions:unarmed_strike → goblin-1` + `AttackResolved`, and the live economy decrements `Bonus: 1 → 0` (it resolves a real attack instead of a no-op).

Damage + HP drop (UI + Redis), from the main attack hit:
`EntityDamaged goblin-1 amount=4 hp_after=3/7 [weapon:1, dnd5e:abilities:dex:3]` — DEX +3 present in the damage breakdown; goblin HP dropped 7→3 in the UI and Redis `GET enc:v2:dev-encounter` confirmed `goblin-1 HP 3/7`.

Correlation: decoding the gRPC-Web stream, all 6 events of one `TakeAction` share a single correlationId (`corr-dev-encounter-3` for the attack, `corr-dev-encounter-7` for the strike) — one id per action, shared across that action's events.

Dice note: the bonus strike itself rolled natural misses every attempt this session (valid outcome); the damage-application path it uses is identical to the main attack, which is shown landing damage above.

Screenshots: `bump-verify-{1-initial, 2-attack-plus5, 3-bonus-strike-miss, 4-attack-hit-damage-plus-granted-strike}.png`.

Out of scope: SELF/NONE target handling for Hide/Dodge/Dash (fixed separately in #606) — those verbs still error on this build, as expected.

Closes #604
Part of KirkDiggler/rpg-project#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm
