### PR TITLE
fix(encounter): drive NPC turns at combat entry — no more NPC-first stalls

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -193,6 +193,9 @@ func run() error {
 			"Load the EXISTING encounter at --encounter-id, add a goblin, and flip it to TURN_BASED, "+
 				"instead of seeding a fresh fixture. Requires an already-persisted encounter (e.g. one "+
 				"created via the lobby StartEncounter RPC). Ignores --mode and --fixture.")
+		injectCombatNPCFirst = flag.Bool("inject-combat-npc-first", false,
+			"With --inject-combat, force the injected goblin to lead initiative (rpg-api#636 repro) "+
+				"instead of leaving turn order to the real roll. No effect without --inject-combat.")
 	)
 	flag.Parse()
 
@@ -235,7 +238,7 @@ func run() error {
 	}
 
 	if *injectCombat {
-		return runInjectCombat(ctx, client, *encounterID)
+		return runInjectCombat(ctx, client, *encounterID, *injectCombatNPCFirst)
 	}
 
 	var chars []*toolkitchar.Data
@@ -325,10 +328,13 @@ func run() error {
 // imported by other packages, so the actual load/AddMonster/SetMode/save
 // logic — including its known-gap documentation — lives in that package, not
 // here). See devcombat.Inject's doc comment for what it does and why.
-func runInjectCombat(ctx context.Context, client redisclient.Client, encounterID string) error {
+func runInjectCombat(ctx context.Context, client redisclient.Client, encounterID string, forceNPCFirst bool) error {
 	repo := encountersv2.NewRedis(client, encTTL)
 
-	out, err := devcombat.Inject(ctx, repo, devcombat.InjectInput{EncounterID: encounterID})
+	out, err := devcombat.Inject(ctx, repo, devcombat.InjectInput{
+		EncounterID:   encounterID,
+		ForceNPCFirst: forceNPCFirst,
+	})
 	if err != nil {
 		if errors.Is(err, encountersv2.ErrNotFound) {
 			return fmt.Errorf(
@@ -342,6 +348,9 @@ func runInjectCombat(ctx context.Context, client redisclient.Client, encounterID
 
 	if out.AlreadySetTurnBased {
 		fmt.Fprintf(os.Stderr, "devseed --inject-combat: encounter %s was already TURN_BASED, re-rolled initiative to include the new monster\n", encounterID)
+	}
+	if forceNPCFirst {
+		fmt.Fprintf(os.Stderr, "devseed --inject-combat-npc-first: goblin %s forced to lead initiative (rpg-api#636 repro)\n", out.GoblinID)
 	}
 	fmt.Fprintf(
 		os.Stderr,

--- a/cmd/devseed/main_test.go
+++ b/cmd/devseed/main_test.go
@@ -95,7 +95,7 @@ func TestRunInjectCombat_DelegatesToDevcombat(t *testing.T) {
 		t.Fatalf("Save seeded encounter: %v", err)
 	}
 
-	if err := runInjectCombat(ctx, client, encID); err != nil {
+	if err := runInjectCombat(ctx, client, encID, false); err != nil {
 		t.Fatalf("runInjectCombat: %v", err)
 	}
 	data, err := repo.Get(ctx, encID)
@@ -106,11 +106,49 @@ func TestRunInjectCombat_DelegatesToDevcombat(t *testing.T) {
 		t.Fatalf("runInjectCombat did not apply devcombat.Inject's effect: mode=%v monsters=%d", data.Mode, len(data.Monsters))
 	}
 
-	err = runInjectCombat(ctx, client, "no-such-encounter")
+	err = runInjectCombat(ctx, client, "no-such-encounter", false)
 	if err == nil {
 		t.Fatal("expected an error for a missing encounter")
 	}
 	if !strings.Contains(err.Error(), "StartEncounter RPC") {
 		t.Fatalf("expected an actionable devseed error message, got: %v", err)
+	}
+}
+
+// TestRunInjectCombat_ForceNPCFirst_DelegatesToDevcombat proves the
+// --inject-combat-npc-first wiring: runInjectCombat forwards forceNPCFirst to
+// devcombat.Inject's ForceNPCFirst input, which is where the deterministic
+// reorder actually happens (see devcombat's own TestInject_ForceNPCFirst_
+// GoblinLeadsInitiative for that behavior's coverage) — this test only proves
+// the CLI wrapper passes the flag through.
+func TestRunInjectCombat_ForceNPCFirst_DelegatesToDevcombat(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+	repo := encountersv2.NewRedis(client, time.Hour)
+
+	const encID = "lobby-enc-npc-first"
+	enc := tkenc.New(ctx, encountercore.EncounterID(encID), tkenc.NewBroker(tkenc.NewInMemoryTransport()))
+	if err := enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: encountercore.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+	}); err != nil {
+		t.Fatalf("AddPlayer alice: %v", err)
+	}
+	if err := repo.Save(ctx, enc.ToData()); err != nil {
+		t.Fatalf("Save seeded encounter: %v", err)
+	}
+
+	if err := runInjectCombat(ctx, client, encID, true); err != nil {
+		t.Fatalf("runInjectCombat: %v", err)
+	}
+	data, err := repo.Get(ctx, encID)
+	if err != nil {
+		t.Fatalf("Get after inject: %v", err)
+	}
+	if data.ActiveIdx != 0 || len(data.Initiative) == 0 || data.Initiative[0] != "goblin-1" {
+		t.Fatalf("runInjectCombat did not forward ForceNPCFirst: active_idx=%d initiative=%v", data.ActiveIdx, data.Initiative)
 	}
 }

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api quality scorecard
 description: Per-component grade with rationale — a graded scorecard to update as the codebase evolves
-updated: 2026-05-25
-confidence: medium — Wave 2.11e encounter v2 graded from shipped-code + integration test verification; older entries reflect 2026-05-02 snapshot pending refresh
+updated: 2026-07-11
+confidence: medium — Wave 2.11e encounter v2 graded from shipped-code + integration test verification; older entries reflect 2026-05-02 snapshot pending refresh; rpg-api#636 note verified against passing tests
 ---
 
 # Quality Scorecard
@@ -107,7 +107,13 @@ What's here as of Wave 2.11e:
 - `EndTurn` (`end_turn.go`) — handles `IsNPCPausedForReaction(err)`;
   `serializePendingPhasedAttacks` marshals the live `*PhasedAttackContext`
   into `AttackContextJSON` before snapshot (honors the encounter SDK's
-  HOST CONTRACT documented in `persistNPCPendingReactions`).
+  HOST CONTRACT documented in `persistNPCPendingReactions`). rpg-api#636: its
+  NPC dispatch loop is now the shared `driveNPCChain`, also used by
+  `DriveStalledNPCTurn` (`drive_npc.go`) — the "combat-entry kick" that
+  `StreamEncounter`/`GetEncounter` call (best-effort, error-swallowed) at every
+  connect so a TURN_BASED encounter that starts with an NPC active (no
+  preceding `EndTurn` to chain off of) doesn't stall forever. Single-flighted
+  per encounter ID (`keyed_mutex.go`) against concurrent connects.
 - `applyReactionConditions` + `applyMonsterReactionConditions`
   (`reaction_conditions.go`) — wires OA on every character and monster +
   Shield on spellcasters. Both applied at every rehydration; idempotent.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-29
-confidence: high — Wave 2 Monk entries verified against passing integration tests
+updated: 2026-07-11
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests
 ---
 
 # rpg-api: Where We Are
@@ -10,6 +10,55 @@ confidence: high — Wave 2 Monk entries verified against passing integration te
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**NPC-first initiative no longer stalls the encounter (rpg-api#636, 2026-07-11)** —
+`Orchestrator.EndTurn`'s NPC dispatch loop only ever ran as the tail of an `EndTurn`
+call — but when a TURN_BASED encounter's very FIRST active actor is an NPC (today:
+`devseed --inject-combat` rolling the goblin first; the future real combat-entry
+trigger doing the same), there is no preceding `EndTurn` to chain off of: every player
+is correctly locked out (not their turn) and nothing ever calls `NPCAct`. The
+encounter stalled forever.
+
+Fix: the NPC dispatch loop is factored out of `EndTurn` into a shared
+`Orchestrator.driveNPCChain` (`internal/orchestrators/encounter/v2/end_turn.go`) that
+owns every persist on every exit path, so both `EndTurn` and a new
+`Orchestrator.DriveStalledNPCTurn` (`drive_npc.go`) can run the identical
+NPCAct+EndTurn cycle. `DriveStalledNPCTurn` is the "combat-entry kick": it loads the
+encounter and, if the active actor is an NPC, drives it (and any chained NPC turns
+after it) until a player is active, the encounter ends, or the chain cap is reached.
+`StreamEncounter` and `GetEncounter` (`handler.go`, `get.go`) both call it — as
+best-effort, error-swallowing self-heals — at the top of every connect-time read,
+since those are the only "first touch" available for an out-of-process write like
+today's devseed injection (the server never otherwise observes combat starting).
+`StreamEncounter` kicks BEFORE `Subscribe` (not after) so the kick's own NPCAct/
+EndTurn broker events fan out live to already-connected viewers without also
+replaying as a redundant post-snapshot event for the connecting client itself — see
+the handler's doc comment for the full ordering rationale.
+
+Concurrency: up to N clients can hit `StreamEncounter`/`GetEncounter` for the same
+encounter at once (e.g. four players reconnecting together), and the toolkit's own
+"am I still the active actor" guard inside `NPCAct` only protects the in-memory copy
+the CALLER loaded — it does not protect across independently loaded snapshots. A new
+per-encounter `keyedMutex` (`keyed_mutex.go`, duplicated from the lobby
+orchestrator's identical single-process pattern rather than shared across packages)
+single-flights `DriveStalledNPCTurn` per encounter ID: only the first caller does
+real work; every other concurrent caller blocks, then re-loads the
+already-persisted post-drive state and no-ops.
+
+The future real (server-side, in-process) combat-entry trigger does NOT need the
+`StreamEncounter`/`GetEncounter` kick at all — it can (and should) call
+`driveNPCChain` directly right after its own `SetMode`, since it IS the server
+observing combat start. The kick exists specifically for paths that bypass normal
+server verbs, today's devseed injection being the only one.
+
+`devcombat.Inject` gained a `ForceNPCFirst` input (`internal/pkg/devcombat/inject.go`)
+that deterministically reorders the freshly-rolled Initiative so the injected goblin
+leads it, instead of depending on a lucky roll to reproduce the stall — exposed as
+`devseed --inject-combat --inject-combat-npc-first` for manual playtest repro, and
+used by the new `TestPartyAssembles_FourPlayers_ThenCombatEntry_
+NPCFirstInitiative_StreamDrivesNPCTurn` integration test
+(`internal/integration/lobby_v1alpha1_test.go`), which drives the fix through the
+real `StreamEncounter` RPC end-to-end (not a direct toolkit/repo manipulation).
 
 **LobbyService v1alpha1 — party assembly + sole encounter construction path (rpg-api#629, 2026-07-07)** —
 New `internal/handlers/dnd5e/lobby/v1alpha1` → `internal/orchestrators/lobby` →

--- a/internal/handlers/dnd5e/v2/encounter/get.go
+++ b/internal/handlers/dnd5e/v2/encounter/get.go
@@ -3,12 +3,14 @@ package encounter
 import (
 	"context"
 	"errors"
+	"log"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/auth"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
@@ -23,6 +25,21 @@ func (h *Handler) GetEncounter(ctx context.Context, req *encounterv2pb.GetEncoun
 	}
 	if req.GetEncounterId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+
+	// rpg-api#636 combat-entry kick: GetEncounter is a connect-time read path
+	// (project.go pairs it with StreamEncounter's snapshot as the two callers
+	// of ProjectFor), so it gets the same best-effort self-heal — see
+	// StreamEncounter's doc comment below for the full rationale. Errors are
+	// logged and swallowed: a kick failure must never turn a read into a
+	// failed RPC, and DriveStalledNPCTurn's own membership check is stricter
+	// than what GetEncounter enforces below, so a non-member's read must not
+	// be gated by the kick's internal load.
+	if _, kickErr := h.orch.DriveStalledNPCTurn(ctx, &encounterorch.DriveStalledNPCTurnInput{
+		EncounterID: req.GetEncounterId(),
+		PlayerID:    core.PlayerID(playerID),
+	}); kickErr != nil {
+		log.Printf("encounter/v2 GetEncounter: combat-entry kick failed for %q: %v", req.GetEncounterId(), kickErr)
 	}
 
 	data, err := h.encRepo.Get(ctx, req.GetEncounterId())

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -255,9 +255,12 @@ func moveEntityStatusError(err error) error {
 // It emits an initial SnapshotDelivered event immediately, then forwards all
 // subsequent broker events for the encounter until the client disconnects.
 //
-// Subscribe-before-snapshot ordering is intentional: subscribing first ensures
-// no events are missed while the snapshot is being built. The broker's buffered
-// channel holds any in-flight events until the forward loop starts.
+// Subscribe-before-snapshot ordering is intentional for everything AFTER the
+// #636 kick below: once subscribed, no POST-subscribe event is missed while
+// the snapshot is being built — the broker's buffered channel holds any
+// in-flight event until the forward loop starts. This guarantee deliberately
+// does NOT cover the kick's own events (see the #636 paragraph immediately
+// below for why those are excluded on purpose, not a gap in this guarantee).
 //
 // rpg-api#636 combat-entry kick: run BEFORE Subscribe, not after. A TURN_BASED
 // encounter whose active actor is an NPC never gets driven by anything if
@@ -297,9 +300,10 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 		log.Printf("encounter/v2 StreamEncounter: combat-entry kick failed for %q: %v", string(encID), kickErr)
 	}
 
-	// Subscribe FIRST so the broker holds events in its buffered channel while
-	// we build the snapshot. Any event firing between Subscribe and the forward
-	// loop is captured and delivered after the snapshot send.
+	// Subscribe (now that the #636 kick above has already run) so the broker
+	// holds events in its buffered channel while we build the snapshot. Any
+	// event firing between THIS Subscribe call and the forward loop is
+	// captured and delivered after the snapshot send.
 	sub, err := h.broker.Subscribe(encID, core.PlayerID(playerID))
 	if err != nil {
 		return status.Errorf(codes.Internal, "subscribe %q: %v", string(encID), err)

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -258,6 +258,27 @@ func moveEntityStatusError(err error) error {
 // Subscribe-before-snapshot ordering is intentional: subscribing first ensures
 // no events are missed while the snapshot is being built. The broker's buffered
 // channel holds any in-flight events until the forward loop starts.
+//
+// rpg-api#636 combat-entry kick: run BEFORE Subscribe, not after. A TURN_BASED
+// encounter whose active actor is an NPC never gets driven by anything if
+// nothing preceded this connect with an EndTurn (today: devseed
+// --inject-combat writes Redis out-of-process, so the server never otherwise
+// observes combat starting; the same gap applies to any future reconnect into
+// an NPC-active encounter). DriveStalledNPCTurn is the same NPCAct+EndTurn
+// dispatch loop EndTurn's own NPC chain uses (see
+// orchestrators/encounter/v2/drive_npc.go); calling it here makes
+// StreamEncounter/GetEncounter self-healing for that stall without special-
+// casing the dev tool. Kicking BEFORE Subscribe (rather than after, per the
+// brief's other candidate ordering) means the kick's own NPCAct/EndTurn broker
+// events do NOT land in THIS connection's buffered channel — they fan out live
+// to any OTHER already-subscribed viewers (who correctly see the goblin's turn
+// resolve in real time), while this connecting client's snapshot (built after,
+// from freshly re-read post-kick data) simply reflects the already-current
+// state instead of replaying its own kick as a redundant post-snapshot event.
+// Errors are logged and swallowed — a kick failure (or a caller who isn't a
+// member, which DriveStalledNPCTurn's load enforces more strictly than this
+// handler ever has) must never block the read; the subsequent membership-blind
+// snapshot flow below is unchanged from pre-#636 behavior on any kick failure.
 func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, stream encounterv2pb.EncounterService_StreamEncounterServer) error {
 	ctx := stream.Context()
 	playerID := auth.GetPlayerID(ctx)
@@ -267,6 +288,13 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 	encID := core.EncounterID(req.GetEncounterId())
 	if encID == "" {
 		return status.Error(codes.InvalidArgument, "encounter_id is required")
+	}
+
+	if _, kickErr := h.orch.DriveStalledNPCTurn(ctx, &encounterorch.DriveStalledNPCTurnInput{
+		EncounterID: string(encID),
+		PlayerID:    core.PlayerID(playerID),
+	}); kickErr != nil {
+		log.Printf("encounter/v2 StreamEncounter: combat-entry kick failed for %q: %v", string(encID), kickErr)
 	}
 
 	// Subscribe FIRST so the broker holds events in its buffered channel while

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -322,6 +322,108 @@ func (s *LobbyV1alpha1IntegrationSuite) advanceUntilPlayerActive(data *tkenc.Dat
 	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, data))
 }
 
+// TestPartyAssembles_FourPlayers_ThenCombatEntry_NPCFirstInitiative_StreamDrivesNPCTurn
+// is the rpg-api#636 regression: it repeats the same
+// create/join/ready/start/inject flow as
+// TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves, but forces
+// the injected goblin to lead initiative via devcombat.Inject's
+// ForceNPCFirst knob — the SAME deterministic reorder `devseed --inject-combat
+// --inject-combat-npc-first` uses for manual repro — instead of relying on a
+// lucky roll. Pre-#636, nothing ever drove the goblin's turn in this
+// state: EndTurn's NPC dispatch loop only ran as a tail of an EndTurn call,
+// and there was none to chain off of (every player is correctly locked out
+// since it isn't their turn), so the encounter stalled forever.
+//
+// The proof is StreamEncounter itself: connecting via the production RPC (not
+// a direct toolkit/repo manipulation, unlike advanceUntilPlayerActive's setup
+// helper) must come back with a player active, not the goblin — proving the
+// handler's combat-entry kick (DriveStalledNPCTurn, called before Subscribe)
+// actually drove the stalled NPC turn as a side effect of the very first
+// connect.
+func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_ThenCombatEntry_NPCFirstInitiative_StreamDrivesNPCTurn() {
+	players := []struct {
+		id, character, name string
+		hp                  int
+	}{
+		{"alice", "char-alice", "Alice", 12},
+		{"bob", "char-bob", "Bob", 10},
+		{"carol", "char-carol", "Carol", 14},
+		{"dave", "char-dave", "Dave", 8},
+	}
+	for _, p := range players {
+		s.seedCharacter(p.character, p.id, p.name, p.hp)
+	}
+
+	createResp, err := s.srv.LobbyClient.CreateLobby(s.authCtx("alice"), &lobbyv1alpha1.CreateLobbyRequest{
+		CampaignId: "campaign-1", CharacterId: "char-alice",
+	})
+	s.Require().NoError(err)
+	lobbyID := createResp.GetLobbyId()
+	joinRef := createResp.GetJoinRef()
+
+	for _, p := range players[1:] {
+		_, joinErr := s.srv.LobbyClient.JoinLobby(s.authCtx(p.id), &lobbyv1alpha1.JoinLobbyRequest{
+			JoinRef: joinRef, CharacterId: p.character,
+		})
+		s.Require().NoError(joinErr)
+	}
+	for _, p := range players {
+		_, readyErr := s.srv.LobbyClient.SetReady(s.authCtx(p.id), &lobbyv1alpha1.SetReadyRequest{
+			LobbyId: lobbyID, Ready: true,
+		})
+		s.Require().NoError(readyErr)
+	}
+
+	startResp, err := s.srv.LobbyClient.StartEncounter(s.authCtx("alice"), &lobbyv1alpha1.StartEncounterRequest{
+		LobbyId: lobbyID,
+	})
+	s.Require().NoError(err)
+	encounterID := startResp.GetEncounterId()
+	s.Require().NotEmpty(encounterID)
+
+	// rpg-api#636 repro: force the goblin to lead initiative instead of
+	// leaving it to the real roll.
+	injectOut, err := devcombat.Inject(s.ctx, s.srv.EncRepoV2, devcombat.InjectInput{
+		EncounterID:   encounterID,
+		ForceNPCFirst: true,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(core.ModeTurnBased, injectOut.Mode)
+
+	preKickData, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	s.Require().Equal(injectOut.GoblinID, preKickData.Initiative[preKickData.ActiveIdx],
+		"setup must confirm the goblin is active before the stream connects — otherwise this isn't testing the stall")
+
+	// The headline #636 proof: connecting via the production StreamEncounter
+	// RPC — the only "first touch" available for an out-of-process injection —
+	// must itself drive the stalled NPC turn. No EndTurn call precedes this;
+	// nothing else has touched the encounter since injection.
+	stream, streamErr := s.srv.EncounterClientV2.StreamEncounter(s.authCtx("alice"),
+		&encounterv2pb.StreamEncounterRequest{EncounterId: encounterID})
+	s.Require().NoError(streamErr)
+	snap, recvErr := stream.Recv()
+	s.Require().NoError(recvErr)
+	s.Require().NotNil(snap.GetSnapshotDelivered())
+
+	turnState := snap.GetSnapshotDelivered().GetEncounter().GetTurnState()
+	s.Require().NotNil(turnState, "a turn-based encounter's snapshot must carry TurnState")
+	s.NotEqual(string(injectOut.GoblinID), turnState.GetActiveEntityId(),
+		"the goblin must no longer be active by the time the snapshot is built — StreamEncounter's combat-entry kick must have driven its turn")
+
+	postKickData, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	activeEntity := postKickData.Initiative[postKickData.ActiveIdx]
+	var activeIsPlayer bool
+	for _, p := range players {
+		if activeEntity == core.EntityID(p.character) {
+			activeIsPlayer = true
+			break
+		}
+	}
+	s.Require().True(activeIsPlayer, "the active actor after the kick must be a player, not another NPC")
+}
+
 // TestJoinLobby_LateJoin_FailedPrecondition proves the "late join" edge
 // policy end-to-end: JoinLobby on a STARTED lobby is rejected, not silently
 // admitted into a mid-encounter party.

--- a/internal/orchestrators/encounter/v2/drive_npc.go
+++ b/internal/orchestrators/encounter/v2/drive_npc.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
@@ -73,6 +75,16 @@ type DriveStalledNPCTurnOutput struct {
 // does not call driveNPCChain and does not persist — so a connect-time kick on
 // every StreamEncounter/GetEncounter never costs an extra write on the common
 // case (it's already a player's turn).
+//
+// Cheap pre-check (Copilot review #638): StreamEncounter/GetEncounter call
+// this on EVERY connect-time read, and the common case is "already a
+// player's turn" — the full o.load(WithCharacterData: true) pays for a
+// character-store fetch + #598 economy seeding per player seat, which would
+// otherwise run on every single connect regardless of whether there is
+// anything to drive. A plain encRepo.Get + membership + raw-snapshot IsNPC
+// check (cheapActiveIsNPC) happens first, INSIDE the per-encounter lock so
+// the decision and the real work stay atomic; only when the raw snapshot's
+// active actor is genuinely an NPC does this pay for the expensive load.
 func (o *Orchestrator) DriveStalledNPCTurn(
 	ctx context.Context,
 	in *DriveStalledNPCTurnInput,
@@ -83,6 +95,20 @@ func (o *Orchestrator) DriveStalledNPCTurn(
 
 	unlock := o.npcDriveLocks.Lock(in.EncounterID)
 	defer unlock()
+
+	data, err := o.encRepo.Get(ctx, in.EncounterID)
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return nil, ErrEncounterNotFound
+		}
+		return nil, fmt.Errorf("check stalled npc turn %q: %w", in.EncounterID, err)
+	}
+	if _, ok := data.Players[in.PlayerID]; !ok {
+		return nil, ErrPlayerNotInEncounter
+	}
+	if !cheapActiveIsNPC(data) {
+		return &DriveStalledNPCTurnOutput{Kicked: false}, nil
+	}
 
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
@@ -98,6 +124,9 @@ func (o *Orchestrator) DriveStalledNPCTurn(
 
 	active := enc.ActiveActor()
 	if active == "" || !enc.IsNPC(active) {
+		// Raced with something else that advanced past the NPC between the
+		// cheap check above and this real load (e.g. a concurrent EndTurn
+		// outside this kick's own lock) — nothing left to drive.
 		return &DriveStalledNPCTurnOutput{Kicked: false}, nil
 	}
 
@@ -106,4 +135,23 @@ func (o *Orchestrator) DriveStalledNPCTurn(
 	}
 
 	return &DriveStalledNPCTurnOutput{Kicked: true}, nil
+}
+
+// cheapActiveIsNPC reports whether data's active actor is an NPC (a monster
+// seat), using only the raw persisted snapshot — no character-store fetch, no
+// hydration. Mirrors tkenc.Encounter's ActiveActor()/IsNPC() logic exactly
+// (rpg-toolkit encounter/encounter.go), just against *Data instead of a
+// loaded *Encounter, so DriveStalledNPCTurn's connect-time pre-check can skip
+// the expensive o.load(WithCharacterData: true) call on the common
+// "already a player's turn" case.
+func cheapActiveIsNPC(data *tkenc.Data) bool {
+	if data.Mode != core.ModeTurnBased || len(data.Initiative) == 0 {
+		return false
+	}
+	if data.ActiveIdx < 0 || data.ActiveIdx >= len(data.Initiative) {
+		return false
+	}
+	active := data.Initiative[data.ActiveIdx]
+	_, isMonster := data.Monsters[active]
+	return isMonster
 }

--- a/internal/orchestrators/encounter/v2/drive_npc.go
+++ b/internal/orchestrators/encounter/v2/drive_npc.go
@@ -1,0 +1,109 @@
+package encounter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// DriveStalledNPCTurnInput carries the parameters for DriveStalledNPCTurn.
+type DriveStalledNPCTurnInput struct {
+	// EncounterID identifies the encounter to check/drive.
+	EncounterID string
+
+	// PlayerID is the authenticated caller triggering the check (a
+	// StreamEncounter/GetEncounter connect). load verifies membership and
+	// returns ErrPlayerNotInEncounter otherwise — callers that want a
+	// best-effort, non-blocking self-heal (StreamEncounter, GetEncounter)
+	// should log and swallow that error rather than fail their own RPC on it,
+	// since a non-member's connect-time read is a pre-existing, unrelated
+	// concern this kick must not start gating.
+	PlayerID core.PlayerID
+}
+
+// DriveStalledNPCTurnOutput reports whether a stalled NPC turn was found and
+// driven.
+type DriveStalledNPCTurnOutput struct {
+	// Kicked is true when the active actor was an NPC that had not yet acted
+	// and this call ran its turn (and any chained NPC turns after it) server
+	// side. False means there was nothing to drive — the encounter is not
+	// turn-based, has no active actor, or the active actor is already a
+	// player — a legitimate, expected outcome on most calls, not an error.
+	Kicked bool
+}
+
+// DriveStalledNPCTurn is the combat-entry kick (rpg-api#636): it loads the
+// encounter and, if the active actor is an NPC, runs the SAME NPCAct+EndTurn
+// dispatch cycle EndTurn's own NPC dispatch loop uses (driveNPCChain,
+// end_turn.go) — until a player is active, the encounter ends, or the chain
+// cap is reached — then persists.
+//
+// Why this exists: EndTurn's dispatch loop only runs on the EndTurn RPC, which
+// requires the CURRENT active actor's owning player to call it. When a
+// TURN_BASED encounter's FIRST active actor is an NPC (an out-of-process
+// devseed --inject-combat roll, a devseed fixture where the monster wins
+// initiative, or — later — a real server-side combat-entry trigger that rolls
+// NPC-first), there is no preceding EndTurn to chain off of: every player is
+// correctly locked out (not their turn) and nothing ever calls NPCAct. The
+// encounter stalls forever. This method is the missing "something must drive
+// the very first NPC" seam, called from wherever the server first touches
+// such an encounter (StreamEncounter subscribe, GetEncounter — see
+// handler.go's callers) instead of being patched into the dev tool: a future
+// in-process combat-entry trigger can (and should) call this — or driveNPCChain
+// directly — right after its own SetMode, so the same fix covers both today's
+// out-of-process injection and tomorrow's real trigger.
+//
+// Single-flight per encounter (npcDriveLocks): StreamEncounter is a read path
+// that up to N clients can hit concurrently (e.g. four players reconnecting at
+// once). Without serializing, each would independently load the same
+// NPC-active snapshot, and the toolkit's own "am I still the active actor"
+// guard (NPCAct checks e.data.ActiveActor() against the in-memory copy IT
+// loaded) does not protect across separately loaded copies — every caller's
+// own load would see the NPC as active and all would dispatch its turn,
+// resolving the same attack multiple times. Locking on EncounterID for the
+// full load+drive+persist means only the first caller does real work; every
+// other concurrent caller blocks, then (once unblocked) loads the
+// ALREADY-persisted post-drive state and no-ops (Kicked=false) because the
+// active actor is by then a player.
+//
+// Idempotent when there is nothing to drive: if the active actor is not an
+// NPC (already a player, encounter not turn-based, or no active actor), this
+// does not call driveNPCChain and does not persist — so a connect-time kick on
+// every StreamEncounter/GetEncounter never costs an extra write on the common
+// case (it's already a player's turn).
+func (o *Orchestrator) DriveStalledNPCTurn(
+	ctx context.Context,
+	in *DriveStalledNPCTurnInput,
+) (*DriveStalledNPCTurnOutput, error) {
+	if in == nil {
+		return nil, errors.New("encounter orchestrator: DriveStalledNPCTurnInput is required")
+	}
+
+	unlock := o.npcDriveLocks.Lock(in.EncounterID)
+	defer unlock()
+
+	enc, err := o.load(ctx, loadInput{
+		EncounterID: in.EncounterID,
+		PlayerID:    in.PlayerID,
+		// WithCharacterData: an NPC attack can trigger a player reaction
+		// (Shield, an opportunity attack readiness check), which needs the
+		// reactor's held character — same requirement as EndTurn's own load.
+		WithCharacterData: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	active := enc.ActiveActor()
+	if active == "" || !enc.IsNPC(active) {
+		return &DriveStalledNPCTurnOutput{Kicked: false}, nil
+	}
+
+	if err := o.driveNPCChain(ctx, enc, in.EncounterID, active, true); err != nil {
+		return nil, fmt.Errorf("drive stalled npc turn %q: %w", in.EncounterID, err)
+	}
+
+	return &DriveStalledNPCTurnOutput{Kicked: true}, nil
+}

--- a/internal/orchestrators/encounter/v2/drive_npc_test.go
+++ b/internal/orchestrators/encounter/v2/drive_npc_test.go
@@ -1,0 +1,268 @@
+package encounter_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// DriveStalledNPCTurn orchestrator tests (rpg-api#636). These prove the
+// combat-entry kick — the seam that fixes "TURN_BASED begins with an NPC as
+// the FIRST active actor and nothing ever drives it, because the NPC dispatch
+// loop only ever ran as a tail of EndTurn":
+//   - the active actor being an NPC drives exactly one NPC turn (and persists);
+//   - a chain of consecutive NPCs cascades all the way to the first player,
+//     exactly like EndTurn's own dispatch loop (driveNPCChain is shared code);
+//   - the active actor already being a player is a true no-op (Kicked=false,
+//     no NPCAct dispatched);
+//   - concurrent kicks against the SAME encounter single-flight: only ONE of N
+//     concurrent callers actually drives the NPC turn, proving the keyed
+//     mutex — not the toolkit's own in-memory ActiveActor guard, which cannot
+//     protect across independently loaded snapshots — prevents the same NPC
+//     turn from being dispatched more than once.
+
+const (
+	dnEncID     = "enc-drive-npc"
+	dnPlayerBob = "bob"
+	dnEntityBob = "char-bob-dn"
+	dnGoblinID  = "goblin-dn"
+	dnGoblin2ID = "goblin-dn-2"
+)
+
+type DriveStalledNPCTurnSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *DriveStalledNPCTurnSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		// Stand-in combat resolver, same choice as EndTurnSuite: no DataJSON is
+		// seeded on the goblins, so NPCAct takes the scripted single-phase path —
+		// isolating the load -> drive -> persist contract from rulebook combat
+		// math (a real d20 roll decides hit/miss, but every assertion here is
+		// about WHETHER/HOW OFTEN a turn was dispatched, not its outcome).
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return v2encounter.NewStandInCombatResolver(nil)
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		ReactionResume: encounterorch.ReactionResume{
+			MarshalAttackContext: func(_ *tkenc.PhasedAttackContext) ([]byte, error) {
+				return []byte(`{}`), nil
+			},
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedTurnBased persists a turn-based encounter with bob (player) and the
+// given monster IDs, forcing the initiative order + active index so the
+// active-actor state is deterministic regardless of the toolkit's own
+// initiative roll. Mirrors EndTurnSuite.seedTurnBased in end_turn_test.go
+// (duplicated rather than shared across suite types for a ~30-line helper —
+// same call this package already made).
+func (s *DriveStalledNPCTurnSuite) seedTurnBased(encID string, monsterIDs []core.EntityID, initiative []core.EntityID, activeIdx int) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    dnPlayerBob,
+		EntityID:    dnEntityBob,
+		Position:    core.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  "slashing",
+	}))
+	for i, mid := range monsterIDs {
+		s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+			ID:          mid,
+			Position:    core.Hex{Q: i + 1, R: 0, S: -(i + 1)},
+			HP:          7,
+			MaxHP:       7,
+			AC:          15,
+			Speed:       6,
+			MonsterRef:  "dnd5e:monsters:goblin",
+			AttackBonus: 4,
+			DamageDice:  "1d6+2",
+			DamageType:  "slashing",
+		}))
+	}
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	data := enc.ToData()
+	data.Initiative = initiative
+	data.ActiveIdx = activeIdx
+	s.Require().NoError(s.repo.Save(s.ctx, data))
+}
+
+func (s *DriveStalledNPCTurnSuite) kick(encID string) (*encounterorch.DriveStalledNPCTurnOutput, error) {
+	return s.orch.DriveStalledNPCTurn(s.ctx, &encounterorch.DriveStalledNPCTurnInput{
+		EncounterID: encID,
+		PlayerID:    dnPlayerBob,
+	})
+}
+
+// --- nil input ---
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_NilInput_Error() {
+	_, err := s.orch.DriveStalledNPCTurn(s.ctx, nil)
+	s.Require().Error(err)
+}
+
+// --- load preconditions surface the same sentinels as every other verb ---
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_MissingEncounter_ErrEncounterNotFound() {
+	_, err := s.kick("nope")
+	s.Require().ErrorIs(err, encounterorch.ErrEncounterNotFound)
+}
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_PlayerNotInEncounter_ErrPlayerNotInEncounter() {
+	enc := tkenc.New(s.ctx, "enc-dn-no-player", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "other", EntityID: "other-char", Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	_, err := s.kick("enc-dn-no-player")
+	s.Require().ErrorIs(err, encounterorch.ErrPlayerNotInEncounter)
+}
+
+// --- no-op cases: nothing to drive, no persist implied ---
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_PlayerAlreadyActive_NoOp() {
+	s.seedTurnBased(dnEncID, []core.EntityID{dnGoblinID}, []core.EntityID{dnEntityBob, dnGoblinID}, 0)
+
+	out, err := s.kick(dnEncID)
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+	s.False(out.Kicked, "the active actor is already a player — there is nothing to drive")
+
+	loaded, getErr := s.repo.Get(s.ctx, dnEncID)
+	s.Require().NoError(getErr)
+	s.Equal(core.EntityID(dnEntityBob), loaded.Initiative[loaded.ActiveIdx],
+		"a no-op kick must not advance the turn")
+}
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_NotTurnBased_NoOp() {
+	enc := tkenc.New(s.ctx, "enc-dn-free-roam", s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: dnPlayerBob, EntityID: dnEntityBob, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+		HP: 14, MaxHP: 14, AC: 14,
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+
+	out, err := s.kick("enc-dn-free-roam")
+	s.Require().NoError(err)
+	s.False(out.Kicked, "a free-roam encounter has no active actor to drive")
+}
+
+// --- the headline fix: NPC-first drives exactly once, no preceding EndTurn ---
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_NPCFirst_DrivesToPlayer() {
+	// Goblin active at idx 0 with NO preceding EndTurn call — this is exactly
+	// the rpg-api#636 repro: devcombat.Inject (or any future in-process
+	// combat-entry trigger) rolled the goblin first, and nothing has ended a
+	// turn yet, so EndTurn's own dispatch loop was never reached.
+	s.seedTurnBased(dnEncID, []core.EntityID{dnGoblinID}, []core.EntityID{dnGoblinID, dnEntityBob}, 0)
+
+	out, err := s.kick(dnEncID)
+	s.Require().NoError(err, "kicking a stalled NPC-first encounter must succeed")
+	s.Require().NotNil(out)
+	s.True(out.Kicked, "the goblin's turn must have been driven")
+
+	loaded, getErr := s.repo.Get(s.ctx, dnEncID)
+	s.Require().NoError(getErr)
+	s.Equal(core.EntityID(dnEntityBob), loaded.Initiative[loaded.ActiveIdx],
+		"after the kick, the active actor must be the player — the goblin's turn ran and ended server-side")
+}
+
+// --- chained NPC-first+NPC-second cascades to the first player ---
+
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_ChainedNPCFirst_CascadesToFirstPlayer() {
+	s.seedTurnBased(dnEncID, []core.EntityID{dnGoblinID, dnGoblin2ID},
+		[]core.EntityID{dnGoblinID, dnGoblin2ID, dnEntityBob}, 0)
+
+	out, err := s.kick(dnEncID)
+	s.Require().NoError(err, "kicking a stalled chained-NPC-first encounter must succeed")
+	s.True(out.Kicked)
+
+	loaded, getErr := s.repo.Get(s.ctx, dnEncID)
+	s.Require().NoError(getErr)
+	s.Equal(core.EntityID(dnEntityBob), loaded.Initiative[loaded.ActiveIdx],
+		"the dispatch loop must cascade past BOTH goblins to the player, exactly like EndTurn's own chain")
+}
+
+// --- single-flight: concurrent kicks against the same encounter must not
+// double-dispatch the same NPC turn ---
+//
+// N goroutines call DriveStalledNPCTurn concurrently against the SAME
+// NPC-first encounter. Without the per-encounter keyed mutex, each would
+// independently load its own copy of the NPC-active snapshot (the toolkit's
+// NPCAct "am I still the active actor" guard only protects the in-memory copy
+// the CALLER loaded, not across separately loaded copies) and all would
+// dispatch the goblin's turn — resolving the same attack multiple times. With
+// the lock, only the first caller to acquire it sees the NPC active; every
+// later caller (once unblocked) re-loads the ALREADY-persisted post-drive
+// state and finds a player active, so it no-ops. Exactly one Kicked=true
+// among N concurrent callers is the deterministic (roll-independent) proof.
+func (s *DriveStalledNPCTurnSuite) TestDriveStalledNPCTurn_ConcurrentKicks_SingleFlight() {
+	const n = 8
+	s.seedTurnBased(dnEncID, []core.EntityID{dnGoblinID}, []core.EntityID{dnGoblinID, dnEntityBob}, 0)
+
+	var wg sync.WaitGroup
+	results := make([]*encounterorch.DriveStalledNPCTurnOutput, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			out, err := s.kick(dnEncID)
+			results[idx] = out
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	kickedCount := 0
+	for i := 0; i < n; i++ {
+		s.Require().NoError(errs[i], "no concurrent caller should error")
+		s.Require().NotNil(results[i])
+		if results[i].Kicked {
+			kickedCount++
+		}
+	}
+	s.Equal(1, kickedCount, "exactly one of the concurrent callers must have driven the NPC turn — the rest must find it already advanced")
+
+	loaded, getErr := s.repo.Get(s.ctx, dnEncID)
+	s.Require().NoError(getErr)
+	s.Equal(core.EntityID(dnEntityBob), loaded.Initiative[loaded.ActiveIdx],
+		"after all concurrent kicks settle, the active actor must be the player")
+}
+
+func TestDriveStalledNPCTurnSuite(t *testing.T) {
+	suite.Run(t, new(DriveStalledNPCTurnSuite))
+}

--- a/internal/orchestrators/encounter/v2/end_turn.go
+++ b/internal/orchestrators/encounter/v2/end_turn.go
@@ -248,6 +248,16 @@ func (o *Orchestrator) driveNPCChain(
 				isNPC = false
 				break
 			}
+			// Copilot review (rpg-api#638): any other EndTurn failure here must
+			// still persist whatever NPCAct already mutated (damage, position,
+			// etc.) before returning — otherwise a retry re-loads the SAME
+			// NPC-active snapshot and re-stalls. endErr stays the %w-wrapped
+			// primary error so the handler's errors.Is classification is
+			// unaffected; a persist failure on top is folded in as non-fatal
+			// context rather than silently dropped.
+			if persistErr := o.persistWithCharacterData(ctx, enc, encounterID); persistErr != nil {
+				return fmt.Errorf("%w (persist failed: %v)", endErr, persistErr)
+			}
 			return endErr
 		}
 		// Post-EndTurn end-of-encounter check (Wave 2.10 guard, defensive — EndTurn

--- a/internal/orchestrators/encounter/v2/end_turn.go
+++ b/internal/orchestrators/encounter/v2/end_turn.go
@@ -132,24 +132,59 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 		return nil, err
 	}
 
-	// NPC dispatch loop. After the toolkit's EndTurn advances initiative, if the
-	// new active actor is an NPC the orchestrator runs its turn server-side and
-	// ends it, then re-checks. The cap is initiative-size + margin so an all-NPC
-	// roster cycles all the way through rather than freezing the RPC. The roster
-	// is read from the synced snapshot (enc.ToData().Initiative) — no parallel
-	// *Data handle, consistent with load's single-state rule.
-	//
-	// Wave 2.10: after each NPCAct / EndTurn cycle, if the encounter has
-	// transitioned to ModeEnded (e.g., an NPC attack killed the last hostile —
-	// not possible today since killEntity only runs in TakeAction's player-attack
-	// path, but cheap insurance for future paths like faction-on-faction NPC
-	// kills, environmental damage, etc.), break out of the loop. The post-loop
-	// persist saves the terminal state and the RPC returns success — the
-	// EncounterEnded event already fired through the broker, and the next combat
-	// verb will get ErrEncounterEnded.
+	// NPC dispatch loop, factored out as driveNPCChain (rpg-api#636) so the
+	// combat-entry kick (drive_npc.go) can run the identical cycle from a
+	// freshly loaded encounter instead of only after an EndTurn call. It owns
+	// every persist on every exit path, including the final "loop completed,
+	// player active or encounter ended" persist — mirroring EndTurn's own
+	// terminal persist pre-#636, so this call is EndTurn's only persist too.
+	if err := o.driveNPCChain(ctx, enc, in.EncounterID, newActive, isNPC); err != nil {
+		return nil, err
+	}
+
+	return &EndTurnOutput{}, nil
+}
+
+// driveNPCChain runs the toolkit's NPCAct + EndTurn cycle while the active
+// actor is an NPC, until a player is active, the encounter ends, or the
+// roster-derived chain cap is reached. active/isNPC are the CURRENT active
+// actor and whether it is an NPC — EndTurn passes its own EndTurn call's
+// result; the combat-entry kick (drive_npc.go) passes enc.ActiveActor() /
+// enc.IsNPC(...) from a freshly loaded encounter that has not (yet) had any
+// verb called on it this request.
+//
+// It persists on EVERY exit path — including the terminal "loop finished
+// cleanly" path — so a zero-iteration call (isNPC false on entry) still
+// persists. That is correct for EndTurn (whose own enc.EndTurn call above
+// already mutated state and must be saved regardless of NPC follow-on) but
+// would be a wasted write for the kick's "active actor is already a player"
+// no-op case — so the kick only calls this when enc.IsNPC(active) is true to
+// begin with, never unconditionally, and treats a successful call as having
+// driven a turn (there is nothing else driveNPCChain would have been asked to
+// do in that case).
+//
+// Wave 2.10: after each NPCAct / EndTurn cycle, if the encounter has
+// transitioned to ModeEnded (e.g., an NPC attack killed the last hostile —
+// not possible today since killEntity only runs in TakeAction's player-attack
+// path, but cheap insurance for future paths like faction-on-faction NPC
+// kills, environmental damage, etc.), break out of the loop. The post-loop
+// persist saves the terminal state and the caller returns success — the
+// EncounterEnded event already fired through the broker, and the next combat
+// verb will get ErrEncounterEnded.
+func (o *Orchestrator) driveNPCChain(
+	ctx context.Context,
+	enc *tkenc.Encounter,
+	encounterID string,
+	active core.EntityID,
+	isNPC bool,
+) error {
+	// The cap is initiative-size + margin so an all-NPC roster cycles all the
+	// way through rather than freezing the caller. The roster is read from the
+	// synced snapshot (enc.ToData().Initiative) — no parallel *Data handle,
+	// consistent with load's single-state rule.
 	npcChainCap := len(enc.ToData().Initiative) + npcChainSafetyMargin
 	for depth := 0; isNPC && depth < npcChainCap; depth++ {
-		if actErr := enc.NPCAct(ctx, newActive); actErr != nil {
+		if actErr := enc.NPCAct(ctx, active); actErr != nil {
 			// Wave 2.11d: NPC turn paused for a player reaction. The encounter has
 			// the pending reaction prompt + the InputRequiredDelivered event already
 			// published BY THE SDK from inside NPCAct (encounter/npc.go at the
@@ -180,21 +215,18 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 				// rationale + rpg-api#540 for the proper aggregate-then-complete fix.
 				o.enforceSingleReactor(enc)
 				if serErr := o.serializeNPCPendingReactions(enc); serErr != nil {
-					return nil, fmt.Errorf("serialize npc pending reactions %q: %w", in.EncounterID, serErr)
+					return fmt.Errorf("serialize npc pending reactions %q: %w", encounterID, serErr)
 				}
-				if persistErr := o.persistWithCharacterData(ctx, enc, in.EncounterID); persistErr != nil {
-					return nil, persistErr
-				}
-				return &EndTurnOutput{}, nil
+				return o.persistWithCharacterData(ctx, enc, encounterID)
 			}
 			// NPCAct errors are system-shaped (rehydration / bus / publish failure
 			// or unexpected state mismatch). Save what state we have first so the
 			// player isn't stuck on the NPC's turn forever; the next manual EndTurn
 			// picks up. Surface the wrapped sentinel so the handler maps to Internal.
-			if persistErr := o.persistWithCharacterData(ctx, enc, in.EncounterID); persistErr != nil {
-				return nil, fmt.Errorf("%w (%v) and persist failed: %w", ErrNPCAct, actErr, persistErr)
+			if persistErr := o.persistWithCharacterData(ctx, enc, encounterID); persistErr != nil {
+				return fmt.Errorf("%w (%v) and persist failed: %w", ErrNPCAct, actErr, persistErr)
 			}
-			return nil, fmt.Errorf("%w %q: %w", ErrNPCAct, string(newActive), actErr)
+			return fmt.Errorf("%w %q: %w", ErrNPCAct, string(active), actErr)
 		}
 		// Post-NPCAct end-of-encounter check (Wave 2.10 guard).
 		if enc.Mode() == core.ModeEnded {
@@ -205,7 +237,7 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 		// #689: enc.EndTurn(ctx, ...) emits the dnd5e TurnEndTopic on the encounter
 		// bus itself for the NPC whose turn is ending — held conditions reset in
 		// place, no host-side publish needed.
-		newActive, isNPC, endErr = enc.EndTurn(ctx, newActive)
+		active, isNPC, endErr = enc.EndTurn(ctx, active)
 		if endErr != nil {
 			// ErrEncounterEnded here means the NPC's action ended the encounter and
 			// the subsequent EndTurn rejected the call. Treat as success — the
@@ -216,7 +248,7 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 				isNPC = false
 				break
 			}
-			return nil, endErr
+			return endErr
 		}
 		// Post-EndTurn end-of-encounter check (Wave 2.10 guard, defensive — EndTurn
 		// doesn't mutate liveness today, but stays robust to future paths that fold
@@ -234,18 +266,14 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 	// with valid encounter setups; the cap-by-roster math above guarantees the
 	// loop reaches a player whenever one exists.
 	if isNPC {
-		if persistErr := o.persistWithCharacterData(ctx, enc, in.EncounterID); persistErr != nil {
-			return nil, persistErr
+		if persistErr := o.persistWithCharacterData(ctx, enc, encounterID); persistErr != nil {
+			return persistErr
 		}
-		return nil, fmt.Errorf("%w: npc %q still active; encounter may have no players in initiative",
-			ErrNPCChainExhausted, string(newActive))
+		return fmt.Errorf("%w: npc %q still active; encounter may have no players in initiative",
+			ErrNPCChainExhausted, string(active))
 	}
 
-	if err := o.persistWithCharacterData(ctx, enc, in.EncounterID); err != nil {
-		return nil, err
-	}
-
-	return &EndTurnOutput{}, nil
+	return o.persistWithCharacterData(ctx, enc, encounterID)
 }
 
 // enforceSingleReactor drops all but the first PendingReactionPrompt on the

--- a/internal/orchestrators/encounter/v2/keyed_mutex.go
+++ b/internal/orchestrators/encounter/v2/keyed_mutex.go
@@ -1,0 +1,45 @@
+package encounter
+
+import "sync"
+
+// keyedMutex serializes mutating operations per encounter ID. Used by
+// DriveStalledNPCTurn (drive_npc.go) so concurrent StreamEncounter/GetEncounter
+// connect-time kicks for the SAME encounter (e.g. four players reconnecting at
+// once, rpg-api#636) serialize instead of each loading the same NPC-active
+// snapshot independently and double-dispatching the NPC's turn.
+//
+// rpg-api is single-process (mirrors the lobby orchestrator's identical
+// keyed_mutex.go, whose doc comment records the same assumption for the
+// broker wiring), so a per-process, per-encounter-ID sync.Mutex is sufficient
+// — no Redis WATCH/MULTI transaction is needed for a guarantee that only has
+// to hold within one process. Duplicated here rather than shared with the
+// lobby package's unexported type: both are ~20-line, package-private
+// concurrency primitives with no other reason to couple the two packages.
+//
+// Known tradeoff: per-key *sync.Mutex entries are never evicted, so this map
+// grows by one entry per distinct encounter ID for the life of the process. An
+// encounter ID is minted once per StartEncounter/devseed call, so this is a
+// slow, usage-bounded leak (not a hot loop) — acceptable for now.
+type keyedMutex struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newKeyedMutex() *keyedMutex {
+	return &keyedMutex{locks: make(map[string]*sync.Mutex)}
+}
+
+// Lock acquires the per-key lock and returns the unlock func. Callers must
+// defer the returned func.
+func (k *keyedMutex) Lock(key string) func() {
+	k.mu.Lock()
+	l, ok := k.locks[key]
+	if !ok {
+		l = &sync.Mutex{}
+		k.locks[key] = l
+	}
+	k.mu.Unlock()
+
+	l.Lock()
+	return l.Unlock
+}

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -180,6 +180,10 @@ type Orchestrator struct {
 	characterData  CharacterDataCascade
 	reactionResume ReactionResume
 	now            func() time.Time
+	// npcDriveLocks single-flights DriveStalledNPCTurn per encounter ID
+	// (rpg-api#636) so concurrent connect-time kicks for the same encounter
+	// don't each load the same NPC-active snapshot and double-dispatch.
+	npcDriveLocks *keyedMutex
 }
 
 // New constructs an Orchestrator from cfg. Returns an error (never a nil
@@ -216,5 +220,6 @@ func New(cfg *Config) (*Orchestrator, error) {
 		characterData:         cfg.CharacterData,
 		reactionResume:        cfg.ReactionResume,
 		now:                   now,
+		npcDriveLocks:         newKeyedMutex(),
 	}, nil
 }

--- a/internal/pkg/devcombat/inject.go
+++ b/internal/pkg/devcombat/inject.go
@@ -51,6 +51,18 @@ type InjectInput struct {
 	// EncounterID identifies the EXISTING encounter to load. Inject returns
 	// encountersv2.ErrNotFound if no encounter is persisted under this ID.
 	EncounterID string
+
+	// ForceNPCFirst deterministically reorders the freshly-rolled Initiative so
+	// the just-injected goblin leads it (ActiveIdx=0), instead of leaving the
+	// toolkit's real initiative roll to decide who goes first. This exists to
+	// reproduce rpg-api#636 ("NPC first in initiative stalls the encounter") on
+	// demand — the bug was originally found by a lucky/unlucky roll, not
+	// something every --inject-combat run hits, so playtest repro and the
+	// regression test both need a deterministic knob rather than looping
+	// --inject-combat until the dice cooperate. Dev-tool-only: production
+	// combat-entry paths must never set this — a real encounter's first actor
+	// should stay whatever the toolkit's own roll decides.
+	ForceNPCFirst bool
 }
 
 // InjectOutput reports what Inject did, for callers that want to print or
@@ -158,6 +170,9 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 	}
 
 	updated := enc.ToData()
+	if input.ForceNPCFirst {
+		forceEntityFirst(updated, goblinID)
+	}
 	if saveErr := repo.Save(ctx, updated); saveErr != nil {
 		return nil, fmt.Errorf("save encounter %q: %w", input.EncounterID, saveErr)
 	}
@@ -170,6 +185,22 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 		PlayerCount:         len(updated.Players),
 		MonsterCount:        len(updated.Monsters),
 	}, nil
+}
+
+// forceEntityFirst reorders data.Initiative so id leads it (index 0) and sets
+// ActiveIdx to 0, preserving the relative order of every other entity. Used
+// only by ForceNPCFirst — see its doc comment for why a deterministic reorder
+// beats reseeding the toolkit's own initiative roll.
+func forceEntityFirst(data *tkenc.Data, id core.EntityID) {
+	reordered := make([]core.EntityID, 0, len(data.Initiative))
+	reordered = append(reordered, id)
+	for _, existing := range data.Initiative {
+		if existing != id {
+			reordered = append(reordered, existing)
+		}
+	}
+	data.Initiative = reordered
+	data.ActiveIdx = 0
 }
 
 // maxOccupiedQ returns the highest Q coordinate occupied by any player or

--- a/internal/pkg/devcombat/inject_test.go
+++ b/internal/pkg/devcombat/inject_test.go
@@ -133,3 +133,29 @@ func (s *InjectSuite) TestInject_MissingEncounter_ReturnsErrNotFound() {
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, encountersv2.ErrNotFound))
 }
+
+// TestInject_ForceNPCFirst_GoblinLeadsInitiative proves the rpg-api#636 repro
+// knob: with ForceNPCFirst, the injected goblin deterministically leads the
+// persisted Initiative (ActiveIdx=0), regardless of what the toolkit's real
+// roll would have produced — this is what lets both the lobby integration
+// test and manual `devseed --inject-combat --inject-combat-npc-first`
+// playtest repro reproduce the "NPC first in initiative stalls the encounter"
+// bug on demand instead of waiting for an unlucky roll.
+func (s *InjectSuite) TestInject_ForceNPCFirst_GoblinLeadsInitiative() {
+	const encID = "lobby-enc-npc-first"
+	s.seedLobbyLikeEncounter(encID)
+
+	out, err := devcombat.Inject(s.ctx, s.repo, devcombat.InjectInput{
+		EncounterID:   encID,
+		ForceNPCFirst: true,
+	})
+	s.Require().NoError(err)
+
+	data, err := s.repo.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	s.Require().Equal(0, data.ActiveIdx)
+	s.Require().Equal(out.GoblinID, data.Initiative[0], "the goblin must lead initiative")
+	s.Require().Len(data.Initiative, 3, "alice, bob, and the goblin must all still be in initiative")
+	s.Require().Contains(data.Initiative, core.EntityID("char-alice"))
+	s.Require().Contains(data.Initiative, core.EntityID("char-bob"))
+}


### PR DESCRIPTION
Closes #636

Board: #19 The Dungeon leg (combat-entry family, sibling of #634/#637).

## Summary

When a TURN_BASED encounter's very first active actor is an NPC (today: `devseed --inject-combat` rolling the goblin first; tomorrow: the real Dungeon-leg combat-entry trigger doing the same), nothing ever drove that turn. `Orchestrator.EndTurn`'s NPC dispatch loop only ran as the tail of an `EndTurn` call, and there's no preceding `EndTurn` to chain off of when an NPC starts active — every player is correctly locked out (not their turn), and nothing ever calls `NPCAct`. The encounter stalled forever.

## Investigation findings

- The NPC dispatch loop lives entirely inside `Orchestrator.EndTurn` (`internal/orchestrators/encounter/v2/end_turn.go`): after `enc.EndTurn(...)` advances initiative, a `for` loop calls `enc.NPCAct` + `enc.EndTurn` again while the active actor is an NPC, handling pause-for-reaction, system failures, and a roster-derived chain cap (`ErrNPCChainExhausted`). This loop has no other caller.
- `devcombat.Inject` (`internal/pkg/devcombat/inject.go`) — the code path behind `devseed --inject-combat` and today's only "add a monster + roll initiative" mechanism — writes straight to the encounter repo (Redis) out-of-process. The server never observes combat starting, so there's no server-side moment to hook "combat started, first actor is an NPC" from the injection itself.
- `StreamEncounter`/`GetEncounter` (`internal/handlers/dnd5e/v2/encounter/{handler,get}.go`) are the only "first touch" a client makes against such an encounter — they read straight from the repo via `ProjectFor`, bypassing the orchestrator entirely.

## Design chosen: (a), server-side kick on encounter interaction

Per the brief, I evaluated (a) kicking on connect vs (b) converting injection to an in-server dev entry point. Went with **(a)**:

- (b) doesn't fix the reconnect-into-NPC-active case, and it's proto/dev-surface growth for a dev tool — the wrong economy of effort.
- (a) fixes both today's out-of-process injection AND future reconnect-into-stalled scenarios, and composes cleanly: the future *real* (in-process) combat-entry trigger doesn't need the kick at all — it can call `driveNPCChain` directly right after its own `SetMode`, since it IS the server observing combat start. The kick exists specifically for paths that bypass normal server verbs (today, that's only devseed injection).

### What shipped

1. **`driveNPCChain`** (`end_turn.go`): the NPC dispatch loop factored out of `EndTurn` into a shared helper taking the current active actor + isNPC flag. Owns persistence on every exit path (pause-for-reaction, NPCAct system failure, chain-exhausted, clean completion) — `EndTurn` itself no longer has its own trailing persist, `driveNPCChain`'s tail covers it.
2. **`DriveStalledNPCTurn`** (new `drive_npc.go`): the "combat-entry kick." Loads the encounter; if the active actor is an NPC, calls `driveNPCChain`; otherwise no-ops without persisting (so a kick on every connect costs nothing on the common case — it's already a player's turn).
3. **`StreamEncounter`/`GetEncounter`** both call the kick — best-effort, error-swallowed (a kick failure or non-member caller must never block a read). `StreamEncounter` kicks **before** `Subscribe`, not after: this way the kick's own NPCAct/EndTurn broker events fan out live to already-connected viewers (who correctly watch the goblin's turn resolve in real time) without also replaying as a redundant post-snapshot event for the connecting client itself, whose snapshot is built afterward from the already-current state.
4. **Single-flight per encounter** (`keyed_mutex.go`, duplicated from the lobby orchestrator's identical single-process pattern): up to N clients can hit `StreamEncounter`/`GetEncounter` for the same encounter concurrently (e.g. four players reconnecting together). The toolkit's own "am I still the active actor" guard inside `NPCAct` only protects the in-memory copy the *caller* loaded — it does not protect across independently-loaded snapshots, so without serializing, all N callers would see the NPC active and all would dispatch its turn. The keyed mutex means only the first caller does real work; the rest re-load the already-persisted post-drive state and no-op.
5. **`devcombat.Inject` gains `ForceNPCFirst`**: deterministically reorders the freshly-rolled Initiative so the injected goblin leads it, instead of depending on a lucky roll to reproduce #636 on demand. Exposed as `devseed --inject-combat --inject-combat-npc-first` for manual playtest repro, and used by the new integration test.

## #637 root-cause observation (not fixed here)

While reading `load.go` and `project.go`, I found the existing "#598 turn-start seeding" mechanism (`SeedActorTurn`/`SeedTurnEconomyForData`) that heals a freshly-turn-based encounter's first PLAYER actor's economy — it's the closest existing analog to what this PR does for NPCs, but explicitly scoped to players only (`isPlayer` guard in `seedActorTurnEconomy`).

One candidate mechanism worth checking first for #637: `ProjectFor` (`project.go:58-78`) only runs `SeedTurnEconomyForData` + hydrates the active actor's menu when **the connecting viewer controls the active actor** (`viewerControlsActiveActor`) — this is an intentional audience gate (the menu/economy is the active actor's private view, per #602), but it means a reconnecting player who does NOT control the active actor gets no seeding side-effect from their own connect. If in the "finn-first" run the first reconnect(s) after restart weren't finn's own client, this could explain empty economy from an observer's perspective. I have **not** done the focused repro #637 asks for (didn't isolate which player reconnected in which order across the two playtest sessions), so this is a hypothesis to check first, not a confirmed root cause — flagging on #637 separately rather than guessing further here.

## Load-bearing

- `driveNPCChain` is now the single source of truth for "run consecutive NPC turns" — both `EndTurn` and `DriveStalledNPCTurn` call it, so any future NPC-dispatch behavior change (pause handling, chain cap, etc.) only needs to land once.
- The combat-entry kick is deliberately **not** wired into every combat-capable verb's `load()` — action verbs are already correctly gated by the toolkit's "is it your turn" check regardless, so hooking there would add per-request overhead without fixing anything the toolkit doesn't already handle. Only the two read-only connect paths (`StreamEncounter`, `GetEncounter`) get it, since those are the actual "first touch" moments for an out-of-process write.
- The future real combat-entry trigger should call `driveNPCChain` directly after its own `SetMode` — it does not need `DriveStalledNPCTurn`'s load-from-repo indirection since it already holds the live encounter in-process.

## Tests

- `internal/orchestrators/encounter/v2/drive_npc_test.go` (new): NPC-first drives exactly once and persists; chained NPC-first+NPC-second cascades to the first player; player-already-active and not-turn-based are true no-ops (no persist); load preconditions (`ErrEncounterNotFound`/`ErrPlayerNotInEncounter`) surface correctly; **concurrent kicks single-flight** — 8 goroutines racing `DriveStalledNPCTurn` against the same NPC-first encounter, asserting exactly one reports `Kicked=true` (roll-independent, deterministic proof the keyed mutex works, not just "no crash").
- `internal/pkg/devcombat/inject_test.go`: `ForceNPCFirst` deterministically puts the goblin at `Initiative[0]`.
- `cmd/devseed/main_test.go`: `--inject-combat-npc-first` CLI wiring forwards to `ForceNPCFirst`.
- `internal/integration/lobby_v1alpha1_test.go` (new): `TestPartyAssembles_FourPlayers_ThenCombatEntry_NPCFirstInitiative_StreamDrivesNPCTurn` — full party assembly → combat injection with forced NPC-first initiative → connecting via the **production `StreamEncounter` RPC** (not direct toolkit manipulation) must itself resolve the stall, with no `EndTurn` call preceding it.
- `go test -race ./...` green. `golangci-lint run` clean on all touched packages (0 issues).

## Four-question gate

- **Goal**: NPC-first initiative encounters self-heal on the very first client connect instead of stalling forever. Met — proven end-to-end via the real `StreamEncounter` RPC in the integration test, not just unit-level.
- **Pattern**: Reuses the existing load→verb→persist single-load orchestrator core; the NPC dispatch loop is now shared rather than duplicated; the keyed-mutex concurrency pattern mirrors the lobby orchestrator's existing solution to the identical problem class.
- **Test**: Unit tests cover the orchestrator seam in isolation (including the concurrency race with a deterministic assertion); the integration test proves the fix through the actual gRPC surface a client would hit.
- **Pushback**: I deliberately did NOT wire the kick into every verb's `load()` (the brief left this as "and/or") — action verbs are already correctly gated by "is it your turn," so that would add overhead without additional correctness. I also added a `ForceNPCFirst` repro knob to `devcombat.Inject` + a `devseed` CLI flag beyond the literal ask, since it lets Kirk manually reproduce this exact bug during playtesting without waiting for an unlucky roll — flagging this as a deliberate scope addition, not scope creep, since it's what both the regression test AND future manual repro need.

## Copilot

Opened as a real PR (not draft) per the brief. Will wait 6-10 min for Copilot's review, then thread-reply/fix every comment before asking for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)