### PR TITLE
fix(devseed): equip armor matching stated ArmorClass (Finn, Alice)

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -126,6 +126,17 @@ const (
 	weaponLongsword     = "longsword"
 	inventoryTypeWeapon = "weapon"
 
+	// armorLeather / armorChainMail match the toolkit's armor.Leather /
+	// armor.ChainMail IDs ("leather" / "chain-mail") — see
+	// rpg-toolkit/rulebooks/dnd5e/armor. Leather is base AC 11 + unlimited
+	// DEX bonus (Alice: 11+3=14). Chain mail is base AC 16 with MaxDexBonus 0
+	// (Finn: 16+0=16). Kept as local string literals (mirrors weaponLongsword
+	// above) rather than importing the armor package, since devseed only
+	// needs the item ID, not the toolkit's AC-calculation types.
+	armorLeather       = "leather"
+	armorChainMail     = "chain-mail"
+	inventoryTypeArmor = "armor"
+
 	damageTypePiercing    = "piercing"
 	damageTypeSlashing    = "slashing"
 	damageTypeFire        = "fire"
@@ -376,7 +387,7 @@ func buildAliceRogueData() *toolkitchar.Data {
 		ClassID:          classes.Rogue,
 		HitPoints:        16,
 		MaxHitPoints:     16,
-		ArmorClass:       14,
+		ArmorClass:       14, // 11 (leather) + DEX(+3)
 		AbilityScores: shared.AbilityScores{
 			abilities.STR: 12, // +1
 			abilities.DEX: 16, // +3 — finesse weapons use DEX
@@ -387,9 +398,11 @@ func buildAliceRogueData() *toolkitchar.Data {
 		},
 		EquipmentSlots: toolkitchar.EquipmentSlots{
 			toolkitchar.SlotMainHand: weaponShortsword,
+			toolkitchar.SlotArmor:    armorLeather,
 		},
 		Inventory: []toolkitchar.InventoryItemData{
 			{Type: inventoryTypeWeapon, ID: weaponShortsword, Quantity: 1},
+			{Type: inventoryTypeArmor, ID: armorLeather, Quantity: 1},
 		},
 		Conditions: []json.RawMessage{sneakJSON},
 		CreatedAt:  now,
@@ -728,7 +741,7 @@ func buildFinnFighterData() *toolkitchar.Data {
 		ClassID:          classes.Fighter,
 		HitPoints:        12,
 		MaxHitPoints:     12,
-		ArmorClass:       16, // chain mail, no shield
+		ArmorClass:       16, // chain mail (16), MaxDexBonus 0 — no shield
 		AbilityScores: shared.AbilityScores{
 			abilities.STR: 16, // +3 — fighter primary, longsword
 			abilities.DEX: 12,
@@ -739,9 +752,11 @@ func buildFinnFighterData() *toolkitchar.Data {
 		},
 		EquipmentSlots: toolkitchar.EquipmentSlots{
 			toolkitchar.SlotMainHand: weaponLongsword,
+			toolkitchar.SlotArmor:    armorChainMail,
 		},
 		Inventory: []toolkitchar.InventoryItemData{
 			{Type: inventoryTypeWeapon, ID: weaponLongsword, Quantity: 1},
+			{Type: inventoryTypeArmor, ID: armorChainMail, Quantity: 1},
 		},
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -863,7 +878,7 @@ func buildAliceRogueL1Data() *toolkitchar.Data {
 		ClassID:          classes.Rogue,
 		HitPoints:        10,
 		MaxHitPoints:     10,
-		ArmorClass:       14,
+		ArmorClass:       14, // 11 (leather) + DEX(+3)
 		AbilityScores: shared.AbilityScores{
 			abilities.STR: 12,
 			abilities.DEX: 16, // +3 — finesse weapons use DEX
@@ -874,9 +889,11 @@ func buildAliceRogueL1Data() *toolkitchar.Data {
 		},
 		EquipmentSlots: toolkitchar.EquipmentSlots{
 			toolkitchar.SlotMainHand: weaponShortsword,
+			toolkitchar.SlotArmor:    armorLeather,
 		},
 		Inventory: []toolkitchar.InventoryItemData{
 			{Type: inventoryTypeWeapon, ID: weaponShortsword, Quantity: 1},
+			{Type: inventoryTypeArmor, ID: armorLeather, Quantity: 1},
 		},
 		Conditions: []json.RawMessage{sneakJSON},
 		CreatedAt:  now,

--- a/cmd/devseed/main_test.go
+++ b/cmd/devseed/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+// main_test.go — rpg-api#619: devseed fixtures declared an ArmorClass but
+// several never equipped SlotArmor, so the toolkit's Character.EffectiveAC
+// computed the unarmored branch (10 + DEX) instead of the intended armored
+// value — every attack against these fixtures during the 2026-07-04
+// playtest resolved against a lower AC than the fixture claimed.
+//
+// This proves the fix at the level that actually matters: not "is
+// EquipmentSlots[SlotArmor] set" (a field-presence check that could still
+// point at the wrong item or a mismatched AC), but "does the toolkit's own
+// EffectiveAC(), computed from the equipped armor, equal the fixture's
+// stated ArmorClass" — the exact quantity a live combat resolves attacks
+// against.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+func TestDevseedFixtures_EffectiveACMatchesStatedArmorClass(t *testing.T) {
+	// Scoped to the fixtures rpg-api#619 actually fixed (equipped armor items
+	// matching the stated ArmorClass). buildBobBarbarianData and
+	// buildCharliMonkData rely on a persisted UnarmoredDefenseCondition
+	// instead of equipped armor for their stated AC — a from-LoadFromData
+	// direct EffectiveAC() call shows THEM under-computing too (bob: 11 want
+	// 14, charli: 13 want 15), but that's a different mechanism (condition
+	// not contributing to the AC chain vs. armor never equipped) and is NOT
+	// what #619 scoped or asked for. Flagging to the wave owner as a
+	// separate finding rather than silently expanding this PR or silently
+	// dropping it.
+	tests := []struct {
+		name  string
+		build func() *character.Data
+	}{
+		{"finn (fighter, chain mail)", buildFinnFighterData},
+		{"alice L2 (rogue, leather)", buildAliceRogueData},
+		{"alice L1 (rogue, leather)", buildAliceRogueL1Data},
+		{"wendy (wizard, unarmored)", buildWendyWizardData},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := tt.build()
+			char, err := character.LoadFromData(context.Background(), data, events.NewEventBus())
+			if err != nil {
+				t.Fatalf("LoadFromData: %v", err)
+			}
+
+			got := char.EffectiveAC(context.Background())
+			if got.Total != data.ArmorClass {
+				t.Fatalf("EffectiveAC() = %d, want %d (the fixture's stated ArmorClass) — components: %+v",
+					got.Total, data.ArmorClass, got.Components)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #619. Part of KirkDiggler/rpg-project#75.

From the 2026-07-04 playtest root-cause trace: `buildFinnFighterData` (added in #615) set `ArmorClass: 16 // chain mail` but only equipped `SlotMainHand`. `Character.EffectiveAC()` — the exact function `combat.GetEffectiveAC` calls to compute `TargetAC` for a real attack (verified: `combatant.go:98` calls `calc.EffectiveAC(ctx)` directly, no other layer) — finds no armor at `SlotArmor` and falls through to the unarmored branch (`10 + DEX = 11`). Every attack against Finn in tonight's playtest resolved against AC 11, not 16. `buildAliceRogueData` / `buildAliceRogueL1Data` (`ArmorClass: 14`, leather) have the identical shape.

**Fix**: equip the armor item matching each fixture's stated AC, in **both** `EquipmentSlots[SlotArmor]` and `Inventory` — mirroring how weapons are already dual-represented in these same fixtures (a toolkit-side smell tracked separately as rpg-toolkit#736, not addressed here):
- **finn**: `armor.ChainMail` (`"chain-mail"`), base AC 16 + `MaxDexBonus: 0` → 16.
- **alice** (both L1 and L2 variants): `armor.Leather` (`"leather"`), base AC 11 + unlimited DEX bonus → 11 + DEX(+3) = 14.

Confirmed both AC values against the toolkit's `rulebooks/dnd5e/armor` registry directly (`ChainMail{AC:16, MaxDexBonus:intPtr(0)}`, `Leather{AC:11, MaxDexBonus:nil}`) before writing the fix, so the stated `ArmorClass` fields aren't just self-consistent with the new equipment — they match 5e SRD math.

## Test plan

- [x] **New test** `TestDevseedFixtures_EffectiveACMatchesStatedArmorClass` (`cmd/devseed/main_test.go`): loads each fixture via the real `character.LoadFromData` and asserts `EffectiveAC().Total` equals the fixture's stated `ArmorClass` — the same computation a live attack uses, not just a field-presence check. Covers finn, alice L1, alice L2, wendy (genuinely unarmored, regression guard).
- [x] Smoke-tested end-to-end against local Redis: `go run ./cmd/devseed --fixture=wave-2-beat2` and the default fixture both seed characters whose `equipment_slots` now show the armor item (`{"armor":"chain-mail","main_hand":"longsword"}` for finn; `{"armor":"leather","main_hand":"shortsword"}` for alice).
- [x] `go build ./...` clean.
- [x] `go test ./...` — 28 packages pass (one more than before this PR: `cmd/devseed` now has a test file).
- [x] `golangci-lint run --new-from-rev=origin/main` → 0 new issues.

## Load-bearing changes

- `cmd/devseed/main.go` — `armorLeather` / `armorChainMail` / `inventoryTypeArmor` constants; `EquipmentSlots[SlotArmor]` + `Inventory` entries added to `buildFinnFighterData`, `buildAliceRogueData`, `buildAliceRogueL1Data`. **Fixture ACs are now honest — devseed characters must equip what their `ArmorClass` claims, or a live attack resolves against a lower AC than the fixture states.**
- `cmd/devseed/main_test.go` — new verification test (see Test plan).

## Scope note — additional finding, not fixed here

The same verification methodology run against `buildBobBarbarianData` and `buildCharliMonkData` (both rely on Unarmored Defense, not equipped armor) shows **they also under-compute**: bob's `EffectiveAC()` = 11, wants 14; charli's = 13, wants 15. This is a **different mechanism** — their persisted `UnarmoredDefenseCondition` isn't contributing to `EffectiveAC()`'s chain at all (both computed exactly `10 + DEX`, with zero CON/WIS bonus component) — not a missing equipped-armor item, and not what #619 scoped or asked for. I did not investigate further or fix it (would require tracing whether `LoadFromData`'s condition re-application actually subscribes `UnarmoredDefenseCondition` onto an AC-modifying chain, which is toolkit-side territory). Flagging explicitly for the wave owner to triage — not included in this PR's test's fixture list, and not silently dropped either.

## Four-question gate

- **Goal**: the death-gate re-playtest needs honest AC — attacks against Finn/Alice should resolve against the AC the fixture claims, not a silently-lower unarmored value. Met and verified via the exact function the combat resolver calls.
- **Pattern**: mirrors the existing weapon dual-representation (`EquipmentSlots` + `Inventory`) already used by every other fixture — no new pattern introduced.
- **Test**: proves the *computed* AC, not just that a field got set — caught that a naive "did I add EquipmentSlots[SlotArmor]" check wouldn't have (Bob/Charli have a superficially-different-looking but symptomatically-identical gap that this same test methodology also caught, even though it's out of scope to fix here).
- **Pushback**: kept this PR to the two fixtures #619 actually names; the Bob/Charli finding is reported, not silently rolled in or silently dropped.