### PR TITLE
feat(lobby): combat-ready members + devseed combat injection — a real fight on GameView

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -341,7 +341,7 @@ func runInjectCombat(ctx context.Context, client redisclient.Client, encounterID
 	}
 
 	if out.AlreadySetTurnBased {
-		fmt.Fprintf(os.Stderr, "devseed --inject-combat: encounter %s already TURN_BASED, leaving mode as-is\n", encounterID)
+		fmt.Fprintf(os.Stderr, "devseed --inject-combat: encounter %s was already TURN_BASED, re-rolled initiative to include the new monster\n", encounterID)
 	}
 	fmt.Fprintf(
 		os.Stderr,

--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -42,6 +42,12 @@
 //	# Seed for free-roam (no initiative). Default is turn_based.
 //	go run ./cmd/devseed --mode=free_roam
 //
+//	# Inject a goblin into an EXISTING encounter (e.g. one created via the
+//	# lobby StartEncounter RPC) and flip it to TURN_BASED, WITHOUT rebuilding
+//	# it or touching its existing players (rpg-api#634 — "a real fight on
+//	# GameView"). --encounter-id must reference an already-persisted encounter.
+//	go run ./cmd/devseed --inject-combat --encounter-id=<id>
+//
 //	# Custom Redis target
 //	REDIS_ADDR=redis.example.com:6379 go run ./cmd/devseed
 //
@@ -61,7 +67,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KirkDiggler/rpg-api/internal/pkg/devcombat"
 	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
@@ -181,6 +189,10 @@ func run() error {
 		mode        = flag.String("mode", modeTurnBased, "Encounter mode: turn_based or free_roam")
 		fixture     = flag.String("fixture", fixtureDefault,
 			"Fixture to seed: wave-1-rogue, wave-2-monk, wave-2-beat2, wave-3-barbarian. Default: alice L2 + bob + wendy.")
+		injectCombat = flag.Bool("inject-combat", false,
+			"Load the EXISTING encounter at --encounter-id, add a goblin, and flip it to TURN_BASED, "+
+				"instead of seeding a fresh fixture. Requires an already-persisted encounter (e.g. one "+
+				"created via the lobby StartEncounter RPC). Ignores --mode and --fixture.")
 	)
 	flag.Parse()
 
@@ -192,9 +204,13 @@ func run() error {
 		addr = defaultRedisAddr
 	}
 
-	encMode, err := parseMode(*mode)
-	if err != nil {
-		return fmt.Errorf("invalid --mode: %w", err)
+	var encMode encountercore.EncounterMode
+	if !*injectCombat {
+		var modeErr error
+		encMode, modeErr = parseMode(*mode)
+		if modeErr != nil {
+			return fmt.Errorf("invalid --mode: %w", modeErr)
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -202,7 +218,7 @@ func run() error {
 
 	// Log the target before connecting so an error that swallows addr (per
 	// the gosec G706 fix below) still leaves a clear breadcrumb.
-	fmt.Fprintf(os.Stderr, "devseed: target redis=%s fixture=%q\n", addr, *fixture)
+	fmt.Fprintf(os.Stderr, "devseed: target redis=%s fixture=%q inject-combat=%v\n", addr, *fixture, *injectCombat)
 
 	client, err := redisclient.NewClient(addr, nil)
 	if err != nil {
@@ -216,6 +232,10 @@ func run() error {
 	if pingErr := client.Ping(ctx).Err(); pingErr != nil {
 		// gosec/G706: same rationale as the NewClient error path.
 		return fmt.Errorf("ping redis: %w", pingErr)
+	}
+
+	if *injectCombat {
+		return runInjectCombat(ctx, client, *encounterID)
 	}
 
 	var chars []*toolkitchar.Data
@@ -294,6 +314,40 @@ func run() error {
 		os.Stderr,
 		"seeded %s%s: mode=%v players=%d monsters=%d ttl=%s\n",
 		encKeyPrefix, encData.ID, encMode, len(encData.Players), len(encData.Monsters), encTTL,
+	)
+	return nil
+}
+
+// runInjectCombat implements --inject-combat: a thin CLI wrapper over
+// devcombat.Inject (internal/pkg/devcombat), the shared code path
+// cmd/devseed and the integration-test suite both call so the CLI mode and
+// the test coverage exercise identical logic (package main cannot be
+// imported by other packages, so the actual load/AddMonster/SetMode/save
+// logic — including its known-gap documentation — lives in that package, not
+// here). See devcombat.Inject's doc comment for what it does and why.
+func runInjectCombat(ctx context.Context, client redisclient.Client, encounterID string) error {
+	repo := encountersv2.NewRedis(client, encTTL)
+
+	out, err := devcombat.Inject(ctx, repo, devcombat.InjectInput{EncounterID: encounterID})
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return fmt.Errorf(
+				"encounter %q not found: --inject-combat requires an EXISTING encounter "+
+					"(e.g. one created via the lobby StartEncounter RPC, or a prior devseed run)",
+				encounterID,
+			)
+		}
+		return err
+	}
+
+	if out.AlreadySetTurnBased {
+		fmt.Fprintf(os.Stderr, "devseed --inject-combat: encounter %s already TURN_BASED, leaving mode as-is\n", encounterID)
+	}
+	fmt.Fprintf(
+		os.Stderr,
+		"devseed --inject-combat: encounter=%s%s goblin=%s pos=(%d,%d,%d) mode=%v players=%d monsters=%d\n",
+		encKeyPrefix, encounterID, out.GoblinID, out.Position.Q, out.Position.R, out.Position.S,
+		out.Mode, out.PlayerCount, out.MonsterCount,
 	)
 	return nil
 }

--- a/cmd/devseed/main_test.go
+++ b/cmd/devseed/main_test.go
@@ -15,8 +15,16 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
@@ -56,5 +64,53 @@ func TestDevseedFixtures_EffectiveACMatchesStatedArmorClass(t *testing.T) {
 					got.Total, data.ArmorClass, got.Components)
 			}
 		})
+	}
+}
+
+// TestRunInjectCombat_DelegatesToDevcombat is a smoke test for the --inject-
+// combat CLI wrapper: it proves runInjectCombat actually calls through to
+// devcombat.Inject (internal/pkg/devcombat) against a real Redis-backed
+// repository, and that a missing encounter surfaces a devseed-flavored,
+// actionable error message. devcombat's own test suite
+// (internal/pkg/devcombat/inject_test.go) covers the injection logic
+// itself (goblin seeding, redundant-SetMode handling, existing players
+// left untouched) — this test only needs to prove the wrapper wiring.
+func TestRunInjectCombat_DelegatesToDevcombat(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+	repo := encountersv2.NewRedis(client, time.Hour)
+
+	const encID = "lobby-enc-1"
+	enc := tkenc.New(ctx, encountercore.EncounterID(encID), tkenc.NewBroker(tkenc.NewInMemoryTransport()))
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: encountercore.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+	}); err != nil {
+		t.Fatalf("AddPlayer alice: %v", err)
+	}
+	if err := repo.Save(ctx, enc.ToData()); err != nil {
+		t.Fatalf("Save seeded encounter: %v", err)
+	}
+
+	if err := runInjectCombat(ctx, client, encID); err != nil {
+		t.Fatalf("runInjectCombat: %v", err)
+	}
+	data, err := repo.Get(ctx, encID)
+	if err != nil {
+		t.Fatalf("Get after inject: %v", err)
+	}
+	if data.Mode != encountercore.ModeTurnBased || len(data.Monsters) != 1 {
+		t.Fatalf("runInjectCombat did not apply devcombat.Inject's effect: mode=%v monsters=%d", data.Mode, len(data.Monsters))
+	}
+
+	err = runInjectCombat(ctx, client, "no-such-encounter")
+	if err == nil {
+		t.Fatal("expected an error for a missing encounter")
+	}
+	if !strings.Contains(err.Error(), "StartEncounter RPC") {
+		t.Fatalf("expected an actionable devseed error message, got: %v", err)
 	}
 }

--- a/docs/architecture/components/integration-test-harness.md
+++ b/docs/architecture/components/integration-test-harness.md
@@ -67,6 +67,23 @@ Because encounter and dungeon repos are in-memory, the harness cannot test persi
 
 Each test suite that creates a new `TestServer` starts a fresh Redis container. Container startup adds ~2-5 seconds per test suite. Tests sharing a harness via `SetupSuite` amortize this cost; tests that create a harness per test case do not.
 
+### v1alpha2 EncounterService character-store wiring (fixed rpg-api#634, 2026-07-11)
+
+The v1alpha2 `EncounterService` handler (`ts.EncounterClientV2`, registered via
+`encounterhandlerv2.New` in `wireServices`) was constructed with no
+`CombatResolverConfig`/`MovementResolverConfig` — unlike `cmd/server/server.go`'s
+production wiring, which passes `charRepo` through both. Without it, the v2 encounter
+orchestrator's `characterData.Attach` hydration cascade (`#689`) silently never ran:
+every combat-capable RPC (`TakeAction`, `EndTurn`, `MoveEntity`, `SubmitCheckReaction`)
+fell back to the stat-snapshot stand-in resolver path regardless of what a test seeded.
+This was invisible for years of tests because every existing combat fixture seeds
+explicit `AttackBonus`/`DamageDice`/`DamageType` on `PlayerInput` directly (the
+devseed-fixture pattern) — none needed real hydration. It became a real blocker for
+testing a lobby-created player (which, by design, carries no flat combat snapshot — see
+`internal/orchestrators/lobby/character.go`'s `seedMemberCombatSnapshot`), so it's fixed
+now: `wireServices` passes `charRepo` through `CombatResolverConfig`/
+`MovementResolverConfig` exactly as production does.
+
 ## Value
 
 The harness is what proves the full system works end-to-end. Unit tests with mocks verify orchestrator logic in isolation. The harness verifies:

--- a/docs/architecture/components/lobby-service.md
+++ b/docs/architecture/components/lobby-service.md
@@ -72,18 +72,23 @@ not this package.
   line-of-sight concept), so every subscriber for a lobby ID gets an identical event
   stream.
 - **`character.go`** — `resolveCharacter` (ownership validation + name enrichment for
-  `CreateLobby`/`JoinLobby`) and `seedMemberHP` (generalizes the old
+  `CreateLobby`/`JoinLobby`) and `seedMemberCombatSnapshot` (generalizes the old
   handler-layer `seedPlayerHP`, rpg-api#612, from one caller to N ready members at
-  `StartEncounter`).
+  `StartEncounter`; renamed + extended by rpg-api#634 to also seed AC honestly from the
+  stored character — see the `memberCombatSnapshot` doc comment for why AttackBonus/
+  DamageDice/DamageType are deliberately NOT seeded here).
 - **`start_encounter.go`** — the lobby -> encounter seam. Builds a fresh
   `tkenc.Encounter` on the SAME broker/repo the v2 encounter service reads from, adds
-  one player per ready member (HP seeded, positions spread along a line — a
+  one player per ready member (HP + AC seeded, positions spread along a line — a
   placeholder; no spawn-point system exists yet), persists ONCE, flips the lobby to
   STARTED, and only then publishes `EncounterStarted`. **Persist-then-emit ordering is
   load-bearing**: a client reacting to the event must find the encounter already in the
   encounter repo — enforced by construction (the `Publish` call is textually after both
   `Save` calls), and proven by
-  `TestStartEncounter_PublishesEncounterStarted_AfterPersist`.
+  `TestStartEncounter_PublishesEncounterStarted_AfterPersist`. A lobby-created member's
+  combat-readiness for TakeAction comes from hydration (the v2 encounter orchestrator's
+  `characterData.Attach` cascade, keyed off the `EntityID` set here), not from a flat
+  AttackBonus/DamageDice snapshot — see status.md's rpg-api#634 entry.
 
 ### Repository (`internal/repositories/lobby/`)
 
@@ -113,7 +118,10 @@ JSON-round-trip-on-every-call contract.
   start an encounter directly in `TURN_BASED` mode; the new contract has no equivalent
   field, so every lobby-constructed encounter starts `FREE_ROAM`. No production caller
   depended on the old behavior (devseed writes straight to Redis); flagged as a design
-  gap for a future RPC revision, not fixed here.
+  gap for a future RPC revision, not fixed here. `devseed --inject-combat`
+  (`internal/pkg/devcombat`) fills this gap for local/MCP playtesting only — it loads an
+  EXISTING lobby-started encounter, adds a monster, and flips TURN_BASED without a proto
+  change (rpg-api#634).
 - **Spawn positions are a placeholder** — `StartEncounter` spreads members along a
   straight line (`Q += index`) since no room/spawn-point system exists yet for a
   freshly-created lobby encounter. Real spawn selection is future work once room
@@ -131,6 +139,14 @@ gate test: four dev-authenticated players create/join/ready/start and land in on
 encounter, each with HP seeded from their bound character, verified both via direct
 `EncRepoV2` inspection and via the pre-existing `StreamEncounter` snapshot path.
 `TestJoinLobby_LateJoin_FailedPrecondition` covers the late-join edge case end-to-end.
+
+`TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves` (same file, rpg-api#634)
+builds on the same party-assembly flow and proves a lobby-created player can actually
+fight: `devcombat.Inject` adds a goblin + flips TURN_BASED, and the active player's real
+`TakeAction` RPC must not return `ErrNonCombatant`. The `TakeAction` assertion itself is
+`t.Skip()`'d pending a rpg-toolkit release past v0.24.3 (see status.md) — everything
+before it (injection, mode flip, initiative containing every player + the goblin) runs
+unconditionally.
 
 The integration harness (`internal/integration/harness/harness.go`) does spin up a real
 Redis container (testcontainers) for the suite, but `LobbyRepo` and `EncRepoV2` are

--- a/docs/architecture/components/lobby-service.md
+++ b/docs/architecture/components/lobby-service.md
@@ -143,10 +143,8 @@ encounter, each with HP seeded from their bound character, verified both via dir
 `TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves` (same file, rpg-api#634)
 builds on the same party-assembly flow and proves a lobby-created player can actually
 fight: `devcombat.Inject` adds a goblin + flips TURN_BASED, and the active player's real
-`TakeAction` RPC must not return `ErrNonCombatant`. The `TakeAction` assertion itself is
-`t.Skip()`'d pending a rpg-toolkit release past v0.24.3 (see status.md) — everything
-before it (injection, mode flip, initiative containing every player + the goblin) runs
-unconditionally.
+`TakeAction` RPC does not return `ErrNonCombatant` (fixed by rpg-toolkit encounter
+v0.24.4, see status.md).
 
 The integration harness (`internal/integration/harness/harness.go`) does spin up a real
 Redis container (testcontainers) for the suite, but `LobbyRepo` and `EncRepoV2` are

--- a/docs/status.md
+++ b/docs/status.md
@@ -60,15 +60,15 @@ rehydrates every lobby-created player from the character store — keyed off
 ignores the flat AC/DamageDice snapshot entirely once a seat is hydrated (it drives
 damage off the held `*character.Character`'s real weapon via
 `Character.WeaponForActionRef`); the flat snapshot only feeds the stand-in fallback for
-an un-hydrated seat. **Fix landed in rpg-toolkit** (branch `fix/combat-gate-hydration`,
-pushed — not yet released; batched per the standing local-override-until-unit-done
-pattern rather than a rushed standalone toolkit PR): `isPlayerCombatant` now also passes
-when the seat carries `DataJSON` (hydrated), independent of the flat snapshot. Until
-rpg-api's `go.mod` bumps past the toolkit release containing that fix, the integration
-test proving the full path (`TestPartyAssembles_FourPlayers_ThenCombatEntry_
-AttackResolves` in `internal/integration/lobby_v1alpha1_test.go`) is `t.Skip()`'d at the
-`TakeAction` assertion — verified locally against a replace directive; un-skip once the
-toolkit dependency updates.
+an un-hydrated seat. **Fixed in rpg-toolkit encounter v0.24.4** (rpg-toolkit#750/#751,
+merged 2026-07-11): `isPlayerCombatant` (now an `*Encounter` method) treats an actually
+HELD seat (`e.heldCharacter(...) != nil`) as combat-ready, independent of the flat
+snapshot — deliberately not `len(DataJSON) > 0`, since DataJSON being set doesn't mean a
+seat has been hydrated (only a `LoadFromData` round-trip's cascade does that; a Copilot
+review catch on the toolkit PR). `go.mod` bumped to `v0.24.4`; the integration test
+proving the full path end-to-end (`TestPartyAssembles_FourPlayers_ThenCombatEntry_
+AttackResolves` in `internal/integration/lobby_v1alpha1_test.go`) now passes for real, no
+skip, no replace directive.
 
 `cmd/devseed` gains `--inject-combat --encounter-id=<id>`: loads the EXISTING encounter
 (does not rebuild it), adds a goblin (`monster.NewGoblin`, same DataJSON pattern every

--- a/docs/status.md
+++ b/docs/status.md
@@ -40,7 +40,57 @@ bypassing the RPC surface.
 Known gap: `StartEncounter`'s proto contract carries no `initial_mode` field (the old
 `CreateEncounter` could start TURN_BASED directly) — every lobby-constructed encounter
 starts FREE_ROAM. No production caller depended on the old field; flagged as a design
-gap, not fixed here.
+gap, not fixed here. `devseed --inject-combat` (below) gives local/MCP playtesting a way
+to add a monster and flip TURN_BASED on a lobby-started encounter without a proto change;
+the real combat-entry trigger is future room/encounter-design work.
+
+**A real fight on GameView — combat-ready lobby members + devseed injection (rpg-api#634, 2026-07-11)** —
+`StartEncounter` now seeds each member's `tkenc.PlayerInput.AC` honestly from
+`character.Data.ArmorClass` (`seedMemberCombatSnapshot`, `internal/orchestrators/lobby/
+character.go`) — the character is already fetched for HP. `AttackBonus`/`DamageDice`/
+`DamageType` stay zero-value: a stored character carries no precomputed field for them
+(they're derived at attack time from equipped weapon + ability scores + proficiency
+bonus — real rules math rpg-api must not duplicate). This used to be a hard block: the
+toolkit's `isPlayerCombatant` gate rejected TakeAction for every lobby-created player
+(`ErrNonCombatant: missing HP/AC/DamageDice`) even though the v2 encounter
+orchestrator's existing `characterData.Attach` cascade (`hydrate_players.go`) already
+rehydrates every lobby-created player from the character store — keyed off
+`PlayerData.EntityID`, which `StartEncounter` already sets — on every combat-capable RPC
+(TakeAction/EndTurn/MoveEntity/SubmitCheckReaction). The real `Dnd5eCombatResolver`
+ignores the flat AC/DamageDice snapshot entirely once a seat is hydrated (it drives
+damage off the held `*character.Character`'s real weapon via
+`Character.WeaponForActionRef`); the flat snapshot only feeds the stand-in fallback for
+an un-hydrated seat. **Fix landed in rpg-toolkit** (branch `fix/combat-gate-hydration`,
+pushed — not yet released; batched per the standing local-override-until-unit-done
+pattern rather than a rushed standalone toolkit PR): `isPlayerCombatant` now also passes
+when the seat carries `DataJSON` (hydrated), independent of the flat snapshot. Until
+rpg-api's `go.mod` bumps past the toolkit release containing that fix, the integration
+test proving the full path (`TestPartyAssembles_FourPlayers_ThenCombatEntry_
+AttackResolves` in `internal/integration/lobby_v1alpha1_test.go`) is `t.Skip()`'d at the
+`TakeAction` assertion — verified locally against a replace directive; un-skip once the
+toolkit dependency updates.
+
+`cmd/devseed` gains `--inject-combat --encounter-id=<id>`: loads the EXISTING encounter
+(does not rebuild it), adds a goblin (`monster.NewGoblin`, same DataJSON pattern every
+other devseed fixture uses), flips to TURN_BASED (skipped if already turn-based, so
+re-running mid-fight just adds another goblin rather than erroring on the toolkit's
+redundant-`SetMode` rejection), and saves. The actual load/AddMonster/SetMode/save logic
+lives in `internal/pkg/devcombat` (`Inject`, Input/Output-typed) rather than in
+`cmd/devseed/main.go` directly — `package main` can't be imported, and both the CLI flag
+and `internal/integration/lobby_v1alpha1_test.go`'s combat-entry test call the identical
+code path. Known acceptable gap, documented in `devcombat.Inject`'s doc comment: a
+monster added this way doesn't get the `monstertraits.LoadMonsterConditions`/OA-reaction
+wiring the toolkit's `LoadFromData` cascade applies to monsters present at load time —
+cosmetic for a first fight; the goblin is fully rehydrated (OA included) on the next
+combat-capable RPC's own load.
+
+**Test harness gap fixed alongside #634**: `internal/integration/harness`'s v1alpha2
+`EncounterService` handler was wired with no `CombatResolverConfig`/`CharacterRepo` at
+all (unlike `cmd/server/server.go`'s production wiring), so the `characterData.Attach`
+hydration cascade silently never ran in ANY existing integration test — every prior
+combat test worked only because it seeded explicit `AttackBonus`/`DamageDice` snapshot
+fields directly, never needing hydration. Fixed to mirror production; verified the full
+`internal/integration/...` suite still passes.
 
 **Chapter 1 (Architecture Honesty) — v2 encounter orchestrator carve COMPLETE (#582, 2026-05-31)** —
 The v2 encounter vertical now runs through a clean `internal/orchestrators/encounter/v2`

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.3
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.4
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.3 h1:z90++aZR50TunjsFf2QFN9GeCPqVXHYDr3wwAB88y2k=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.3/go.mod h1:r2m0f6m3g3J02FBMI2Gn9fsNKDf6ErhrmuhQNByVvtg=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.24.4 h1:LSlHDnfaZCMzdP0V03DKuP6GOAyk/SIn/OnIofO4qfw=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.24.4/go.mod h1:r2m0f6m3g3J02FBMI2Gn9fsNKDf6ErhrmuhQNByVvtg=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -292,11 +292,28 @@ func (ts *TestServer) wireServices(cfg *Config) error {
 	// v1alpha2 encounter wiring — broker and repo are stored on ts so tests can
 	// seed data via ts.EncRepoV2.Save(...) and the registered handler sees the
 	// same state (single shared instance).
+	//
+	// CombatResolverConfig/MovementResolverConfig carry charRepo (mirrors
+	// cmd/server/server.go's production wiring) so the #689 characterData
+	// cascade actually hydrates players from DataJSON on combat-capable RPCs.
+	// Without this, EVERY player attack in this harness fell back to the
+	// stat-snapshot stand-in path regardless of what a test seeds — harmless
+	// for tests that seed explicit AttackBonus/DamageDice (the pre-#634
+	// pattern), but it silently defeated any test of a HYDRATED player (a
+	// lobby-created character, which by design carries no flat combat
+	// snapshot — rpg-api#634 Part 1). Roller is left nil so the rulebook uses
+	// its crypto-random default, matching production.
 	ts.BrokerV2 = tkenc.NewBroker(tkenc.NewInMemoryTransport())
 	ts.EncRepoV2 = encountersv2.NewInMemory()
 	encV2Handler, err := encounterhandlerv2.New(&encounterhandlerv2.HandlerConfig{
 		Broker: ts.BrokerV2,
 		Repo:   ts.EncRepoV2,
+		CombatResolverConfig: &encounterhandlerv2.Dnd5eCombatResolverConfig{
+			CharacterRepo: charRepo,
+		},
+		MovementResolverConfig: &encounterhandlerv2.Dnd5eMovementResolverConfig{
+			CharacterRepo: charRepo,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("v2 encounter handler: %w", err)

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -20,7 +20,9 @@ import (
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+	"github.com/KirkDiggler/rpg-api/internal/pkg/devcombat"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
@@ -173,6 +175,161 @@ func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_CreateJoi
 		s.Require().NotNil(snap.GetSnapshotDelivered())
 		s.Require().Equal(encounterID, snap.GetSnapshotDelivered().GetEncounter().GetId())
 	}
+}
+
+// TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves builds on the
+// same create/join/ready/start party-assembly flow as
+// TestPartyAssembles_FourPlayers_CreateJoinReadyStart and adds rpg-api#634's
+// combat-entry proof: once the party is seated in a v2 encounter,
+// devcombat.Inject (the SAME code path cmd/devseed's --inject-combat flag
+// uses) adds a goblin and flips the encounter to TURN_BASED, and the active
+// player's real attack via the production TakeAction RPC actually resolves
+// — NOT ErrNonCombatant, which is what every lobby-created player hit before
+// #634 (isPlayerCombatant gated on a flat AC/DamageDice snapshot
+// StartEncounter had no honest way to populate for an arbitrary character).
+//
+// A miss is still a valid pass: the toolkit resolves the attack with a real
+// d20, matching TestCombatSlice_TakeActionAndEndTurn_NPCDispatch's
+// established pattern in encounter_v2_test.go. What this test proves is that
+// the attack RESOLVES at all instead of being rejected at the combatant gate
+// — that rejection is the bug #634 fixes, not the coin-flip of hit vs. miss.
+func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves() {
+	players := []struct {
+		id, character, name string
+		hp                  int
+	}{
+		{"alice", "char-alice", "Alice", 12},
+		{"bob", "char-bob", "Bob", 10},
+		{"carol", "char-carol", "Carol", 14},
+		{"dave", "char-dave", "Dave", 8},
+	}
+	for _, p := range players {
+		s.seedCharacter(p.character, p.id, p.name, p.hp)
+	}
+
+	createResp, err := s.srv.LobbyClient.CreateLobby(s.authCtx("alice"), &lobbyv1alpha1.CreateLobbyRequest{
+		CampaignId: "campaign-1", CharacterId: "char-alice",
+	})
+	s.Require().NoError(err)
+	lobbyID := createResp.GetLobbyId()
+	joinRef := createResp.GetJoinRef()
+
+	for _, p := range players[1:] {
+		_, joinErr := s.srv.LobbyClient.JoinLobby(s.authCtx(p.id), &lobbyv1alpha1.JoinLobbyRequest{
+			JoinRef: joinRef, CharacterId: p.character,
+		})
+		s.Require().NoError(joinErr)
+	}
+	for _, p := range players {
+		_, readyErr := s.srv.LobbyClient.SetReady(s.authCtx(p.id), &lobbyv1alpha1.SetReadyRequest{
+			LobbyId: lobbyID, Ready: true,
+		})
+		s.Require().NoError(readyErr)
+	}
+
+	startResp, err := s.srv.LobbyClient.StartEncounter(s.authCtx("alice"), &lobbyv1alpha1.StartEncounterRequest{
+		LobbyId: lobbyID,
+	})
+	s.Require().NoError(err)
+	encounterID := startResp.GetEncounterId()
+	s.Require().NotEmpty(encounterID)
+
+	// rpg-api#634 Part 2: inject a goblin into the lobby-started encounter and
+	// flip it to TURN_BASED — the same code path cmd/devseed's --inject-combat
+	// uses.
+	injectOut, err := devcombat.Inject(s.ctx, s.srv.EncRepoV2, devcombat.InjectInput{EncounterID: encounterID})
+	s.Require().NoError(err)
+	s.Require().Equal(core.ModeTurnBased, injectOut.Mode)
+
+	encData, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	s.Require().Contains(encData.Monsters, injectOut.GoblinID, "injected goblin must be in the encounter")
+	s.Require().Contains(encData.Initiative, injectOut.GoblinID, "goblin must be included in the rolled initiative order")
+	for _, p := range players {
+		pd, ok := encData.Players[core.PlayerID(p.id)]
+		s.Require().True(ok, "player %q must survive combat injection", p.id)
+		s.Require().Contains(encData.Initiative, pd.EntityID, "player %q must be included in the rolled initiative order", p.id)
+	}
+
+	// Advance to a player's own turn (initiative is roll-dependent — the
+	// goblin may go first) via direct toolkit manipulation. This is setup for
+	// the assertion below, not the assertion itself — mirrors
+	// EncounterV2IntegrationSuite.advanceUntilPlayerActiveByDirectToolkit in
+	// encounter_v2_test.go (duplicated rather than shared across suite types
+	// for a ~15-line helper).
+	s.advanceUntilPlayerActive(encData)
+
+	data, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	activeEntity := data.Initiative[data.ActiveIdx]
+	var activePlayer string
+	for pid, pd := range data.Players {
+		if pd.EntityID == activeEntity {
+			activePlayer = string(pid)
+			break
+		}
+	}
+	s.Require().NotEmpty(activePlayer, "an active player must be found before TakeAction")
+
+	// The headline #634 proof: TakeAction against the lobby-created,
+	// characterData.Attach-hydrated player must NOT return ErrNonCombatant.
+	// Pre-#634, isPlayerCombatant rejected EVERY lobby-created player because
+	// StartEncounter had no honest AC/DamageDice snapshot to seed.
+	//
+	// BLOCKED on a rpg-toolkit encounter release past v0.24.3: the gate
+	// relaxation (isPlayerCombatant treats a hydrated seat — DataJSON present
+	// — as combat-ready, since the real Dnd5eCombatResolver ignores the flat
+	// AC/DamageDice snapshot once hydrated anyway) lives on rpg-toolkit branch
+	// fix/combat-gate-hydration — pushed, not yet released (batched per the
+	// standing local-override-until-unit-done pattern rather than rushed out
+	// as its own PR). Verified locally against a replace directive pointing
+	// at that branch: with it, this assertion passes; against the currently
+	// published v0.24.3 it fails with ErrNonCombatant ("missing HP/AC/
+	// DamageDice"). Un-skip once go.mod bumps past the toolkit release that
+	// includes the fix.
+	s.T().Skip("blocked on rpg-toolkit encounter isPlayerCombatant relaxation (branch fix/combat-gate-hydration) — rpg-api#634")
+
+	_, err = s.srv.EncounterClientV2.TakeAction(s.authCtx(activePlayer), &encounterv2pb.TakeActionRequest{
+		EncounterId:   encounterID,
+		ActorEntityId: string(activeEntity),
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: string(injectOut.GoblinID)},
+		},
+	})
+	s.Require().NoError(err, "attack must resolve — a lobby-created player must pass the combatant gate")
+}
+
+// advanceUntilPlayerActive cycles NPC (goblin) turns via direct toolkit
+// calls + a deterministic stand-in resolver until the active actor is a
+// player, then persists the advanced state. Mirrors
+// EncounterV2IntegrationSuite.advanceUntilPlayerActiveByDirectToolkit in
+// encounter_v2_test.go.
+func (s *LobbyV1alpha1IntegrationSuite) advanceUntilPlayerActive(data *tkenc.Data) {
+	for {
+		s.Require().NotEmpty(data.Initiative, "encounter has empty initiative; SetMode/inject may have failed")
+		active := data.Initiative[data.ActiveIdx]
+		isPlayer := false
+		for _, pd := range data.Players {
+			if pd.EntityID == active {
+				isPlayer = true
+				break
+			}
+		}
+		if isPlayer {
+			break
+		}
+		// Active is the goblin — run NPCAct + EndTurn to cycle, via a
+		// deterministic stand-in resolver (always hits) so this setup step
+		// doesn't depend on a real d20.
+		enc, reloadErr := tkenc.LoadFromData(s.ctx, data, s.srv.BrokerV2, tkenc.WithCombatResolver(testStandInResolver{}))
+		s.Require().NoError(reloadErr)
+		s.Require().NoError(enc.NPCAct(s.ctx, active))
+		_, _, endErr := enc.EndTurn(context.Background(), active)
+		s.Require().NoError(endErr)
+		data = enc.ToData()
+	}
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, data))
 }
 
 // TestJoinLobby_LateJoin_FailedPrecondition proves the "late join" edge

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -274,21 +274,11 @@ func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_ThenComba
 	// The headline #634 proof: TakeAction against the lobby-created,
 	// characterData.Attach-hydrated player must NOT return ErrNonCombatant.
 	// Pre-#634, isPlayerCombatant rejected EVERY lobby-created player because
-	// StartEncounter had no honest AC/DamageDice snapshot to seed.
-	//
-	// BLOCKED on a rpg-toolkit encounter release past v0.24.3: the gate
-	// relaxation (isPlayerCombatant treats a hydrated seat — DataJSON present
-	// — as combat-ready, since the real Dnd5eCombatResolver ignores the flat
-	// AC/DamageDice snapshot once hydrated anyway) lives on rpg-toolkit branch
-	// fix/combat-gate-hydration — pushed, not yet released (batched per the
-	// standing local-override-until-unit-done pattern rather than rushed out
-	// as its own PR). Verified locally against a replace directive pointing
-	// at that branch: with it, this assertion passes; against the currently
-	// published v0.24.3 it fails with ErrNonCombatant ("missing HP/AC/
-	// DamageDice"). Un-skip once go.mod bumps past the toolkit release that
-	// includes the fix.
-	s.T().Skip("blocked on rpg-toolkit encounter isPlayerCombatant relaxation (branch fix/combat-gate-hydration) — rpg-api#634")
-
+	// StartEncounter had no honest AC/DamageDice snapshot to seed. The gate
+	// relaxation (isPlayerCombatant treats an actually-held seat as
+	// combat-ready, since the real Dnd5eCombatResolver ignores the flat
+	// AC/DamageDice snapshot once hydrated anyway) shipped in rpg-toolkit
+	// encounter v0.24.4 (rpg-toolkit#750/#751).
 	_, err = s.srv.EncounterClientV2.TakeAction(s.authCtx(activePlayer), &encounterv2pb.TakeActionRequest{
 		EncounterId:   encounterID,
 		ActorEntityId: string(activeEntity),

--- a/internal/orchestrators/lobby/character.go
+++ b/internal/orchestrators/lobby/character.go
@@ -30,32 +30,52 @@ func (o *Orchestrator) resolveCharacter(ctx context.Context, playerID, character
 	return out.Character.Data.Name, nil
 }
 
-// seedMemberHP looks up characterID in the character store and returns its
-// current/max HP, generalizing the single-caller seedPlayerHP that used to
-// live in the deleted v1alpha2 CreateEncounter handler (rpg-api#612) to
-// StartEncounter's N-member seeding. Without this seed, PlayerData.HP/MaxHP
-// stays 0/0 forever — the toolkit's combat verbs only clamp HP downward, so
-// an unseeded seat is "undying" and its HP bar always reads 0/0.
+// memberCombatSnapshot is the honest subset of a stored character's combat
+// stats StartEncounter can seed onto a tkenc.PlayerInput without doing rules
+// math: HP/MaxHP/AC are stored fields, copied verbatim. AttackBonus,
+// DamageDice, and DamageType are deliberately absent — a character carries
+// no precomputed field for them (they're derived at attack time from
+// equipped weapon + ability scores + proficiency bonus, real rules math
+// rpg-api must not duplicate). See start_encounter.go's isPlayerCombatant
+// discussion (rpg-api#634).
+type memberCombatSnapshot struct {
+	hp, maxHP, ac int
+}
+
+// seedMemberCombatSnapshot looks up characterID in the character store and
+// returns its current/max HP and AC, generalizing the single-caller
+// seedPlayerHP that used to live in the deleted v1alpha2 CreateEncounter
+// handler (rpg-api#612) to StartEncounter's N-member seeding. Without the HP
+// seed, PlayerData.HP/MaxHP stays 0/0 forever — the toolkit's combat verbs
+// only clamp HP downward, so an unseeded seat is "undying" and its HP bar
+// always reads 0/0. Without the AC seed, a player who ends up as a
+// stat-snapshot defender stub (e.g. a monster attacks before this player's
+// own hydration cascade has run) would present AC 0 — trivially hit by
+// every attack (rpg-toolkit encounter/npc.go's TargetAC: targetPlayer.AC).
 //
 // A NotFound character (or a nil character repo, defensive for tests) leaves
-// HP/MaxHP at 0 rather than failing StartEncounter — a character genuinely
-// missing at start time is a data-consistency issue surfaced elsewhere, not
-// a reason to block the whole party. Any OTHER character-store error
-// surfaces: a real store failure should not be silently swallowed into an
-// incorrect 0/0 seed.
-func (o *Orchestrator) seedMemberHP(ctx context.Context, characterID string) (hp, maxHP int, err error) {
+// the snapshot zeroed rather than failing StartEncounter — a character
+// genuinely missing at start time is a data-consistency issue surfaced
+// elsewhere, not a reason to block the whole party. Any OTHER character-store
+// error surfaces: a real store failure should not be silently swallowed into
+// an incorrect zeroed seed.
+func (o *Orchestrator) seedMemberCombatSnapshot(ctx context.Context, characterID string) (memberCombatSnapshot, error) {
 	if o.characterRepo == nil {
-		return 0, 0, nil
+		return memberCombatSnapshot{}, nil
 	}
 	out, getErr := o.characterRepo.Get(ctx, characterrepo.GetInput{ID: characterID})
 	if getErr != nil {
 		if apierr.IsNotFound(getErr) {
-			return 0, 0, nil
+			return memberCombatSnapshot{}, nil
 		}
-		return 0, 0, getErr
+		return memberCombatSnapshot{}, getErr
 	}
 	if out == nil || out.Character == nil || out.Character.Data == nil {
-		return 0, 0, nil
+		return memberCombatSnapshot{}, nil
 	}
-	return out.Character.Data.HitPoints, out.Character.Data.MaxHitPoints, nil
+	return memberCombatSnapshot{
+		hp:    out.Character.Data.HitPoints,
+		maxHP: out.Character.Data.MaxHitPoints,
+		ac:    out.Character.Data.ArmorClass,
+	}, nil
 }

--- a/internal/orchestrators/lobby/lobby_test.go
+++ b/internal/orchestrators/lobby/lobby_test.go
@@ -87,6 +87,23 @@ func (s *LobbySuite) expectCharacter(characterID, playerID, name string, hp, max
 		}, nil)
 }
 
+// expectCharacterWithAC is expectCharacter plus a stored ArmorClass, for
+// tests that assert StartEncounter's honest combat-snapshot seeding
+// (rpg-api#634): AC is a real stored field, copied verbatim onto
+// tkenc.PlayerInput.AC.
+func (s *LobbySuite) expectCharacterWithAC(characterID, playerID, name string, hp, maxHP, ac int) {
+	s.charRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: characterID}).
+		Return(&characterrepo.GetOutput{
+			Character: &entities.Character{
+				Data: &toolkitchar.Data{
+					PlayerID: playerID, Name: name,
+					HitPoints: hp, MaxHitPoints: maxHP, ArmorClass: ac,
+				},
+			},
+		}, nil)
+}
+
 // expectCharacterNotFound arms s.charRepo to return NotFound for characterID.
 func (s *LobbySuite) expectCharacterNotFound(characterID string) {
 	s.charRepo.EXPECT().

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -50,12 +50,13 @@ const memberSightRange = 10
 // This subsumes the deleted v1alpha2 CreateEncounter RPC (lobby-surface.md
 // "StartEncounter subsumes CreateEncounter"): it is now the ONLY way an
 // encounter comes into existence. It builds a fresh toolkit encounter, adds
-// one player per ready member (HP seeded from the character store,
+// one player per ready member (HP and AC seeded from the character store,
 // generalizing the single-caller seedPlayerHP the old handler-layer
-// CreateEncounter used), persists it ONCE to the encounter repo, transitions
-// the lobby to STARTED, and only then publishes EncounterStarted.
-// Persist-then-emit ordering is load-bearing: a client reacting to
-// EncounterStarted must find the encounter already in the encounter repo.
+// CreateEncounter used — see seedMemberCombatSnapshot in character.go),
+// persists it ONCE to the encounter repo, transitions the lobby to STARTED,
+// and only then publishes EncounterStarted. Persist-then-emit ordering is
+// load-bearing: a client reacting to EncounterStarted must find the
+// encounter already in the encounter repo.
 func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInput) (*StartEncounterOutput, error) {
 	if in == nil {
 		return nil, errors.New("lobby orchestrator: StartEncounterInput is required")
@@ -92,9 +93,9 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 	)
 
 	for i, m := range members {
-		hp, maxHP, hpErr := o.seedMemberHP(ctx, m.CharacterID)
-		if hpErr != nil {
-			return nil, fmt.Errorf("seed HP for character %q: %w", m.CharacterID, hpErr)
+		snap, snapErr := o.seedMemberCombatSnapshot(ctx, m.CharacterID)
+		if snapErr != nil {
+			return nil, fmt.Errorf("seed combat snapshot for character %q: %w", m.CharacterID, snapErr)
 		}
 		q := i * spawnPositionSpacing
 		if addErr := enc.AddPlayer(tkenc.PlayerInput{
@@ -102,8 +103,19 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 			EntityID:   core.EntityID(m.CharacterID),
 			Position:   core.Hex{Q: q, R: 0, S: -q},
 			SightRange: memberSightRange,
-			HP:         hp,
-			MaxHP:      maxHP,
+			HP:         snap.hp,
+			MaxHP:      snap.maxHP,
+			AC:         snap.ac,
+			// AttackBonus/DamageDice/DamageType stay zero: a stored character
+			// carries no precomputed field for them (real rules math, derived
+			// at attack time from equipped weapon + ability scores +
+			// proficiency bonus — see memberCombatSnapshot's doc comment in
+			// character.go). isPlayerCombatant (rpg-toolkit combat.go) treats
+			// a hydrated seat as combat-ready instead of gating on these flat
+			// fields; the v2 encounter orchestrator's characterData.Attach
+			// cascade rehydrates this player from EntityID on every
+			// combat-capable RPC (hydrate_players.go), independent of what
+			// StartEncounter seeds here.
 		}); addErr != nil {
 			return nil, fmt.Errorf("add member %q to encounter: %w", m.PlayerID, addErr)
 		}

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -61,6 +61,33 @@ func (s *LobbySuite) TestStartEncounter_Success_ConstructsAndPersistsEncounter()
 	s.Require().Equal(out.EncounterID, lobbyData.EncounterID)
 }
 
+// TestStartEncounter_SeedsHonestCombatSnapshot proves the rpg-api#634 fix:
+// AC is seeded from the stored character (a real field, copied verbatim),
+// while AttackBonus/DamageDice/DamageType stay zero — a character carries no
+// precomputed value for them, and rpg-api must not compute one (that's rules
+// math the toolkit owns). isPlayerCombatant instead treats a hydrated seat
+// as combat-ready; that hydration comes from the v2 encounter orchestrator's
+// characterData.Attach cascade on the first combat-capable RPC, not from
+// StartEncounter, so DataJSON is correctly absent here.
+func (s *LobbySuite) TestStartEncounter_SeedsHonestCombatSnapshot() {
+	s.seedReadyLobby("lobby-s7", "alice")
+	s.expectCharacterWithAC("char-alice", "alice", "Alice", 12, 12, 15)
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-s7",
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	alice := encData.Players[core.PlayerID("alice")]
+	s.Require().Equal(15, alice.AC, "AC must be seeded honestly from the stored character")
+	s.Require().Zero(alice.AttackBonus, "no stored field to honestly derive an attack bonus from")
+	s.Require().Empty(alice.DamageDice, "no stored field to honestly derive damage dice from")
+	s.Require().Empty(alice.DamageType, "no stored field to honestly derive a damage type from")
+	s.Require().Empty(alice.DataJSON, "hydration is the v2 orchestrator's characterData.Attach cascade's job, not StartEncounter's")
+}
+
 func (s *LobbySuite) TestStartEncounter_CharacterNotFound_SeedsZeroHP_NotFatal() {
 	s.seedReadyLobby("lobby-s2", "alice")
 	s.charRepo.EXPECT().

--- a/internal/pkg/devcombat/inject.go
+++ b/internal/pkg/devcombat/inject.go
@@ -1,0 +1,160 @@
+// Package devcombat implements the dev-tooling half of rpg-api#634 ("a real
+// fight on GameView"): injecting a goblin into an EXISTING encounter and
+// flipping it to TURN_BASED, without rebuilding the encounter or touching its
+// existing players. cmd/devseed's --inject-combat flag and the integration
+// test suite both call Inject so they exercise the identical code path —
+// package main (cmd/devseed) cannot be imported by other packages, so this
+// logic lives here rather than in cmd/devseed/main.go.
+//
+// This fills a gap production StartEncounter does not (and should not) fill
+// itself: there is no room/encounter-design system yet to decide when and
+// what monsters spawn into a lobby-started encounter (the lobby contract
+// deliberately dropped an initial_mode field — rpg-project#81 decision log).
+// The real combat-entry trigger is future room/encounter-design work; this
+// package exists purely so local/MCP playtesting can exercise a fight against
+// a lobby-started encounter today.
+package devcombat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+)
+
+// monsterRefGoblin identifies the injected monster's type, matching
+// cmd/devseed's existing fixture convention.
+const monsterRefGoblin = "dnd5e:monsters:goblin"
+
+// goblinDamageDice is the injected goblin's stat-snapshot damage-dice
+// fallback (used by StandInCombatResolver if the goblin's own attacks ever
+// run without a held character), matching every other devseed fixture's
+// goblin.
+const goblinDamageDice = "1d6+2"
+
+// goblinAttackBonus matches goblin's NewScimitarAction, same as every other
+// devseed fixture.
+const goblinAttackBonus = 4
+
+// goblinSpeed is 30ft / 5ft-per-hex.
+const goblinSpeed = 6
+
+// goblinDamageType is the injected goblin's stat-snapshot damage type.
+const goblinDamageType = "slashing"
+
+// InjectInput carries the parameters for Inject.
+type InjectInput struct {
+	// EncounterID identifies the EXISTING encounter to load. Inject returns
+	// encountersv2.ErrNotFound if no encounter is persisted under this ID.
+	EncounterID string
+}
+
+// InjectOutput reports what Inject did, for callers that want to print or
+// assert on it.
+type InjectOutput struct {
+	GoblinID            core.EntityID
+	Position            core.Hex
+	Mode                core.EncounterMode
+	AlreadySetTurnBased bool
+	PlayerCount         int
+	MonsterCount        int
+}
+
+// Inject loads the EXISTING encounter at input.EncounterID, adds a goblin,
+// and flips the encounter to TURN_BASED — WITHOUT rebuilding the encounter or
+// touching its existing players. This is the honest complement to rpg-api
+// #634 Part 1 (lobby StartEncounter seeds real players with an honest
+// HP/AC/no-fake-attack-stats snapshot but never spawns monsters): a lobby-
+// started encounter has no monster and stays FreeRoam until something adds
+// one, and this is that something for dev/playtest purposes.
+//
+// If the encounter is already TURN_BASED (e.g. a second goblin is being
+// injected mid-fight), SetMode is skipped rather than erroring — the toolkit
+// rejects a redundant SetMode call ("mode is already turn_based").
+//
+// Known acceptable gap: a monster added here does NOT go through
+// monstertraits.LoadMonsterConditions / the OA reaction-readiness wiring that
+// rpg-toolkit encounter's hydrateMonster applies during the LoadFromData
+// cascade (npc.go) — AddMonster only seeds the flat MonsterData snapshot +
+// DataJSON blob on this call's short-lived encounter, not a live held
+// *monster.Monster with conditions subscribed. The injected goblin still
+// attacks/defends via its AttackBonus/DamageDice/DamageType snapshot (set
+// below) and gets fully rehydrated — including OA wiring — on the NEXT
+// combat-capable RPC's own LoadFromData (the v2 encounter orchestrator's
+// characterData cascade attaches fresh DataJSON for every seat on every
+// combat-capable request). Only the opportunity-attack reaction for THIS
+// specific goblin is missing until then — cosmetic for a first fight.
+func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput) (*InjectOutput, error) {
+	data, err := repo.Get(ctx, input.EncounterID)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter %q: %w", input.EncounterID, err)
+	}
+
+	// devcombat never publishes events; the broker only exists because
+	// LoadFromData/AddMonster/SetMode require one. The persisted Data is what
+	// matters — the next real load builds its own broker.
+	transport := tkenc.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := tkenc.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+
+	enc, err := tkenc.LoadFromData(ctx, data, broker)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter %q from data: %w", input.EncounterID, err)
+	}
+
+	goblinID := core.EntityID(fmt.Sprintf("goblin-%d", len(data.Monsters)+1))
+	goblin := monster.NewGoblin(string(goblinID))
+	goblinData := goblin.ToData()
+	goblinDataJSON, err := json.Marshal(goblinData)
+	if err != nil {
+		return nil, fmt.Errorf("marshal goblin data: %w", err)
+	}
+
+	// StartEncounter spaces lobby members along Q=0..N-1, R=0
+	// (spawnPositionSpacing, internal/orchestrators/lobby/start_encounter.go)
+	// — one hex past the last member puts the goblin adjacent to the party
+	// instead of stacked on a player.
+	goblinQ := len(data.Players) + 1
+	goblinPos := core.Hex{Q: goblinQ, R: 0, S: -goblinQ}
+	if addErr := enc.AddMonster(tkenc.MonsterInput{
+		ID:          goblinID,
+		Position:    goblinPos,
+		HP:          goblinData.HitPoints,
+		MaxHP:       goblinData.MaxHitPoints,
+		AC:          goblinData.ArmorClass,
+		Speed:       goblinSpeed,
+		MonsterRef:  monsterRefGoblin,
+		AttackBonus: goblinAttackBonus,
+		DamageDice:  goblinDamageDice,
+		DamageType:  goblinDamageType,
+		DataJSON:    goblinDataJSON,
+	}); addErr != nil {
+		return nil, fmt.Errorf("add goblin to encounter %q: %w", input.EncounterID, addErr)
+	}
+
+	alreadyTurnBased := data.Mode == core.ModeTurnBased
+	if !alreadyTurnBased {
+		if setErr := enc.SetMode(core.ModeTurnBased); setErr != nil {
+			return nil, fmt.Errorf("set mode turn_based on encounter %q: %w", input.EncounterID, setErr)
+		}
+	}
+
+	updated := enc.ToData()
+	if saveErr := repo.Save(ctx, updated); saveErr != nil {
+		return nil, fmt.Errorf("save encounter %q: %w", input.EncounterID, saveErr)
+	}
+
+	return &InjectOutput{
+		GoblinID:            goblinID,
+		Position:            goblinPos,
+		Mode:                updated.Mode,
+		AlreadySetTurnBased: alreadyTurnBased,
+		PlayerCount:         len(updated.Players),
+		MonsterCount:        len(updated.Monsters),
+	}, nil
+}

--- a/internal/pkg/devcombat/inject.go
+++ b/internal/pkg/devcombat/inject.go
@@ -73,8 +73,14 @@ type InjectOutput struct {
 // one, and this is that something for dev/playtest purposes.
 //
 // If the encounter is already TURN_BASED (e.g. a second goblin is being
-// injected mid-fight), SetMode is skipped rather than erroring — the toolkit
-// rejects a redundant SetMode call ("mode is already turn_based").
+// injected mid-fight), the toolkit rejects a redundant SetMode call ("mode is
+// already turn_based") — and AddMonster alone never touches Initiative (only
+// SetMode's rollInitiative does), so a monster added while already
+// turn-based would otherwise sit in the encounter forever without ever
+// getting a turn. Inject instead round-trips FREE_ROAM -> TURN_BASED to force
+// a fresh roll that includes the new monster, accepting the reset to
+// Round=1/ActiveIdx=0 as the honest cost of adding a combatant mid-fight in a
+// dev tool (not a live production interrupt).
 //
 // Known acceptable gap: a monster added here does NOT go through
 // monstertraits.LoadMonsterConditions / the OA reaction-readiness wiring that
@@ -115,11 +121,13 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 		return nil, fmt.Errorf("marshal goblin data: %w", err)
 	}
 
-	// StartEncounter spaces lobby members along Q=0..N-1, R=0
-	// (spawnPositionSpacing, internal/orchestrators/lobby/start_encounter.go)
-	// — one hex past the last member puts the goblin adjacent to the party
-	// instead of stacked on a player.
-	goblinQ := len(data.Players) + 1
+	// Placed one hex past the party's leading edge — the highest Q among
+	// existing players AND monsters — so the goblin starts adjacent to the
+	// party instead of stacked on an occupied hex. Computed from actual
+	// positions (not assumed from StartEncounter's current Q=0..N-1 layout)
+	// so this stays correct if spawn placement ever changes, and so a SECOND
+	// injected goblin doesn't stack on the first.
+	goblinQ := maxOccupiedQ(data) + 1
 	goblinPos := core.Hex{Q: goblinQ, R: 0, S: -goblinQ}
 	if addErr := enc.AddMonster(tkenc.MonsterInput{
 		ID:          goblinID,
@@ -138,10 +146,15 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 	}
 
 	alreadyTurnBased := data.Mode == core.ModeTurnBased
-	if !alreadyTurnBased {
-		if setErr := enc.SetMode(core.ModeTurnBased); setErr != nil {
-			return nil, fmt.Errorf("set mode turn_based on encounter %q: %w", input.EncounterID, setErr)
+	if alreadyTurnBased {
+		// Round-trip to force rollInitiative to include the just-added
+		// monster — see the doc comment above.
+		if setErr := enc.SetMode(core.ModeFreeRoam); setErr != nil {
+			return nil, fmt.Errorf("reset encounter %q to free_roam before re-rolling initiative: %w", input.EncounterID, setErr)
 		}
+	}
+	if setErr := enc.SetMode(core.ModeTurnBased); setErr != nil {
+		return nil, fmt.Errorf("set mode turn_based on encounter %q: %w", input.EncounterID, setErr)
 	}
 
 	updated := enc.ToData()
@@ -157,4 +170,23 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 		PlayerCount:         len(updated.Players),
 		MonsterCount:        len(updated.Monsters),
 	}, nil
+}
+
+// maxOccupiedQ returns the highest Q coordinate occupied by any player or
+// monster in data, or -1 if the encounter is empty. Used to place a newly
+// injected monster one hex past the party's leading edge, computed from
+// actual positions rather than assumed from any particular spawn layout.
+func maxOccupiedQ(data *tkenc.Data) int {
+	maxQ := -1
+	for _, pd := range data.Players {
+		if pd.View != nil && pd.View.Position.Q > maxQ {
+			maxQ = pd.View.Position.Q
+		}
+	}
+	for _, md := range data.Monsters {
+		if md.Position.Q > maxQ {
+			maxQ = md.Position.Q
+		}
+	}
+	return maxQ
 }

--- a/internal/pkg/devcombat/inject_test.go
+++ b/internal/pkg/devcombat/inject_test.go
@@ -74,13 +74,19 @@ func (s *InjectSuite) TestInject_AddsGoblinAndFlipsToTurnBased() {
 	data, err := s.repo.Get(s.ctx, encID)
 	s.Require().NoError(err)
 	s.Require().Equal(core.ModeTurnBased, data.Mode)
-	s.Require().NotEmpty(data.Initiative, "SetMode(TurnBased) must roll initiative")
+	s.Require().Contains(data.Initiative, out.GoblinID, "the goblin must be in the rolled initiative order, or it can never take a turn")
+	s.Require().Contains(data.Initiative, core.EntityID("char-alice"))
+	s.Require().Contains(data.Initiative, core.EntityID("char-bob"))
 
 	goblin, ok := data.Monsters["goblin-1"]
 	s.Require().True(ok)
 	s.Require().Positive(goblin.HP)
 	s.Require().Positive(goblin.AC)
 	s.Require().NotEmpty(goblin.DataJSON, "goblin must carry DataJSON — monster.NewGoblin, not a hand-rolled stub")
+	// alice (Q:0) and bob (Q:1) are the party's leading edge; the goblin must
+	// land one hex past it (Q:2), not two (the off-1 bug Copilot review
+	// caught on rpg-api#635), and not stacked on either player.
+	s.Require().Equal(2, goblin.Position.Q, "goblin must spawn adjacent to the party's leading edge, not two hexes past it")
 
 	alice, ok := data.Players["alice"]
 	s.Require().True(ok, "existing player must survive injection")
@@ -90,11 +96,15 @@ func (s *InjectSuite) TestInject_AddsGoblinAndFlipsToTurnBased() {
 	s.Require().Empty(alice.DamageDice)
 }
 
-// TestInject_AlreadyTurnBased_SkipsRedundantSetMode proves a second injection
-// against an in-progress fight doesn't hit the toolkit's "mode is already
-// turn_based" SetMode rejection — it adds another goblin (goblin-2, keyed off
-// the current monster count) and leaves the mode/initiative alone.
-func (s *InjectSuite) TestInject_AlreadyTurnBased_SkipsRedundantSetMode() {
+// TestInject_AlreadyTurnBased_ReRollsInitiativeForNewMonster proves a second
+// injection against an in-progress fight doesn't hit the toolkit's "mode is
+// already turn_based" SetMode rejection — Inject round-trips FREE_ROAM ->
+// TURN_BASED to force a fresh roll — and, critically, that the added goblin
+// (goblin-2, keyed off the current monster count) actually lands in the
+// re-rolled Initiative order. AddMonster alone never touches Initiative, so
+// without the round-trip a mid-fight monster would sit in the encounter
+// forever without ever getting a turn.
+func (s *InjectSuite) TestInject_AlreadyTurnBased_ReRollsInitiativeForNewMonster() {
 	const encID = "lobby-enc-2"
 	s.seedLobbyLikeEncounter(encID)
 
@@ -110,6 +120,9 @@ func (s *InjectSuite) TestInject_AlreadyTurnBased_SkipsRedundantSetMode() {
 	data, err := s.repo.Get(s.ctx, encID)
 	s.Require().NoError(err)
 	s.Require().Len(data.Monsters, 2)
+	s.Require().Equal(core.ModeTurnBased, data.Mode)
+	s.Require().Contains(data.Initiative, out.GoblinID, "the newly injected goblin must be in the re-rolled initiative order, or it can never take a turn")
+	s.Require().Contains(data.Initiative, core.EntityID("goblin-1"), "the first goblin must still be in the re-rolled initiative order")
 }
 
 // TestInject_MissingEncounter_ReturnsErrNotFound proves --inject-combat

--- a/internal/pkg/devcombat/inject_test.go
+++ b/internal/pkg/devcombat/inject_test.go
@@ -1,0 +1,122 @@
+package devcombat_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-api/internal/pkg/devcombat"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// InjectSuite covers devcombat.Inject: the shared load/AddMonster/SetMode/save
+// logic behind cmd/devseed's --inject-combat flag AND the lobby integration
+// test's combat-entry step (rpg-api#634).
+type InjectSuite struct {
+	suite.Suite
+	ctx  context.Context
+	repo encountersv2.Repository
+}
+
+func TestInjectSuite(t *testing.T) {
+	suite.Run(t, new(InjectSuite))
+}
+
+func (s *InjectSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.repo = encountersv2.NewInMemory()
+}
+
+// seedLobbyLikeEncounter writes a two-player encounter matching what the
+// lobby StartEncounter RPC produces post-#634 Part 1: real HP/AC, FreeRoam
+// mode, no monsters, no AttackBonus/DamageDice/DamageType/DataJSON.
+func (s *InjectSuite) seedLobbyLikeEncounter(encID string) {
+	transport := tkenc.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := tkenc.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 14, MaxHP: 14, AC: 13,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+}
+
+// TestInject_AddsGoblinAndFlipsToTurnBased is the headline #634 Part 2 proof:
+// injection adds a real, honest goblin (HP/AC/DataJSON all set) and rolls
+// initiative, without rebuilding or mutating the encounter's existing
+// players (which stay in their honest #634 Part 1 shape: no
+// AttackBonus/DamageDice/DamageType, no DataJSON).
+func (s *InjectSuite) TestInject_AddsGoblinAndFlipsToTurnBased() {
+	const encID = "lobby-enc-1"
+	s.seedLobbyLikeEncounter(encID)
+
+	out, err := devcombat.Inject(s.ctx, s.repo, devcombat.InjectInput{EncounterID: encID})
+	s.Require().NoError(err)
+	s.Require().Equal(core.EntityID("goblin-1"), out.GoblinID)
+	s.Require().Equal(core.ModeTurnBased, out.Mode)
+	s.Require().False(out.AlreadySetTurnBased)
+	s.Require().Equal(2, out.PlayerCount)
+	s.Require().Equal(1, out.MonsterCount)
+
+	data, err := s.repo.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	s.Require().Equal(core.ModeTurnBased, data.Mode)
+	s.Require().NotEmpty(data.Initiative, "SetMode(TurnBased) must roll initiative")
+
+	goblin, ok := data.Monsters["goblin-1"]
+	s.Require().True(ok)
+	s.Require().Positive(goblin.HP)
+	s.Require().Positive(goblin.AC)
+	s.Require().NotEmpty(goblin.DataJSON, "goblin must carry DataJSON — monster.NewGoblin, not a hand-rolled stub")
+
+	alice, ok := data.Players["alice"]
+	s.Require().True(ok, "existing player must survive injection")
+	s.Require().Equal(14, alice.AC)
+	s.Require().Equal(12, alice.HP)
+	s.Require().Zero(alice.AttackBonus, "injection must not mutate the existing honest #634 Part 1 snapshot")
+	s.Require().Empty(alice.DamageDice)
+}
+
+// TestInject_AlreadyTurnBased_SkipsRedundantSetMode proves a second injection
+// against an in-progress fight doesn't hit the toolkit's "mode is already
+// turn_based" SetMode rejection — it adds another goblin (goblin-2, keyed off
+// the current monster count) and leaves the mode/initiative alone.
+func (s *InjectSuite) TestInject_AlreadyTurnBased_SkipsRedundantSetMode() {
+	const encID = "lobby-enc-2"
+	s.seedLobbyLikeEncounter(encID)
+
+	_, err := devcombat.Inject(s.ctx, s.repo, devcombat.InjectInput{EncounterID: encID})
+	s.Require().NoError(err)
+
+	out, err := devcombat.Inject(s.ctx, s.repo, devcombat.InjectInput{EncounterID: encID})
+	s.Require().NoError(err, "a second injection must not fail on the toolkit's redundant-SetMode rejection")
+	s.Require().Equal(core.EntityID("goblin-2"), out.GoblinID)
+	s.Require().True(out.AlreadySetTurnBased)
+	s.Require().Equal(2, out.MonsterCount)
+
+	data, err := s.repo.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	s.Require().Len(data.Monsters, 2)
+}
+
+// TestInject_MissingEncounter_ReturnsErrNotFound proves --inject-combat
+// against a nonexistent encounter ID fails loudly (and identifiably via
+// errors.Is) instead of silently seeding nothing.
+func (s *InjectSuite) TestInject_MissingEncounter_ReturnsErrNotFound() {
+	_, err := devcombat.Inject(s.ctx, s.repo, devcombat.InjectInput{EncounterID: "no-such-encounter"})
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, encountersv2.ErrNotFound))
+}


### PR DESCRIPTION
Closes #634

Board #19 "The Dungeon Run" — opens The Dungeon leg.

## What this does

**Part 1 (production)**: `StartEncounter` (`internal/orchestrators/lobby/start_encounter.go`) now seeds each ready member's `tkenc.PlayerInput.AC` honestly from the stored character's `ArmorClass` (the character is already fetched for HP seeding — see `seedMemberCombatSnapshot` in `character.go`). `AttackBonus`/`DamageDice`/`DamageType` stay zero-value on purpose: a stored character carries no precomputed field for them — they're derived at attack time from equipped weapon + ability scores + proficiency bonus, real rules math rpg-api must not duplicate.

**Part 2 (dev tooling)**: `cmd/devseed` gains `--inject-combat --encounter-id=<id>`: loads an EXISTING encounter, adds a goblin (`monster.NewGoblin`, same DataJSON pattern every other devseed fixture uses), flips it to `TURN_BASED` (skipped if already turn-based, so re-running mid-fight adds another goblin instead of erroring), and saves — without rebuilding the encounter or touching its players. The actual logic lives in a new `internal/pkg/devcombat` package (`Inject`, Input/Output-typed) rather than in `cmd/devseed/main.go`, because `package main` can't be imported — both the CLI flag and the new integration test call the identical code path.

## Load-bearing

`StartEncounter`'s AC seed alone does **not** unblock combat — the toolkit's `isPlayerCombatant` gate (`encounter/combat.go`) rejected every lobby-created player regardless, because it checked the flat `AC`/`DamageDice` snapshot even though the v2 encounter orchestrator's **existing** `characterData.Attach` cascade (`hydrate_players.go`) already rehydrates every lobby-created player from the character store on every combat-capable RPC (TakeAction/EndTurn/MoveEntity/SubmitCheckReaction), keyed off `PlayerData.EntityID` — which `StartEncounter` already set correctly. The real `Dnd5eCombatResolver` completely ignores the flat snapshot once a seat is hydrated (it drives damage off the held `*character.Character`'s real equipped weapon via `Character.WeaponForActionRef`); the flat fields only feed the stand-in fallback for an un-hydrated seat.

Investigated both honest paths per the issue: (i) deriving a snapshot from stored data — dead end, `character.Data` has no attack-bonus/damage-dice field to copy; (ii) a small toolkit seam — this is it. **Implemented on rpg-toolkit branch [`fix/combat-gate-hydration`](https://github.com/KirkDiggler/rpg-toolkit/tree/fix/combat-gate-hydration)** (pushed, not yet opened as a PR — batching per the standing local-override-until-unit-done pattern rather than rushing out a standalone toolkit PR). `isPlayerCombatant` now also passes when the seat carries `DataJSON` (hydrated), independent of the flat snapshot.

**Until rpg-api's `go.mod` bumps past the toolkit release containing that fix**, the integration test proving the full path end-to-end (`TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves`) is `s.T().Skip()`'d right at the `TakeAction` assertion, with the reason and toolkit branch name in the skip message. Everything before the skip (inject combat, mode flips to TURN_BASED, initiative includes every player + the goblin) runs and asserts unconditionally — only the final "attack actually resolves" step is gated. Verified locally against a `replace` directive pointing at that branch: with it, the assertion passes (`TakeAction` succeeds instead of returning `ErrNonCombatant`); against the currently published `v0.24.3` it fails with `ErrNonCombatant: missing HP/AC/DamageDice`, confirming the test genuinely depends on the toolkit fix and not just the harness fix below.

**Bonus finding, fixed in this PR**: the integration test harness's v1alpha2 `EncounterService` handler had **zero** `CharacterRepo` wiring (unlike `cmd/server/server.go`'s production wiring), so the `characterData.Attach` hydration cascade silently never ran in *any* existing integration test — every prior combat test worked only because it hand-seeded explicit `AttackBonus`/`DamageDice` on `PlayerInput` directly. This would have silently defeated the very story #634 needs to prove, so I fixed `internal/integration/harness/harness.go` to mirror production wiring. Verified the full `internal/integration/...` suite still passes after the change.

## Docs

`docs/status.md` gets a new "A real fight on GameView" entry; `docs/architecture/components/lobby-service.md` and `docs/architecture/components/integration-test-harness.md` updated to describe the renamed/extended `seedMemberCombatSnapshot`, the devseed injection tool, the new combat-entry test, and the harness wiring fix.

## Playtest

The orchestrator playtests this branch via MCP before merge (goblin visible, ActionMenu live in TURN_BASED, attack lands with damage, turns cycle, goblin dies) — that verification is **blocked on the toolkit bump** the same way the integration test is, since the gate fix is what makes a real attack possible at all.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test -race ./...` green (one test intentionally skipped, see above)
- `golangci-lint run ./...`: 74 issues repo-wide, none attributable to touched files (verified via a scoped lint pass + per-file cross-reference against the full-repo run)
- Full `internal/integration/...` suite passes (testcontainers Redis, real gRPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
