### PR TITLE
chore(deps): bump rulebooks/dnd5e to v0.65.2 (rage sustains on missed attack)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1 h1:secTNO31pOc6eAbRGrIeKjXSW/Fv06ha1uughYzjShA=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2 h1:lxFfE5hShIkvQrR/SPM04uUYf1WnO3Uh/283rZlNS5c=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=


### PR DESCRIPTION
## Summary

Bumps `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e` from v0.65.1 to v0.65.2 to pick up the fix for rage dropping on a missed attack.

Closes the unit started by [rpg-toolkit#755](https://github.com/KirkDiggler/rpg-toolkit/issues/755) / [rpg-toolkit#756](https://github.com/KirkDiggler/rpg-toolkit/pull/756):

- `RagingCondition.DidAttackThisTurn` was only set from the hit-only damage chain, so a raging barbarian who attacked and **missed** lost rage at turn end (`no_combat_activity`) — found in the rage-sweep verification playtest. RAW: rage sustains on any attack attempt against a hostile creature since the last turn, hit or miss.
- The toolkit fix moved the sustain flag to a new `onPostAttackRoll` handler subscribed to `PostAttackRollChain`, which fires on every attack roll regardless of outcome. No behavior change on the rpg-api side beyond picking up the corrected condition.

This branch was playtest-verified against the fix pre-merge via a local replace directive; this PR strips that and bumps to the real published tag.

## Test plan

- [x] `go mod tidy` — clean diff, no other dependency drift, no replace directives
- [x] `go test -race ./...` — full suite green (see tail below)

```
ok  	github.com/KirkDiggler/rpg-api/cmd/devseed	1.066s
ok  	github.com/KirkDiggler/rpg-api/internal/apierr	1.036s
ok  	github.com/KirkDiggler/rpg-api/internal/auth	1.064s
ok  	github.com/KirkDiggler/rpg-api/internal/components/dungeon	1.136s
ok  	github.com/KirkDiggler/rpg-api/internal/components/dungeon/adapter	1.047s
ok  	github.com/KirkDiggler/rpg-api/internal/components/dungeon/encounter	1.046s
ok  	github.com/KirkDiggler/rpg-api/internal/components/dungeon/presentation	1.034s
ok  	github.com/KirkDiggler/rpg-api/internal/components/dungeon/toolkit	1.087s
ok  	github.com/KirkDiggler/rpg-api/internal/components/spawner	1.042s
ok  	github.com/KirkDiggler/rpg-api/internal/entities	1.069s
ok  	github.com/KirkDiggler/rpg-api/internal/handlers/api/v1alpha1	1.032s
ok  	github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/lobby/v1alpha1	1.055s
ok  	github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v1alpha1/character	1.050s
ok  	github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v1alpha1/encounter	1.059s
ok  	github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter	3.210s
ok  	github.com/KirkDiggler/rpg-api/internal/integration	16.694s
ok  	github.com/KirkDiggler/rpg-api/internal/integration/character	2.402s
ok  	github.com/KirkDiggler/rpg-api/internal/integration/encounter	8.931s
ok  	github.com/KirkDiggler/rpg-api/internal/integration/harness	1.960s
ok  	github.com/KirkDiggler/rpg-api/internal/orchestrators/character	1.048s
ok  	github.com/KirkDiggler/rpg-api/internal/orchestrators/dice	1.025s
ok  	github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter	1.175s
ok  	github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2	1.396s
ok  	github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby	1.085s
ok  	github.com/KirkDiggler/rpg-api/internal/pkg/devcombat	1.133s
ok  	github.com/KirkDiggler/rpg-api/internal/processors/event	1.039s
ok  	github.com/KirkDiggler/rpg-api/internal/publishers/encounter	1.333s
ok  	github.com/KirkDiggler/rpg-api/internal/repositories/dungeons	1.054s
ok  	github.com/KirkDiggler/rpg-api/internal/repositories/encounterlog	1.039s
ok  	github.com/KirkDiggler/rpg-api/internal/repositories/encounters	1.036s
ok  	github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2	1.050s
ok  	github.com/KirkDiggler/rpg-api/internal/repositories/lobby	1.042s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)