### PR TITLE
chore(deps): bump toolkit to encounter v0.24.2 + rulebooks/dnd5e v0.64.1 (death-gate fixes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260704152519-f224488c38b4
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.0 h1:uU7iKA3Zm1WWlaDgSFWb71Y9FULX8Y9oWYGlftOym1I=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.0/go.mod h1:jf1tRpx8N6Z0kZXBLjkAqNud68hwFxY4K/MXCQsgbBU=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.24.2 h1:g9PUtiS9rz5+nZoL6cAiaWrR8aVKpazYpaBDN8qxYmM=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.24.2/go.mod h1:r2m0f6m3g3J02FBMI2Gn9fsNKDf6ErhrmuhQNByVvtg=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.0 h1:d5jgX8uAkWm8lWGkm8ciHwShMDaJhFB3yibC0I9eXz0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1 h1:Cq7BjIYRK9zh7EK6BWejZd6w3c8uNx8pVVjWB0Pw0yc=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=


### PR DESCRIPTION
## Summary
- Bumps `github.com/KirkDiggler/rpg-toolkit/encounter` v0.24.0 → v0.24.2 and `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e` v0.64.0 → v0.64.1 (real tags, `go mod tidy` clean, no replace directives, no pseudo-versions).
- Related: KirkDiggler/rpg-toolkit#738, KirkDiggler/rpg-toolkit#739, wave KirkDiggler/rpg-project#75.
- `go build ./...` and `go test ./...` are clean with no fallout — the encounter API surface added in toolkit#739 required no changes on the rpg-api side.

## Load-bearing
rpg-api's graph now contains Unconscious-at-0/death-saves/targeting-skip and the StatusRemoved bridge — the Beat 2 death gate is live on main once merged.

## Note on local tooling
`make pre-commit` (lint step) and `make ci-check` (import/lint checks) currently fail on a **completely clean `origin/main` clone with no changes at all** — verified against a fresh throwaway clone. This is pre-existing debt (73 golangci-lint findings repo-wide, plus a `mock/` subdirectory exclusion pattern that doesn't catch nested `**/mock/` dirs for goimports) unrelated to this bump. The actual CI gates (`Test and Coverage`, `Build and Push Docker Image` — neither workflow runs lint) are unaffected and pass.

## Test plan
- [x] `go get` to real tags, `go mod tidy` clean (no replace directives, no pseudo-versions)
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages green)
- [x] Verified pre-existing `make ci-check`/lint failures are unrelated (reproduced identically on pristine `origin/main`)
- [ ] Copilot review addressed
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)