### PR TITLE
fix(character): advertise Rogue Expertise, fix category round-trip, restore ValidateChoices

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -540,6 +540,10 @@ func convertChoiceCategoryToProto(category shared.ChoiceCategory) dnd5ev1alpha1.
 		return dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT
 	case shared.ChoiceFightingStyle:
 		return dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_FIGHTING_STYLE
+	case shared.ChoiceToolProficiency:
+		return dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_TOOLS
+	case shared.ChoiceExpertise:
+		return dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EXPERTISE
 	case shared.ChoiceRace:
 		return dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_RACE
 	case shared.ChoiceClass:
@@ -2272,9 +2276,16 @@ func loadAllClassChoices(classID classes.Class) []*dnd5ev1alpha1.Choice {
 		}
 	}
 
+	// Add expertise choice if present (e.g., Rogue, Bard)
+	if requirements.Expertise != nil && requirements.Expertise.Count > 0 {
+		expertiseChoice := createExpertiseChoice(requirements.Expertise)
+		if expertiseChoice != nil {
+			result = append(result, expertiseChoice)
+		}
+	}
+
 	// TODO: Add other choice types as needed:
 	// - Language choices (requirements.Languages)
-	// - Expertise (requirements.Expertise)
 
 	return result
 }
@@ -2646,6 +2657,42 @@ func createToolChoice(req *choices.ToolRequirement) *dnd5ev1alpha1.Choice {
 		Options: &dnd5ev1alpha1.Choice_ToolOptions{
 			ToolOptions: &dnd5ev1alpha1.ToolOptions{
 				Available: toolOptions,
+			},
+		},
+	}
+}
+
+// createExpertiseChoice converts an expertise requirement to a proto Choice.
+//
+// ExpertiseRequirement has no fixed option list: expertise can apply to any
+// skill the character ends up proficient in (class, race, or background), and
+// that set isn't known until the draft's other choices are recorded. So this
+// advertises the full skill universe here; the toolkit enforces the real
+// subset (proficient skills only) when the choice is submitted and again at
+// ValidateChoices.
+//
+// Tool-based expertise (e.g. thieves' tools) isn't advertised: the toolkit's
+// class-choice write path only records skill selections for expertise today
+// (see handler.go's CHOICE_CATEGORY_EXPERTISE case).
+func createExpertiseChoice(req *choices.ExpertiseRequirement) *dnd5ev1alpha1.Choice {
+	if req == nil || req.Count <= 0 {
+		return nil
+	}
+
+	allSkills := skills.List()
+	skillOptions := make([]dnd5ev1alpha1.Skill, 0, len(allSkills))
+	for _, skill := range allSkills {
+		skillOptions = append(skillOptions, convertSkillToProtoEnum(skill))
+	}
+
+	return &dnd5ev1alpha1.Choice{
+		Id:          string(req.ID),
+		Description: req.Label,
+		ChooseCount: int32(req.Count),
+		ChoiceType:  dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EXPERTISE,
+		Options: &dnd5ev1alpha1.Choice_ExpertiseOptions{
+			ExpertiseOptions: &dnd5ev1alpha1.ExpertiseOptions{
+				AvailableSkills: skillOptions,
 			},
 		},
 	}

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -229,6 +229,30 @@ func (s *CharacterCreationSuite) TestCreateRogue() {
 	s.T().Log("Creating Rogue character...")
 	ctx := s.authCtx("test-player-rogue")
 
+	// ListClasses must advertise Rogue's Expertise requirement - the client
+	// otherwise never learns a Rogue needs this choice (rpg-api#625).
+	listResp, err := s.server.CharacterClient.ListClasses(ctx, &dnd5ev1alpha1.ListClassesRequest{})
+	s.Require().NoError(err)
+	var rogueInfo *dnd5ev1alpha1.ClassInfo
+	for _, classInfo := range listResp.GetClasses() {
+		if classInfo.GetClassId() == dnd5ev1alpha1.Class_CLASS_ROGUE {
+			rogueInfo = classInfo
+			break
+		}
+	}
+	s.Require().NotNil(rogueInfo, "ListClasses should include Rogue")
+	var expertiseChoice *dnd5ev1alpha1.Choice
+	for _, choice := range rogueInfo.GetChoices() {
+		if choice.GetChoiceType() == dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EXPERTISE {
+			expertiseChoice = choice
+			break
+		}
+	}
+	s.Require().NotNil(expertiseChoice, "Rogue ClassInfo should advertise an Expertise choice")
+	s.Assert().Equal(int32(2), expertiseChoice.GetChooseCount())
+	s.Assert().NotEmpty(expertiseChoice.GetExpertiseOptions().GetAvailableSkills(),
+		"Expertise choice should advertise available skills")
+
 	// Create draft
 	createResp, err := s.server.CharacterClient.CreateDraft(ctx, &dnd5ev1alpha1.CreateDraftRequest{})
 	s.Require().NoError(err)

--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -686,11 +686,9 @@ func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftIn
 	}
 
 	// Validate all choices
-	// TODO: Temporarily disabled due to toolkit bug #313 - ValidateChoices doesn't handle fighting styles
-	// Re-enable once https://github.com/KirkDiggler/rpg-toolkit/issues/313 is fixed
-	// if err := draft.ValidateChoices(); err != nil {
-	// 	return nil, fmt.Errorf("draft validation failed: %w", err)
-	// }
+	if err = draft.ValidateChoices(); err != nil {
+		return nil, fmt.Errorf("draft validation failed: %w", err)
+	}
 
 	// Convert to character with generated ID
 	characterID := o.idGen.Generate()

--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -687,7 +687,7 @@ func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftIn
 
 	// Validate all choices
 	if err = draft.ValidateChoices(); err != nil {
-		return nil, fmt.Errorf("draft validation failed: %w", err)
+		return nil, apierr.InvalidArgumentf("draft validation failed: %v", err)
 	}
 
 	// Convert to character with generated ID


### PR DESCRIPTION
## Summary

Closes #625.

- `loadAllClassChoices` now emits an EXPERTISE choice for classes with an `ExpertiseRequirement` (Rogue today). Since `ExpertiseRequirement` has no fixed option list — expertise applies to whatever skill the character ends up proficient in via class/race/background, which isn't known at this static `ListClasses`/`GetClassDetails` layer — the full skill universe (`skills.List()`) is advertised as available, and the toolkit enforces the real proficient-skill subset when the choice is submitted (`draft.go` `SetClassChoices`) and again at `ValidateChoices()`.
- `convertChoiceCategoryToProto` now maps `TOOLS` and `EXPERTISE` instead of silently dropping them to `CHOICE_CATEGORY_UNSPECIFIED` on round-trip.
- Restored `draft.ValidateChoices()` in `FinalizeDraft`, disabled since toolkit#313 (fighting styles). That issue closed in Sept 2025 and the fix has been on toolkit main since; confirmed no existing class integration test (Fighter, Barbarian, Monk, Rogue) regresses with it back on.

## Load-bearing

None — this closes a data gap the toolkit already handled; no new architectural decisions.

## Test plan

- `go build ./...` — clean
- `go test ./internal/handlers/dnd5e/v1alpha1/character/... ./internal/orchestrators/character/...` — pass
- `go test -v -race ./internal/integration/character/...` — all 7 tests pass (Fighter, Barbarian, Monk, Rogue, 3 validation tests), including a new assertion in `TestCreateRogue` that `ListClasses` now advertises the Expertise requirement (`chooseCount == 2`, non-empty `AvailableSkills`) before the draft is even created
- `golangci-lint run` — 73 pre-existing issues confirmed identical on a clean `main` checkout (mock import-order drift + unrelated encounter/dice lint debt); this diff introduces zero new issues (verified: fixed one `govet` shadow warning my own change introduced along the way)
- `make pre-commit` / `make ci-check` — both fail on this repo today purely due to that same pre-existing debt (confirmed identical on unmodified main); GitHub Actions `test.yml` doesn't run golangci-lint at all, only `go test -race` with coverage, which is green
- End-to-end: paired with rpg-dnd5e-web#437 (KirkDiggler/rpg-dnd5e-web#437) — verified live via Chrome DevTools MCP that a Rogue can be created through the real web UI end-to-end against this build (see that PR for detail)

## Pushback / follow-up

**Correction**: an earlier version of this note incorrectly blamed rpg-toolkit. Re-traced with the actual pinned version (`rulebooks/dnd5e@v0.64.1`) and the toolkit is correct end to end: `draft.go:859` `compileSkills` sets `shared.Expert` for expertise picks, `character.go:192` doubles the proficiency bonus for `shared.Expert` in `GetSkillModifier`, and `ToCharacter().ToData()` preserves the full proficiency-level map.

The actual break is in **this repo**: `converters.go` `ConvertCharacterDataToProto` (~line 1096) flattens `data.Skills` (`map[Skill]ProficiencyLevel`) into a boolean "is proficient" list for the proto's `Proficiencies.skills` field, discarding the level distinction — so Expert and Proficient look identical on the wire, and nothing downstream (web) can double the modifier. Fixing it fully also needs a proto change: `Proficiencies` has no field to carry a level or computed modifier per skill (unlike `AbilityModifiers`, which exists for abilities). Filed with full trace evidence and a recommended fix shape (expose the toolkit's already-computed `GetSkillModifier` value per skill, not a raw level, per the boundary rule) as #627 — cross-repo (proto schema + this repo + web), genuinely separate from this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2
