### PR TITLE
feat: consume toolkit cleanup + wire strike ActionRef->weapon resolution (#712)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260601231022-a92fb6b11f91
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.21.1
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.21.4
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.2
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.4
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.21.1 h1:ioMIZppDlVFzEIjP3/vGvr4uULcr727XumpcnQrvkEs=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.21.1/go.mod h1:3OnMjbsyp7rLxmKwOQLyJEirgKZ8i/cXQ1lOsCojBAs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.21.4 h1:GIedtDRwQCvBg63jTwPunncI0bv46r+1naFIyHef6SY=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.21.4/go.mod h1:qi0muF7myW5CGiz0F6x1Z0C4UD1R8YQ+HiRDOcVHlTk=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.2 h1:oRGHY5rjjN1hMq9bVLdr+7zOQY30e+/uK3cCUVtORoY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.2/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.4 h1:p5KIGTdVTO0mHY56moiTqHTI8GKpblADzthgNerrY9s=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.4/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/auth/mock/mock_discord.go
+++ b/internal/auth/mock/mock_discord.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	auth "github.com/KirkDiggler/rpg-api/internal/auth"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockTokenValidator is a mock of TokenValidator interface.

--- a/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver.go
@@ -34,6 +34,13 @@ package encounter
 // Monster weapon: for monster attackers the resolver maps the monster's first
 // melee action ref to the real toolkit weapon definition so combat.ResolveAttack
 // picks the right ability modifier — the same single model used for characters.
+//
+// Character weapon (rpg-toolkit#712): for character attackers the resolver
+// delegates the strike-ActionRef-to-weapon mapping to the toolkit-owned
+// Character.WeaponForActionRef instead of switching on the equipped slot /
+// AttackHand itself. This is what makes unarmed_strike/flurry_strike resolve
+// unarmed even when a weapon is equipped, and off_hand_strike resolve with a
+// working combat.TwoWeaponContext instead of hard-failing.
 
 import (
 	"context"
@@ -269,12 +276,30 @@ func asMonster(c combat.Combatant) *monster.Monster {
 	return m
 }
 
-// resolveWeapon returns the weapon to use for combat.AttackInput.
+// weaponResolution is the resolver's unified per-attack weapon pick: the
+// weapon to swing, the attack hand, and (for character off-hand strikes) the
+// TwoWeaponContext the rulebook's off-hand validation requires.
+type weaponResolution struct {
+	weapon     *weapons.Weapon
+	attackHand combat.AttackHand
+	twoWeapon  combat.TwoWeaponContext
+}
+
+// resolveWeapon returns the weapon (+ hand + optional two-weapon context) to
+// use for combat.AttackInput.
 //
-// For character attackers: reads the equipped main-hand (or off-hand) weapon.
+// For character attackers: delegates to the toolkit-owned
+// Character.WeaponForActionRef (rpg-toolkit#712) — "which weapon does this
+// strike ActionRef swing" is rules knowledge the toolkit owns, not something
+// the resolver switches on. This replaces the old equipped-slot/AttackHand
+// lookup: unarmed_strike/flurry_strike now always resolve unarmed even when a
+// weapon is equipped, and off_hand_strike installs a working TwoWeaponContext
+// instead of hard-failing.
+//
 // For monster attackers: maps the monster's first melee action ref to the real
 // toolkit weapon definition so combat.ResolveAttack picks the correct ability
-// modifier — the same single model used for characters.
+// modifier — the same single model used for characters. Monsters have no
+// ActionRef-driven hand selection, so AttackHand comes from the wire label.
 //
 // Fallback: if the character has no weapon equipped, a minimal unarmed stub is
 // returned so the attack can still resolve.
@@ -282,30 +307,42 @@ func (r *Dnd5eCombatResolver) resolveWeapon(
 	attackerChar *character.Character,
 	attackerMon *monster.Monster,
 	input tkenc.AttackInput,
-) (*weapons.Weapon, error) {
+) (*weaponResolution, error) {
 	if attackerChar != nil {
-		return r.characterWeapon(attackerChar, input.AttackHand)
+		return r.characterWeapon(attackerChar, input)
 	}
 	if attackerMon != nil {
-		return r.monsterWeapon(attackerMon, input.AttackerDamageType)
+		return &weaponResolution{
+			weapon:     r.monsterWeapon(attackerMon, input.AttackerDamageType),
+			attackHand: attackHandFromWire(input.AttackHand),
+		}, nil
 	}
-	return unarmedStubWeapon(), nil
+	return &weaponResolution{weapon: unarmedStubWeapon(), attackHand: attackHandFromWire(input.AttackHand)}, nil
 }
 
-// characterWeapon retrieves the equipped weapon for a character attacker.
-// Falls back to a stub "unarmed" weapon if no weapon is equipped.
-func (r *Dnd5eCombatResolver) characterWeapon(char *character.Character, attackHand string) (*weapons.Weapon, error) {
-	slot := character.SlotMainHand
-	if attackHand == attackHandOffLabel {
-		slot = character.SlotOffHand
+// characterWeapon delegates the strike-ActionRef-to-weapon mapping to the
+// toolkit (rpg-toolkit#712, Character.WeaponForActionRef) instead of picking
+// the weapon by equipped slot / AttackHand itself.
+func (r *Dnd5eCombatResolver) characterWeapon(char *character.Character, input tkenc.AttackInput) (*weaponResolution, error) {
+	sel, err := char.WeaponForActionRef(&input.ActionRef)
+	if err != nil {
+		return nil, fmt.Errorf("weapon for action ref: %w", err)
 	}
-	equipped := char.GetEquippedSlot(slot)
-	if equipped != nil {
-		if w := equipped.AsWeapon(); w != nil {
-			return w, nil
-		}
+	return &weaponResolution{
+		weapon:     sel.Weapon,
+		attackHand: sel.AttackHand,
+		twoWeapon:  sel.TwoWeapon,
+	}, nil
+}
+
+// attackHandFromWire maps the wire-side AttackHand label ("off" vs
+// main/empty) to the toolkit's typed combat.AttackHand. Used for monster and
+// no-attacker paths, which have no ActionRef-driven weapon/hand selection.
+func attackHandFromWire(wire string) combat.AttackHand {
+	if wire == attackHandOffLabel {
+		return combat.AttackHandOff
 	}
-	return unarmedStubWeapon(), nil
+	return combat.AttackHandMain
 }
 
 // monsterWeapon resolves the real weapon for a held monster attacker by reading
@@ -315,7 +352,8 @@ func (r *Dnd5eCombatResolver) characterWeapon(char *character.Character, attackH
 //
 // When no known-ref action is found, falls back to the unarmed stub so the
 // attack resolves with the monster's ability modifier via the normal path.
-func (r *Dnd5eCombatResolver) monsterWeapon(mon *monster.Monster, damageTypeStr string) (*weapons.Weapon, error) {
+// Always returns a valid weapon (never nil).
+func (r *Dnd5eCombatResolver) monsterWeapon(mon *monster.Monster, damageTypeStr string) *weapons.Weapon {
 	dmgType := damage.Type(damageTypeStr)
 	if dmgType == "" {
 		dmgType = damage.Bludgeoning
@@ -333,10 +371,10 @@ func (r *Dnd5eCombatResolver) monsterWeapon(mon *monster.Monster, damageTypeStr 
 		if w.DamageType == "" {
 			w.DamageType = dmgType
 		}
-		return &w, nil
+		return &w
 	}
 
-	return unarmedStubWeapon(), nil
+	return unarmedStubWeapon()
 }
 
 // monsterActionRefToWeaponID maps a monster action ref ID to its toolkit
@@ -444,20 +482,21 @@ func (r *Dnd5eCombatResolver) prepareHeldAttack(input tkenc.AttackInput) (*heldA
 
 	charReg := r.buildEncounterCharacterRegistryFromResolved(attackerChar, targetChar)
 
-	weapon, err := r.resolveWeapon(attackerChar, asMonster(input.Attacker), input)
+	weaponSel, err := r.resolveWeapon(attackerChar, asMonster(input.Attacker), input)
 	if err != nil {
 		return nil, false, fmt.Errorf("resolve weapon: %w", err)
-	}
-
-	attackHand := combat.AttackHandMain
-	if input.AttackHand == attackHandOffLabel {
-		attackHand = combat.AttackHandOff
 	}
 
 	ctx := context.Background()
 	resolveCtx := combat.WithCombatantLookup(ctx, reg)
 	gameCtx := gamectx.NewGameContext(gamectx.GameContextConfig{CharacterRegistry: charReg})
 	resolveCtx = gamectx.WithGameContext(resolveCtx, gameCtx)
+	if weaponSel.twoWeapon != nil {
+		// off_hand_strike: install the toolkit-built TwoWeaponContext so the
+		// rulebook's off-hand validation (light-weapon check + bonus-action
+		// gate) doesn't hard-fail (rpg-toolkit#712).
+		resolveCtx = combat.WithTwoWeaponContext(resolveCtx, weaponSel.twoWeapon)
+	}
 	if r.encounterData != nil {
 		resolveCtx = gamectx.WithRoom(resolveCtx, newEncounterHexRoom(r.encounterData))
 		resolveCtx = gamectx.WithReactionReadiness(resolveCtx, buildReactionReadinessMap(r.encounterData))
@@ -466,9 +505,9 @@ func (r *Dnd5eCombatResolver) prepareHeldAttack(input tkenc.AttackInput) (*heldA
 	return &heldAttackPrep{
 		attackerID: attackerID,
 		targetID:   targetID,
-		weapon:     weapon,
+		weapon:     weaponSel.weapon,
 		resolveCtx: resolveCtx,
 		bus:        bus,
-		attackHand: attackHand,
+		attackHand: weaponSel.attackHand,
 	}, true, nil
 }

--- a/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver_weapon_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver_weapon_test.go
@@ -1,0 +1,226 @@
+package encounter
+
+// White-box tests for the strike-ActionRef -> weapon resolution wired in
+// rpg-toolkit#712. These live in package encounter (not encounter_test) so
+// they can call the unexported resolveWeapon directly and assert on the
+// concrete weaponResolution — the crispest proof that the resolver now honors
+// AttackInput.ActionRef instead of switching on the equipped slot / AttackHand.
+//
+// The behavioral contract (owned by the toolkit's
+// Character.WeaponForActionRef, exercised here through the resolver call-site):
+//   - unarmed_strike by a weapon-holding character resolves the canonical
+//     unarmed weapon, NOT the equipped weapon.
+//   - off_hand_strike resolves the equipped off-hand weapon, AttackHandOff,
+//     and populates a TwoWeaponContext (so the rulebook's off-hand validation
+//     does not hard-fail).
+//   - a normal strike is unchanged: the equipped main-hand weapon, main hand,
+//     no TwoWeaponContext.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+type ResolveWeaponTestSuite struct {
+	suite.Suite
+	ctx      context.Context
+	resolver *Dnd5eCombatResolver
+}
+
+func TestResolveWeaponTestSuite(t *testing.T) {
+	suite.Run(t, new(ResolveWeaponTestSuite))
+}
+
+func (s *ResolveWeaponTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.resolver = NewDnd5eCombatResolverForData(Dnd5eCombatResolverConfig{}, nil)
+}
+
+// weaponHoldingMonk hydrates a Monk with a shortsword equipped in the main
+// hand — the exact case #712 broke: a weapon-holding Monk's unarmed_strike
+// swung the equipped shortsword instead of resolving unarmed.
+func (s *ResolveWeaponTestSuite) weaponHoldingMonk(id string) *character.Character {
+	data := &character.Data{
+		ID:               id,
+		Name:             "Test Monk",
+		Level:            1,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Monk,
+		HitPoints:        10,
+		MaxHitPoints:     10,
+		ArmorClass:       13,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12, abilities.DEX: 16, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 14, abilities.CHA: 8,
+		},
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeWeapon, ID: weapons.Shortsword, Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotMainHand: weapons.Shortsword,
+		},
+	}
+	char, err := character.LoadFromData(s.ctx, data, events.NewEventBus())
+	s.Require().NoError(err)
+	// Guard: the shortsword really is equipped, so a "resolves unarmed" assertion
+	// is meaningful (it must ignore a present weapon, not an empty slot).
+	s.Require().NotNil(char.GetEquippedSlot(character.SlotMainHand))
+	s.Require().Equal(weapons.Shortsword, char.GetEquippedSlot(character.SlotMainHand).AsWeapon().ID)
+	return char
+}
+
+// dualWielder hydrates a Fighter with a shortsword main-hand + dagger off-hand
+// (both light) so off_hand_strike has a real off-hand weapon to resolve.
+func (s *ResolveWeaponTestSuite) dualWielder(id string) *character.Character {
+	data := &character.Data{
+		ID:               id,
+		Name:             "Test Dual Wielder",
+		Level:            1,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		HitPoints:        12,
+		MaxHitPoints:     12,
+		ArmorClass:       15,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 16, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 8,
+		},
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeWeapon, ID: weapons.Shortsword, Quantity: 1},
+			{Type: shared.EquipmentTypeWeapon, ID: weapons.Dagger, Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotMainHand: weapons.Shortsword,
+			character.SlotOffHand:  weapons.Dagger,
+		},
+	}
+	char, err := character.LoadFromData(s.ctx, data, events.NewEventBus())
+	s.Require().NoError(err)
+	return char
+}
+
+// TestUnarmedStrike_WeaponHoldingMonk_ResolvesUnarmed proves the resolver now
+// honors the ActionRef: a Monk holding a shortsword who submits unarmed_strike
+// resolves the canonical unarmed weapon, not the equipped shortsword. Before
+// #712 the resolver picked by equipped slot and swung the shortsword.
+func (s *ResolveWeaponTestSuite) TestUnarmedStrike_WeaponHoldingMonk_ResolvesUnarmed() {
+	monk := s.weaponHoldingMonk("char-monk")
+
+	res, err := s.resolver.resolveWeapon(monk, nil, tkenc.AttackInput{
+		AttackerID: "char-monk",
+		ActionRef:  *refs.Actions.UnarmedStrike(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().NotNil(res.weapon)
+	s.Equal(weapons.UnarmedStrike, res.weapon.ID,
+		"unarmed_strike must resolve the canonical unarmed weapon, not the equipped shortsword")
+	s.NotEqual(weapons.Shortsword, res.weapon.ID)
+	s.Equal(combat.AttackHandMain, res.attackHand)
+	s.Nil(res.twoWeapon, "a main-hand unarmed strike carries no two-weapon context")
+}
+
+// TestFlurryStrike_WeaponHoldingMonk_ResolvesUnarmed: flurry_strike is also a
+// Monk unarmed strike — same ignore-the-equipped-weapon contract.
+func (s *ResolveWeaponTestSuite) TestFlurryStrike_WeaponHoldingMonk_ResolvesUnarmed() {
+	monk := s.weaponHoldingMonk("char-monk")
+
+	res, err := s.resolver.resolveWeapon(monk, nil, tkenc.AttackInput{
+		AttackerID: "char-monk",
+		ActionRef:  *refs.Actions.FlurryStrike(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(weapons.UnarmedStrike, res.weapon.ID,
+		"flurry_strike must resolve unarmed, not the equipped shortsword")
+	s.Equal(combat.AttackHandMain, res.attackHand)
+	s.Nil(res.twoWeapon)
+}
+
+// TestOffHandStrike_SelectsOffHandWeaponWithTwoWeaponContext proves
+// off_hand_strike selects the off-hand weapon (dagger), sets AttackHandOff,
+// and populates a TwoWeaponContext so the rulebook's off-hand validation does
+// not hard-fail — the exact failure #712 called out for AttackHand="off".
+func (s *ResolveWeaponTestSuite) TestOffHandStrike_SelectsOffHandWeaponWithTwoWeaponContext() {
+	tw := s.dualWielder("char-twf")
+
+	res, err := s.resolver.resolveWeapon(tw, nil, tkenc.AttackInput{
+		AttackerID: "char-twf",
+		ActionRef:  *refs.Actions.OffHandStrike(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().NotNil(res.weapon)
+	s.Equal(weapons.Dagger, res.weapon.ID,
+		"off_hand_strike must resolve the off-hand dagger, not the main-hand shortsword")
+	s.Equal(combat.AttackHandOff, res.attackHand)
+	s.Require().NotNil(res.twoWeapon,
+		"off_hand_strike must populate a TwoWeaponContext or the rulebook off-hand validation hard-fails")
+
+	// The context reports the character's REAL equipped weapons.
+	mainHand := res.twoWeapon.GetMainHandWeapon("char-twf")
+	offHand := res.twoWeapon.GetOffHandWeapon("char-twf")
+	s.Require().NotNil(mainHand)
+	s.Require().NotNil(offHand)
+	s.Equal(weapons.Shortsword, mainHand.WeaponID)
+	s.Equal(weapons.Dagger, offHand.WeaponID)
+}
+
+// TestNormalStrike_ResolvesEquippedMainHand: the normal attack path is
+// unchanged — a strike resolves the equipped main-hand weapon, main hand, no
+// two-weapon context.
+func (s *ResolveWeaponTestSuite) TestNormalStrike_ResolvesEquippedMainHand() {
+	tw := s.dualWielder("char-twf")
+
+	res, err := s.resolver.resolveWeapon(tw, nil, tkenc.AttackInput{
+		AttackerID: "char-twf",
+		ActionRef:  *refs.Actions.Strike(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(weapons.Shortsword, res.weapon.ID,
+		"a normal strike resolves the equipped main-hand weapon")
+	s.Equal(combat.AttackHandMain, res.attackHand)
+	s.Nil(res.twoWeapon)
+}
+
+// TestOffHandStrike_ThroughResolveAttack_DoesNotHardFail drives off_hand_strike
+// through the full public ResolveAttack (prepareHeldAttack installs the
+// TwoWeaponContext into the resolve ctx via combat.WithTwoWeaponContext). It
+// proves end-to-end that the wiring prevents the "two-weapon context not
+// available" hard-fail #712 flagged, and still yields a valid outcome.
+func (s *ResolveWeaponTestSuite) TestOffHandStrike_ThroughResolveAttack_DoesNotHardFail() {
+	attacker := s.dualWielder("char-twf")
+	defender := s.weaponHoldingMonk("char-monk")
+
+	outcome, err := s.resolver.ResolveAttack(tkenc.AttackInput{
+		AttackerID: "char-twf",
+		TargetID:   "char-monk",
+		ActionRef:  *refs.Actions.OffHandStrike(),
+		AttackHand: "off",
+		TargetAC:   13,
+		Attacker:   attacker,
+		Defender:   defender,
+	})
+
+	s.Require().NoError(err, "off_hand_strike must not hard-fail once the TwoWeaponContext is wired into the resolve ctx")
+	s.Require().NotNil(outcome)
+	s.GreaterOrEqual(outcome.AttackRoll, 1)
+	s.LessOrEqual(outcome.AttackRoll, 20)
+}

--- a/internal/handlers/dnd5e/v2/encounter/translate_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate_test.go
@@ -31,11 +31,12 @@ func (s *TranslateSuite) TestHexToPosition_CubeMapping() {
 }
 
 func (s *TranslateSuite) TestTranslateEvent_MoveEvent_FullPath() {
-	// NewMoveEvent signature (events/move.go:34): (encID, seq, mover, path, perPlayer)
+	// NewMoveEvent signature (events/move.go:43): (encID, seq, mover, from, path, perPlayer)
 	evt := events.NewMoveEvent(
 		"enc-1",
 		uint64(1),
 		"char-A",
+		core.Hex{Q: 0, R: 0, S: 0},
 		[]core.Hex{{Q: 0, R: 0, S: 0}, {Q: 1, R: -1, S: 0}, {Q: 2, R: -2, S: 0}},
 		map[core.PlayerID]events.MovePlayerSlice{
 			"player-B": {SeenSegments: []core.Hex{{Q: 0, R: 0, S: 0}, {Q: 1, R: -1, S: 0}, {Q: 2, R: -2, S: 0}}},
@@ -56,6 +57,7 @@ func (s *TranslateSuite) TestTranslateEvent_MoveEvent_FullPath() {
 func (s *TranslateSuite) TestTranslateEvent_MoveEvent_EmptySliceReturnsErrViewerSawNothing() {
 	evt := events.NewMoveEvent(
 		"enc-1", uint64(1), "char-A",
+		core.Hex{Q: 0, R: 0, S: 0},
 		[]core.Hex{{Q: 0, R: 0, S: 0}},
 		map[core.PlayerID]events.MovePlayerSlice{
 			"player-B": {SeenSegments: nil},
@@ -67,7 +69,7 @@ func (s *TranslateSuite) TestTranslateEvent_MoveEvent_EmptySliceReturnsErrViewer
 }
 
 func (s *TranslateSuite) TestTranslateEvent_MoveEvent_ViewerNotInPerPlayerReturnsErrViewerSawNothing() {
-	evt := events.NewMoveEvent("enc-1", uint64(1), "char-A", nil, nil)
+	evt := events.NewMoveEvent("enc-1", uint64(1), "char-A", core.Hex{}, nil, nil)
 	_, err := v2encounter.TranslateEvent(evt, "player-X", s.now)
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
@@ -115,6 +117,7 @@ func (s *TranslateSuite) TestTranslateEvent_Sequence_SetCorrectly() {
 		"enc-1",
 		uint64(42),
 		"char-A",
+		core.Hex{Q: 0, R: 0, S: 0},
 		[]core.Hex{{Q: 0, R: 0, S: 0}},
 		map[core.PlayerID]events.MovePlayerSlice{
 			"player-B": {SeenSegments: []core.Hex{{Q: 0, R: 0, S: 0}}},

--- a/internal/orchestrators/character/mock/mock_service.go
+++ b/internal/orchestrators/character/mock/mock_service.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/dice/mock/mock_service.go
+++ b/internal/orchestrators/dice/mock/mock_service.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/encounter/mock/mock_service.go
+++ b/internal/orchestrators/encounter/mock/mock_service.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	encounter "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/processors/event/mock/mock_processor.go
+++ b/internal/processors/event/mock/mock_processor.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	event "github.com/KirkDiggler/rpg-api/internal/processors/event"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockProcessor is a mock of Processor interface.

--- a/internal/publishers/encounter/mock/mock_publisher.go
+++ b/internal/publishers/encounter/mock/mock_publisher.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	encounter "github.com/KirkDiggler/rpg-api/internal/publishers/encounter"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockPublisher is a mock of Publisher interface.

--- a/internal/repositories/character/mock/mock_repository.go
+++ b/internal/repositories/character/mock/mock_repository.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/character_draft/mock/mock_repository.go
+++ b/internal/repositories/character_draft/mock/mock_repository.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dice_session/mock/mock_repository.go
+++ b/internal/repositories/dice_session/mock/mock_repository.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dungeons/mock/mock_repository.go
+++ b/internal/repositories/dungeons/mock/mock_repository.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	dungeons "github.com/KirkDiggler/rpg-api/internal/repositories/dungeons"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/encounterlog/mock/mock_repository.go
+++ b/internal/repositories/encounterlog/mock/mock_repository.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	encounterlog "github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/encounters/mock/mock_repository.go
+++ b/internal/repositories/encounters/mock/mock_repository.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	encounters "github.com/KirkDiggler/rpg-api/internal/repositories/encounters"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/services/sandboxroom/mock/mock_service.go
+++ b/internal/services/sandboxroom/mock/mock_service.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockService is a mock of Service interface.


### PR DESCRIPTION
## Summary

- Bump `rpg-toolkit/encounter` v0.21.1 -> v0.21.4 and `rpg-toolkit/rulebooks/dnd5e` v0.61.2 -> v0.61.4, consuming the merged toolkit cleanup (#711/#713/#717/#718/#719/#720).
- Wire `dnd5e_combat_resolver.go`'s `characterWeapon` to delegate the strike-`ActionRef`-to-weapon mapping to the toolkit-owned `Character.WeaponForActionRef` (#712) instead of switching on the equipped slot / `AttackHand`. `combat.WithTwoWeaponContext(resolveCtx, weaponSel.twoWeapon)` is installed into the resolve ctx when the selection carries a two-weapon context.
- This makes `unarmed_strike` / `flurry_strike` resolve the canonical unarmed weapon even when a weapon is equipped, and `off_hand_strike` resolve with a working `combat.TwoWeaponContext` instead of hard-failing the rulebook's off-hand validation.

## Test added

`internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver_weapon_test.go` — white-box (`package encounter`) suite `ResolveWeaponTestSuite` locking in the ref->weapon contract at the `resolveWeapon`/`characterWeapon` boundary:

- `TestUnarmedStrike_WeaponHoldingMonk_ResolvesUnarmed` / `TestFlurryStrike_WeaponHoldingMonk_ResolvesUnarmed` — a weapon-holding Monk's `unarmed_strike`/`flurry_strike` resolves the canonical unarmed weapon, not the equipped shortsword.
- `TestOffHandStrike_SelectsOffHandWeaponWithTwoWeaponContext` — `off_hand_strike` selects the off-hand dagger, sets `AttackHandOff`, and populates a `TwoWeaponContext` reporting both real equipped weapons.
- `TestNormalStrike_ResolvesEquippedMainHand` — a normal `attack` ref is unchanged: resolves the equipped main-hand weapon, main hand, no two-weapon context.
- `TestOffHandStrike_ThroughResolveAttack_DoesNotHardFail` — drives the full public `ResolveAttack` to prove `off_hand_strike` no longer hard-fails end-to-end once the `TwoWeaponContext` is wired into the resolve ctx.

Sanity-checked locally: temporarily reverted `characterWeapon` to an equipped-slot/`AttackHand` lookup that ignores `ActionRef` (the pre-#712 behavior) and confirmed 4 of 5 new subtests fail with the expected diffs (unarmed/flurry resolve `shortsword` instead of `unarmed-strike`; off-hand resolves `shortsword` with `attackHand="main"` and a nil `TwoWeaponContext`; the through-`ResolveAttack` test hard-fails with `"two-weapon context not available for off-hand attack validation"`). Restored the fix and reran — all green.

`translate_test.go` adapted to the bumped `events.NewMoveEvent(..., from, ...)` signature. Mock file changes are mockgen import-regroup churn from the bump, no behavior change.

Part of KirkDiggler/rpg-project#54. Makes toolkit #712/#714/#715/#718/#719 observable end-to-end.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/dnd5e/v2/encounter/...` (all green, including the new `ResolveWeaponTestSuite`)
- [x] Sanity-checked the new tests fail without the fix (see above)
- [ ] GitHub CI green
- [ ] Copilot review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm