### PR TITLE
chore(deps): bump toolkit encounter v0.24.5 + rulebooks/dnd5e v0.65.1 (rage sweep at encounter end)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.4
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.4 h1:LSlHDnfaZCMzdP0V03DKuP6GOAyk/SIn/OnIofO4qfw=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.4/go.mod h1:r2m0f6m3g3J02FBMI2Gn9fsNKDf6ErhrmuhQNByVvtg=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5 h1:oWxo4ivzDvGIW5t35Qe9AgFvrwZF4ml8l1iFDm7lYgY=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5/go.mod h1:huvD72keDai4f699qeE+oJR8fqsK1k+sn17RcLAV0Sc=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0 h1:/wmlRd+NgWUoAikqTUm8oQcvrk4kEX5BHZdlt8JirUk=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1 h1:secTNO31pOc6eAbRGrIeKjXSW/Fv06ha1uughYzjShA=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=


### PR DESCRIPTION
## Summary

- Bumps `github.com/KirkDiggler/rpg-toolkit/encounter` v0.24.4 → v0.24.5 and `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e` v0.65.0 → v0.65.1 — real tagged versions, no replace directives.
- Picks up the encounter-end condition sweep fix for the rage-leak-across-encounters bug found in the 2026-07-12 slice-3 playtest: `checkEncounterEnd` now publishes a `CombatEndEvent` to every held player character before the terminal `EncounterEndedEvent`, and `RagingCondition` self-removes on it the same way it already does on rest. Without this, a barbarian whose own killing blow ended an encounter carried the raging condition into the persisted character data, and the next encounter's hydration cascade silently re-applied the rage damage bonus with zero rage charges spent.
- This is the rpg-api half of the cross-repo unit for KirkDiggler/rpg-toolkit#752 — KirkDiggler/rpg-toolkit#753 landed the toolkit-side fix and is merged/tagged. Orchestrator-level playtests (two-fight scenario) follow this merge, so this PR lands pre-merge on that verification.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` clean.
- [x] `go test -race ./...` — full suite green, no failures.
- [x] `go.mod`/`go.sum` diff scoped to exactly the two version bumps; no replace directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)