### PR TITLE
chore(deps): bump rulebooks/dnd5e to v0.65.0 (Rage RAW fixes, Ki gate, IsMelee)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.3
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1 h1:Cq7BjIYRK9zh7EK6BWejZd6w3c8uNx8pVVjWB0Pw0yc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0 h1:/wmlRd+NgWUoAikqTUm8oQcvrk4kEX5BHZdlt8JirUk=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=


### PR DESCRIPTION
## Summary
- Bumps `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e` from v0.64.1 to v0.65.0, which includes rpg-toolkit#747 (Rage RAW fixes) and rpg-toolkit#748 (Monk Ki gate).
- Pure dependency bump — `go mod tidy` touched only `go.mod`/`go.sum` for this one module; no other dependency drifted.
- No call-site changes were needed. rpg-api only calls the toolkit's high-level `combat.ResolveAttackHit` / `combat.ApplyAttackOutcome` entry points; the new `IsMelee` field is derived internally by the toolkit from `AttackChainEvent.IsMelee` (itself derived from weapon data) and threaded through automatically. rpg-api never constructs `ResolveDamageInput`/`DealDamageInput` directly, so melee-ness stays a toolkit-owned rule as it should — the API doesn't have to decide it.

## Load-bearing
- **Rage's damage bonus is now melee-STR-only.** Previously it applied to any Strength-based damage, including thrown/ranged Strength attacks — that was a RAW bug. A raging Barbarian throwing a handaxe (STR, but ranged) no longer gets the +2/+3 rage bonus.
- **Raging now grants advantage on Strength checks and saving throws**, which the condition was previously missing entirely (PHB rage benefit). Mirrors the same `SavingThrowChain` pattern `DodgingCondition` already used for DEX saves, plus a new `AbilityCheckChain` subscription for the check side.
- **No more phantom Ki resource at level 1.** Monk characters below level 2 no longer get a Ki resource created during draft finalization — Ki is a level-2+ Monk feature per RAW.

## Test plan
- [x] `go build ./...` — clean, no call-site changes required
- [x] `go test -race ./...` — all packages pass (matches what CI runs)
- [x] `go test ./internal/integration/character/...` — explicit pass, including `TestCreateMonk` (exercises the Ki-gate fix) and `TestCreateBarbarian`
- [x] `golangci-lint run ./...` — 73 issues, matching the known pre-existing baseline exactly (zero new issues)

## References
- rpg-toolkit#745 (Rage RAW gap issue)
- rpg-toolkit#746 (Ki gate issue)
- rpg-toolkit tag: `rulebooks/dnd5e/v0.65.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2