### PR TITLE
fix(lobby): seed member SightRange so the party can see each other

### DIFF
--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -143,6 +143,24 @@ func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_CreateJoi
 		s.Require().Equal(p.hp, pd.MaxHP)
 	}
 
+	// rpg-api#632: an unseeded SightRange leaves every member able to see only
+	// their own spawn hex — the party never actually sees each other despite
+	// spawning adjacent. Assert every member's cumulative reveal covers every
+	// OTHER member's spawn hex, so this regression can't pass silently again.
+	for _, viewer := range players {
+		viewerPD := encData.Players[core.PlayerID(viewer.id)]
+		s.Require().NotZero(viewerPD.View.SightRange,
+			"player %q must have a seeded SightRange", viewer.id)
+		for _, other := range players {
+			if other.id == viewer.id {
+				continue
+			}
+			otherPD := encData.Players[core.PlayerID(other.id)]
+			s.Require().True(viewerPD.View.RevealedHexes.Has(otherPD.View.Position),
+				"player %q must be able to see player %q's spawn hex", viewer.id, other.id)
+		}
+	}
+
 	// All four land in the SAME encounter via the pre-existing v2
 	// StreamEncounter path — the already-proven snapshot-first flow
 	// (lobby-surface.md "Verify").

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -32,6 +32,16 @@ type StartEncounterOutput struct {
 // selection is future work once room integration lands.
 const spawnPositionSpacing = 1
 
+// memberSightRange is the initial perception radius seeded for every member
+// added to a freshly-started encounter (rpg-api#632). Without it,
+// tkenc.PlayerInput.SightRange defaults to 0 and AddPlayer's initial reveal
+// (encounter.go's VisibleHexesAt(pos, 0)) shows each player exactly one hex,
+// so party members can never see each other. 10 matches the devseed fixture
+// (cmd/devseed/main.go) for parity between the harness and real lobby-started
+// encounters; character-derived vision is future work (deferred per
+// rpg-api#632's correction comment).
+const memberSightRange = 10
+
 // StartEncounter is the lobby -> encounter seam. Host-only, all-ready
 // gated, atomic member-set snapshot (guarded by the per-lobby lock so a
 // racing LeaveLobby lands either before this snapshot — member excluded —
@@ -88,11 +98,12 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		}
 		q := i * spawnPositionSpacing
 		if addErr := enc.AddPlayer(tkenc.PlayerInput{
-			PlayerID: core.PlayerID(m.PlayerID),
-			EntityID: core.EntityID(m.CharacterID),
-			Position: core.Hex{Q: q, R: 0, S: -q},
-			HP:       hp,
-			MaxHP:    maxHP,
+			PlayerID:   core.PlayerID(m.PlayerID),
+			EntityID:   core.EntityID(m.CharacterID),
+			Position:   core.Hex{Q: q, R: 0, S: -q},
+			SightRange: memberSightRange,
+			HP:         hp,
+			MaxHP:      maxHP,
 		}); addErr != nil {
 			return nil, fmt.Errorf("add member %q to encounter: %w", m.PlayerID, addErr)
 		}

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -45,6 +45,16 @@ func (s *LobbySuite) TestStartEncounter_Success_ConstructsAndPersistsEncounter()
 	s.Require().Equal(12, encData.Players[core.PlayerID("alice")].HP, "HP must be seeded from the character store")
 	s.Require().Equal(10, encData.Players[core.PlayerID("bob")].HP)
 
+	// rpg-api#632: an unseeded SightRange (0) reveals exactly one hex per
+	// player, so nobody can see anybody else — the diagnosed bug. Assert each
+	// member's cumulative reveal actually covers the other member's spawn hex,
+	// not just their own.
+	alice := encData.Players[core.PlayerID("alice")]
+	bob := encData.Players[core.PlayerID("bob")]
+	s.Require().NotZero(alice.View.SightRange, "SightRange must be seeded — a zero value reveals only the player's own hex")
+	s.Require().True(alice.View.RevealedHexes.Has(bob.View.Position), "alice must be able to see bob's spawn hex")
+	s.Require().True(bob.View.RevealedHexes.Has(alice.View.Position), "bob must be able to see alice's spawn hex")
+
 	lobbyData, err := s.lobbyRepo.Get(s.ctx, "lobby-s1")
 	s.Require().NoError(err)
 	s.Require().Equal(lobbyrepo.StatusStarted, lobbyData.Status)


### PR DESCRIPTION
## Summary

Closes #632
Umbrella: KirkDiggler/rpg-project#81

`StartEncounter`'s `tkenc.PlayerInput` (`internal/orchestrators/lobby/start_encounter.go`) omitted `SightRange`, so it defaulted to 0. The toolkit's `AddPlayer` seeds each seat's initial reveal via `VisibleHexesAt(pos, 0)` (`encounter.go:295` in rpg-toolkit), which at radius 0 reveals exactly the player's own hex — so no party member could ever see any other member after `StartEncounter`, even though spawn spacing (`spawnPositionSpacing = 1`) already puts them adjacent.

Per the issue's correction comment, this is a one-field bug, not a missing-geometry problem: there is no room/wall system on the encounter stack yet (that's the separate ADR-0034 consolidation, explicitly out of scope here).

**Fix:** seed `SightRange: memberSightRange` (a new named constant, `10`) on every member's `PlayerInput`, matching the value devseed's fixture (`cmd/devseed/main.go`) already uses — so real lobby-started encounters get the same visibility devseed-driven harness runs always had.

## Load-bearing

- `memberSightRange = 10` is a placeholder constant, not character-derived vision — that's future work, deferred per #632's own correction comment.
- **Adjacent finding, not fixed here (scope discipline):** devseed's `PlayerInput` also sets `AC`, `AttackBonus`, `DamageDice`, `DamageType` — `StartEncounter` sets none of these (only `HP`/`MaxHP`, now plus `SightRange`). I traced this through the toolkit: `isPlayerCombatant` (rpg-toolkit `combat.go:224`, gating the `"attack"` verb in `combat_phased.go:79`) reads the flat `PlayerData.AC`/`DamageDice` snapshot fields directly, and the downstream `DataJSON` hydration cascade (rpg-api's `attachPlayerCharacterData` in `internal/handlers/dnd5e/v2/encounter/hydrate_players.go`, which runs on the *next* combat-capable RPC) never writes those values back onto `PlayerData`. **Net effect: every lobby-started encounter today has the `"attack"` action verb completely blocked (`ErrNonCombatant`) for all players** — a real, separate bug from the visibility one, worth its own issue. Not touched here per the brief's explicit scope boundary (`SightRange` only, don't expand without evidence — this is now evidence, surfaced for triage rather than folded into this PR).

## Test plan

- [x] Extended `TestStartEncounter_Success_ConstructsAndPersistsEncounter` (unit) to assert `SightRange` is seeded and each of the two members' `RevealedHexes` covers the other's spawn hex.
- [x] Extended `TestPartyAssembles_FourPlayers_CreateJoinReadyStart` (integration, the boarded 4-player gate test) with a full pairwise assertion: every member's `RevealedHexes` must cover every *other* member's spawn hex. This test previously passed straight through the bug — it now can't.
- [x] `go build ./...` clean.
- [x] `go test -race ./internal/orchestrators/lobby/... ./internal/integration/...` green (one unrelated pre-existing flake in `TestMonkIntegrationSuite`, a testcontainers-resource-contention flake in a completely separate combat-start helper — passes in isolation, confirmed not touched by this diff).
- [x] `golangci-lint run ./internal/orchestrators/lobby/...` — 0 issues. `golangci-lint run --new-from-rev=origin/main ./internal/integration/...` — 0 new issues.
- Playtest verification (4-browser: all four see each other on the revealed blob) happens on this branch before merge, per the issue's own verify step.

## Four-question gate

- **Goal:** party members can see each other immediately after `StartEncounter` — yes, verified via `RevealedHexes` assertions in both the unit and integration test.
- **Pattern:** matches devseed's existing `PlayerInput.SightRange: 10` fixture value; named constant next to the existing `spawnPositionSpacing` placeholder, same doc-comment style.
- **Test:** both the unit test and the 4-player integration test now fail without the fix and pass with it (verified the integration test previously passed through the bug — that's exactly what the new assertion closes).
- **Pushback:** the AC/AttackBonus/DamageDice/DamageType omission is a bigger, separate bug (blocks the `"attack"` verb entirely for lobby-started encounters) — flagged above for a follow-up issue rather than folded into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)