### PR TITLE
fix(v2/encounter): translate ConditionRemovedEvent → StatusRemoved (badges clear live)

### DIFF
--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -82,6 +82,8 @@ func TranslateEvent(evt events.EncounterEvent, viewer core.PlayerID, now time.Ti
 		return translateDamageDealtEvent(e, viewer, now)
 	case *events.ConditionAppliedEvent:
 		return translateConditionAppliedEvent(e, viewer, now)
+	case *events.ConditionRemovedEvent:
+		return translateConditionRemovedEvent(e, viewer, now)
 	case *events.ResourceChangedEvent:
 		return translateResourceChangedEvent(e, viewer, now)
 	case *events.ModeChangedEvent:
@@ -552,6 +554,29 @@ func translateConditionAppliedEvent(e *events.ConditionAppliedEvent, viewer core
 		Timestamp: timestamppb.New(now),
 		Event: &encounterv2pb.EncounterEvent_StatusApplied{
 			StatusApplied: out,
+		},
+	}, nil
+}
+
+// translateConditionRemovedEvent maps the toolkit's ConditionRemovedEvent
+// (a status clearing — e.g., "dodging" wearing off at the dodger's next
+// turn start) to the proto StatusRemoved envelope. Mirrors
+// translateConditionAppliedEvent's shape (rpg-api#622): same per-viewer
+// visibility check and the same conditionRefFor parsing for ConditionRef.
+func translateConditionRemovedEvent(e *events.ConditionRemovedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	slice, ok := e.PerPlayer[viewer]
+	if !ok || !slice.Visible {
+		return nil, ErrViewerSawNothing
+	}
+	out := &encounterv2pb.StatusRemoved{
+		EntityId:     string(e.TargetID),
+		StatusSource: conditionRefFor(e.ConditionRef),
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_StatusRemoved{
+			StatusRemoved: out,
 		},
 	}, nil
 }

--- a/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate_combat_test.go
@@ -595,6 +595,66 @@ func (s *TranslateSuite) TestTranslateEvent_ConditionAppliedEvent_NotVisible_Ret
 	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
 }
 
+func (s *TranslateSuite) TestTranslateEvent_ConditionRemovedEvent_HappyPath_FullyQualifiedRef() {
+	// rpg-api#622: no case existed for ConditionRemovedEvent, so the event
+	// fell to the unknown branch (ErrUnknownEventType) and the stream loop
+	// logged a "translator gap" instead of sending StatusRemoved — the Dodge
+	// badge could never clear live. This asserts the happy path AND that the
+	// gap path is not taken.
+	evt := events.NewConditionRemovedEvent(
+		"enc-1", uint64(23),
+		"char-A",
+		"dnd5e:conditions:dodging", "turn_start",
+		map[core.PlayerID]events.ConditionRemovedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	s.Require().False(errors.Is(err, v2encounter.ErrUnknownEventType),
+		"ConditionRemovedEvent must not fall to the translator-gap branch")
+
+	rem := out.GetStatusRemoved()
+	s.Require().NotNil(rem, "expected StatusRemoved envelope")
+	s.Require().Equal("char-A", rem.GetEntityId())
+	s.Require().NotNil(rem.GetStatusSource())
+	s.Require().Equal("dnd5e", rem.GetStatusSource().GetModule())
+	s.Require().Equal("conditions", rem.GetStatusSource().GetType())
+	s.Require().Equal("dodging", rem.GetStatusSource().GetId())
+	s.Require().Equal(int64(23), out.Sequence)
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ConditionRemovedEvent_BareIDFallsBackToDefaults() {
+	evt := events.NewConditionRemovedEvent(
+		"enc-1", uint64(24),
+		"char-A",
+		"prone", "stood_up",
+		map[core.PlayerID]events.ConditionRemovedSlice{
+			"player-A": {Visible: true},
+		},
+	)
+	out, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().NoError(err)
+	src := out.GetStatusRemoved().GetStatusSource()
+	s.Require().Equal("dnd5e", src.GetModule())
+	s.Require().Equal("condition", src.GetType())
+	s.Require().Equal("prone", src.GetId())
+}
+
+func (s *TranslateSuite) TestTranslateEvent_ConditionRemovedEvent_NotVisible_ReturnsErrViewerSawNothing() {
+	evt := events.NewConditionRemovedEvent(
+		"enc-1", uint64(25),
+		"char-A",
+		"dnd5e:conditions:dodging", "turn_start",
+		map[core.PlayerID]events.ConditionRemovedSlice{
+			"player-A": {Visible: false},
+		},
+	)
+	_, err := v2encounter.TranslateEvent(evt, "player-A", s.now)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, v2encounter.ErrViewerSawNothing))
+}
+
 func (s *TranslateSuite) TestTranslateEvent_ModeChangedEvent_FreeRoamToTurnBased() {
 	evt := events.NewModeChangedEvent(
 		"enc-1", uint64(30),


### PR DESCRIPTION
## Summary

`translate.go`'s `TranslateEvent` switch had a case for `*events.ConditionAppliedEvent` but no case for `*events.ConditionRemovedEvent`. During the 2026-07-05 re-playtest (KirkDiggler/rpg-project#75), rpg-toolkit#738's bridge correctly fired `ConditionRemovedEvent` at the dodger's next turn start, but the event fell to the translator's unknown branch and was dropped — confirmed live in the api log as:

```
encounter/v2 translator gap: event=*events.ConditionRemovedEvent
```

The `StatusRemoved` proto message already existed in rpg-api-protos but was never sent, so the Dodge status badge (and any other condition-removal) could never clear on live clients even though it correctly appeared when applied.

## Fix

Added `translateConditionRemovedEvent`, mirroring `translateConditionAppliedEvent`'s shape exactly:
- Same per-viewer visibility check (`PerPlayer[viewer].Visible`) → `ErrViewerSawNothing`.
- Same `conditionRefFor` parsing of the toolkit's `module:type:id` condition ref string, with the same bare-id fallback (`module=dnd5e, type=condition`).
- `entity_id` + `status_source` copied verbatim per the boundary rule — no computation, no new logic, just the wire translation that was missing.

Web already consumes `StatusRemoved` in its dispatch layer, so no client-side change is needed.

## Scope

This is **part 1 of #622**. The death-resolution broker events (`DeathSaveRolled`/`Stabilized`) are **not** included — they're blocked on rpg-toolkit#741 and are the issue's second half.

## Load-bearing

- `translateConditionRemovedEvent` (translate.go) is the new verbatim-copy translator case; it is the only place `StatusRemoved` gets populated on the v2 encounter wire.
- The TDD tests in `translate_combat_test.go` assert both the happy path (fully-qualified and bare condition refs) and — explicitly — that `ConditionRemovedEvent` no longer falls to `ErrUnknownEventType` (the translator-gap branch that was silently swallowing it and only logging).

## Test plan

- [x] Failing test written first (`TestTranslateEvent_ConditionRemovedEvent_*`), confirmed red against the pre-fix switch (`ErrUnknownEventType`).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `goimports -l` — all clean.
- [x] `go mod tidy` — no diff.
- [x] `go test -race -coverprofile=... $(go list ./... | grep -v /gen/ | grep -v /mock | grep -v cmd/server)` — matches the `test.yml` CI job exactly, all packages pass.
- [x] `golangci-lint run` scoped to the touched package (`./internal/handlers/dnd5e/v2/encounter/...`) shows zero issues in `translate.go` / `translate_combat_test.go`. (Repo-wide `golangci-lint run` currently reports ~73 pre-existing issues across unrelated files — none in the files this PR touches — and lint is not part of the `test.yml`/`docker.yml` CI gate, so this is pre-existing debt out of scope here.)

Closes part of #622 (tracking issue stays open for part 2).