### PR TITLE
feat(dungeon): walls on the wire + goblins seeded at StartEncounter

### DIFF
--- a/cmd/devseed/main.go
+++ b/cmd/devseed/main.go
@@ -569,6 +569,28 @@ func buildWendyWizardData() *toolkitchar.Data {
 	}
 }
 
+// setModeIfRequested flips enc to mode when the caller asked for
+// ModeTurnBased — a no-op for any other requested mode (FreeRoam-from-fresh
+// -create is already the SDK's NewData default).
+//
+// Every fixture in this file places its goblin well within the seeded
+// players' SightRange, so AddMonster's inline combat-entry check
+// (rpg-toolkit#759's checkCombatEntry, which runs on every AddPlayer/
+// AddMonster call) may have ALREADY flipped FREE_ROAM -> TURN_BASED and
+// rolled initiative by the time this is called — an explicit SetMode would
+// then be redundant and error ("mode is already TURN_BASED"). Checking
+// enc.Mode() first makes this idempotent regardless of which path got the
+// encounter into TURN_BASED.
+func setModeIfRequested(enc *tkenc.Encounter, mode encountercore.EncounterMode) error {
+	if mode != encountercore.ModeTurnBased || enc.Mode() == encountercore.ModeTurnBased {
+		return nil
+	}
+	if err := enc.SetMode(mode); err != nil {
+		return fmt.Errorf("set mode turn_based: %w", err)
+	}
+	return nil
+}
+
 // buildEncounterData seeds the encounter with all three players + the
 // goblin, then flips it into the requested mode. Positions match the
 // rpg-dnd5e-web PlaytestHarness SEEDED_FALLBACK so the harness renders
@@ -669,10 +691,8 @@ func buildEncounterData(encounterID string, mode encountercore.EncounterMode) (*
 	// SetMode is a no-op for FreeRoam-from-fresh-create (the SDK's NewData
 	// already defaults to FreeRoam); only call it for TurnBased so the SDK
 	// rolls initiative and seeds ActiveIdx/Round.
-	if mode == encountercore.ModeTurnBased {
-		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
-			return nil, fmt.Errorf("set mode turn_based: %w", err)
-		}
+	if err := setModeIfRequested(enc, mode); err != nil {
+		return nil, err
 	}
 
 	return enc.ToData(), nil
@@ -779,10 +799,8 @@ func buildWave2MonkEncounterData(encounterID string, mode encountercore.Encounte
 		return nil, fmt.Errorf("add goblin: %w", err)
 	}
 
-	if mode == encountercore.ModeTurnBased {
-		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
-			return nil, fmt.Errorf("set mode turn_based: %w", err)
-		}
+	if err := setModeIfRequested(enc, mode); err != nil {
+		return nil, err
 	}
 
 	return enc.ToData(), nil
@@ -908,10 +926,8 @@ func buildWave2Beat2EncounterData(encounterID string, mode encountercore.Encount
 		return nil, fmt.Errorf("add goblin: %w", err)
 	}
 
-	if mode == encountercore.ModeTurnBased {
-		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
-			return nil, fmt.Errorf("set mode turn_based: %w", err)
-		}
+	if err := setModeIfRequested(enc, mode); err != nil {
+		return nil, err
 	}
 
 	return enc.ToData(), nil
@@ -1030,10 +1046,8 @@ func buildWave1RogueEncounterData(encounterID string, mode encountercore.Encount
 		return nil, fmt.Errorf("add goblin: %w", err)
 	}
 
-	if mode == encountercore.ModeTurnBased {
-		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
-			return nil, fmt.Errorf("set mode turn_based: %w", err)
-		}
+	if err := setModeIfRequested(enc, mode); err != nil {
+		return nil, err
 	}
 
 	return enc.ToData(), nil
@@ -1094,10 +1108,8 @@ func buildWave3BarbarianEncounterData(encounterID string, mode encountercore.Enc
 		return nil, fmt.Errorf("add goblin (wave-3-barbarian): %w", err)
 	}
 
-	if mode == encountercore.ModeTurnBased {
-		if err := enc.SetMode(encountercore.ModeTurnBased); err != nil {
-			return nil, fmt.Errorf("set mode turn_based (wave-3-barbarian): %w", err)
-		}
+	if err := setModeIfRequested(enc, mode); err != nil {
+		return nil, fmt.Errorf("(wave-3-barbarian): %w", err)
 	}
 
 	return enc.ToData(), nil

--- a/docs/architecture/components/lobby-service.md
+++ b/docs/architecture/components/lobby-service.md
@@ -122,10 +122,14 @@ JSON-round-trip-on-every-call contract.
   (`internal/pkg/devcombat`) fills this gap for local/MCP playtesting only — it loads an
   EXISTING lobby-started encounter, adds a monster, and flips TURN_BASED without a proto
   change (rpg-api#634).
-- **Spawn positions are a placeholder** — `StartEncounter` spreads members along a
-  straight line (`Q += index`) since no room/spawn-point system exists yet for a
-  freshly-created lobby encounter. Real spawn selection is future work once room
-  integration lands.
+- **Player spawn positions are still a placeholder** — `StartEncounter` spreads members
+  along a straight line (`Q += index`) rather than a real spawn-point selection within
+  the room. **The room itself now exists** (rpg-api#644, The Dungeon wave 1:
+  `enc.InitRoom(20, 20, environments.PatternRandom)` runs before the member loop, and 2
+  goblins are seeded at verified-unseen positions within it — see `docs/status.md`'s "The
+  Dungeon wave 1" entry) — only the PLAYER placement within that room is still the
+  pre-wave-1 line placeholder. Real player spawn-point selection (e.g. clustering near a
+  room entrance) is future work.
 - **`keyedMutex` never evicts** — see the orchestrator section above.
 - **Discord-instance join_ref carrier is out of scope** — only the dev/playtest carrier
   (an opaque `join_ref` passed explicitly) ships here. The Discord Activity carrier

--- a/docs/status.md
+++ b/docs/status.md
@@ -54,6 +54,35 @@ design work" — see the correction inline. The full MCP playtest (web step 9, w
 9 in `ideas/the-dungeon/design.md`) still closes the wave; this PR is the api half only
 (design doc steps 7-8).
 
+**Playtest follow-up: live initiative roster broadcast on combat entry (rpg-api#644,
+2026-07-15)** — the connect-time snapshot's `TurnState.InitiativeOrder` was the only
+place a client ever learned the turn order; a mid-stream `FREE_ROAM` → `TURN_BASED`
+transition (the toolkit's `rollInitiative`, inside `SetMode`) published no roster of its
+own, so a client watching the fight start live saw an empty initiative list until its
+next full snapshot. `internal/handlers/dnd5e/v2/encounter/handler.go`'s stream loop now
+synthesizes a proto `InitiativeRolled` envelope (`order=[]string`, `EncounterEvent` oneof
+field 41 — already defined on the wire, unused until now, zero proto changes) and sends
+it right after the `ModeChanged` translation whenever a `ModeChangedEvent` transitions
+`To==TURN_BASED`; `translateForStream` returns a slice so one broker event can produce
+two wire envelopes. Broadcast to every connected viewer, not just whoever moved.
+
+**Known rough edge: the roster read races the orchestrator's save (rpg-api#647)** — every
+combat-capable orchestrator verb follows a mutate-then-persist pattern where the toolkit
+SDK call (e.g. `MoveEntity`'s `enc.Move(...)`) mutates state AND synchronously publishes
+its broker events *before returning*, and only once it returns does the orchestrator
+`Save` the result. The stream goroutine that wakes on the just-published `ModeChangedEvent`
+can therefore call `h.encRepo.Get` before that `Save` lands, reading the pre-transition
+(empty-`Initiative`) snapshot — reproduced reliably under `go test -race -count=10` before
+the fix, intermittent without `-race`. Worked around with a bounded retry
+(`loadRolledInitiative`, up to 15 attempts / 10ms apart / ~150ms worst case) rather than a
+longer fixed delay, since the real `Save` is the very next thing the orchestrator does.
+This is an interim workaround, not the fix: rpg-api#647 tracks both the general race class
+(the same pattern already exists in the `InputRequiredDeliveredEvent` prompt-lookup path,
+untested under sustained `-race` load) and the toolkit-side seam that would delete the
+retry outright — e.g. the SDK deferring its publish until after an explicit persist
+callback, or exposing the freshly-rolled `Initiative` directly on the event instead of
+requiring a repo round-trip at all.
+
 **The live v1alpha1 encounter stack is DELETED (rpg-api#642, 2026-07-13)** —
 the audit-flagged registered-and-serving `dnd5e.api.v1alpha1.EncounterService`
 (`cmd/server/server.go:233`), its 5,844-line `internal/orchestrators/encounter/

--- a/docs/status.md
+++ b/docs/status.md
@@ -83,6 +83,35 @@ retry outright — e.g. the SDK deferring its publish until after an explicit pe
 callback, or exposing the freshly-rolled `Initiative` directly on the event instead of
 requiring a repo round-trip at all.
 
+**Playtest follow-up: live EntityAppeared carries entity type (rpg-api#644, 2026-07-15)** —
+a monster (or player) becoming visible via a live `Move` (rpg-toolkit#762's monster
+`EntityAppeared` emission) projected on the wire as `type=UNSPECIFIED` — a goblin rendered
+as a generic capsule instead of its model. The toolkit's `EntityAppearedEvent` deliberately
+carries only an entity ID + position (same minimal cause-event shape as the
+DoorOpened/HexRevealed split already in this file), so the live translator built a bare
+`{id, position}` Entity, leaving `type`/`hp`/`armor_class`/the character-or-monster oneof
+unset. `handler.go`'s stream loop now branches on `EntityAppearedEvent` and calls the new
+`translateEntityAppearedEventWithData`, which looks the entity up in freshly-loaded data
+and builds the full Entity via `playerEntity`/`monsterEntity` — the monster-entity-building
+code that used to live inline in `ProjectFor` is now `monsterEntity`, extracted so the
+snapshot and live paths share one authoritative builder instead of drifting the way they
+did before this fix (existing `TestProjectSuite` snapshot tests pin the extraction as
+behavior-preserving). Unlike the `InitiativeRolled` read above, this one is NOT exposed to
+the rpg-api#647 race class — the appearing entity's identity was always persisted by an
+earlier, separate, already-completed request (`AddPlayer`/`AddMonster` inside
+`StartEncounter` or `devcombat.Inject`); no retry needed. One subtlety caught by
+`TestMovementSlicePerViewerProjection_AsymmetricLoS` while building this: the Entity's
+`Position` must stay the EVENT's own reported position, not the entity's current stored
+position — `ProjectVisibilityTransition` can report "appeared" at an intermediate hex of a
+multi-hex pass-through move, not the mover's final resting position. **Same rough-edge
+family as #647, worth flagging next to it:** unlike `ModeChanged` (once per fight),
+`EntityAppeared` can now fire on every LOS-changing move during active combat
+(rpg-toolkit#762's own scope includes "a player rounding a corner mid-fight") — if the
+per-event repo read ever shows up as a real cost, the natural follow-up is caching the
+connect-time snapshot's Players/Monsters in the stream goroutine's own state instead of
+round-tripping Redis per appearance; not built now, flagged here so it's discoverable
+rather than re-derived.
+
 **The live v1alpha1 encounter stack is DELETED (rpg-api#642, 2026-07-13)** —
 the audit-flagged registered-and-serving `dnd5e.api.v1alpha1.EncounterService`
 (`cmd/server/server.go:233`), its 5,844-line `internal/orchestrators/encounter/

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-13
-confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint
+updated: 2026-07-15
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests
 ---
 
 # rpg-api: Where We Are
@@ -10,6 +10,49 @@ confidence: high — Wave 2 Monk entries verified against passing integration te
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**The Dungeon wave 1 (api half) — walls on the wire + real goblins seeded at StartEncounter (rpg-api#644, 2026-07-15)** —
+`StartEncounter` (`internal/orchestrators/lobby/start_encounter.go`) now calls
+`enc.InitRoom(20, 20, environments.PatternRandom)` right after `tkenc.New` (before any
+`AddPlayer`/`AddMonster`, both of which consult `e.room` internally) and seeds
+`goblinCount` (2) real goblins (`monster.NewGoblin`, DataJSON-carrying, identical shape
+to the devseed/`devcombat.Inject` goblins) before persisting. Bumped
+`rpg-toolkit/encounter` to v0.25.0 and added `rpg-toolkit/tools/spawn` v0.2.0
+(rpg-toolkit#759). The projector (`internal/handlers/dnd5e/v2/encounter/project.go`'s
+`ProjectFor`) now populates `Space.Walls` from the encounter's persisted room snapshot —
+whole-room visibility for wave 1 (not LOS-gated like `Hexes`/`Entities`); zero proto
+changes (`Wall`/`WallKind` already existed on the wire, unpopulated).
+
+Goblin placement is verified NOT visible to any player at spawn — `AddMonster`
+inline-checks combat entry (rpg-toolkit#759's `checkCombatEntry`), so a goblin seeded
+within sight would flip the encounter to `TURN_BASED` immediately, violating the design
+bar ("walk into a room, the fight starts" — combat starts on a `Move` that forms sight,
+never at spawn). **Known toolkit gap, not fixed here:** `tools/spawn`'s own
+`BasicSpawnEngine` position search (`findValidPosition`, and the constraint-aware
+`ConstraintSolver.FindValidPositions`) never consults the real `spatial.Room` this wave
+introduced — no `room.CanPlaceEntity`/`room.IsLineOfSightBlocked` calls anywhere in that
+path — and its optional `LineOfSight` constraint is a Euclidean-distance stub
+(`constraints.go`'s `hasLineOfSight`, doc-flagged as a Phase-3 placeholder). `SpawnConfig`
+also has no fixed/target-position injection point. `StartEncounter` still constructs and
+calls `spawn.BasicSpawnEngine.PopulateRoom` (wired to `enc.RoomOrchestrator()`, exercising
+rpg-toolkit#757/#759's `getRoomFromSpatial`/`placeEntityInRoom` fix from a real caller),
+but discards its returned position in favor of one computed from the toolkit's own
+wall-aware `perception.CanSeeAt` — see `seedGoblins`'/`safeGoblinHexes`' doc comments in
+`start_encounter.go` for the full reasoning. A toolkit follow-up issue for
+fixed-position spawn support is recommended before wave 2 needs dynamic (non-fixed-2)
+monster placement through this engine.
+
+Verified via `internal/orchestrators/lobby/start_encounter_test.go`'s
+`TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSightedMove`: real `StartEncounter`
+call → walled room + 2 goblins persisted, `Mode == FREE_ROAM` at spawn (not
+`TURN_BASED`), then a rehydrated `enc.Move` onto a goblin's hex flips `Mode ==
+TURN_BASED` **by rule** (the toolkit's own inline `checkCombatEntry`, not anything
+rpg-api triggers) — no `devseed --inject-combat` involved. Stress-run 50x clean (room
+generation and goblin placement are both randomized). This retires this doc's
+"Known gap" note below about the combat-entry trigger being "future room/encounter-
+design work" — see the correction inline. The full MCP playtest (web step 9, wave-1 step
+9 in `ideas/the-dungeon/design.md`) still closes the wave; this PR is the api half only
+(design doc steps 7-8).
 
 **The live v1alpha1 encounter stack is DELETED (rpg-api#642, 2026-07-13)** —
 the audit-flagged registered-and-serving `dnd5e.api.v1alpha1.EncounterService`
@@ -110,8 +153,12 @@ Known gap: `StartEncounter`'s proto contract carries no `initial_mode` field (th
 `CreateEncounter` could start TURN_BASED directly) — every lobby-constructed encounter
 starts FREE_ROAM. No production caller depended on the old field; flagged as a design
 gap, not fixed here. `devseed --inject-combat` (below) gives local/MCP playtesting a way
-to add a monster and flip TURN_BASED on a lobby-started encounter without a proto change;
-the real combat-entry trigger is future room/encounter-design work.
+to add a monster and flip TURN_BASED on a lobby-started encounter without a proto change.
+**Correction (rpg-api#644, 2026-07-15): the real combat-entry trigger has landed** — see
+"The Dungeon wave 1" entry above. `StartEncounter` now seeds real goblins into a real
+walled room and combat starts by rule (a `Move` that forms sight), not just via
+`devseed --inject-combat`; the dev-inject tool remains for playtest control (design doc:
+"the inject tool stays for playtest control"), not as the only path anymore.
 
 **A real fight on GameView — combat-ready lobby members + devseed injection (rpg-api#634, 2026-07-11)** —
 `StartEncounter` now seeds each member's `tkenc.PlayerInput.AC` honestly from

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,33 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**Wave-close blocker: stale character combat economy blocked all movement on fresh
+encounters (rpg-api#644, 2026-07-15)** — found live on the dev stack: every `MoveEntity`
+on a brand-new `FREE_ROAM` encounter failed `insufficient movement remaining: Nft, 0ft
+remaining`, even on the very first move. Root cause was NOT a code regression in this
+wave's commits (confirmed: none of them touch `MoveEntity`, the orchestrator, or
+character hydration) — `character.Character.ActionEconomy`
+(`rpg-toolkit/rulebooks/dnd5e/character`) has no encounter scoping; it is a flat field on
+the character record. rpg-toolkit's `Move()` budget gate treats any non-nil
+`ActionEconomy` as "in combat, enforce the budget" (`InCombat() == ActionEconomy != nil`),
+and `ExitCombat()` — the toolkit's own API for clearing it, whose doc literally says "call
+this when the encounter ends" — was never called anywhere: not in rpg-api, not even
+inside rpg-toolkit's own encounter package (which owns `EncounterEndedEvent` but never
+wires `ExitCombat` to it). A character that ever finished a combat (e.g. an earlier
+playtest session) carries its depleted economy — `movement_remaining: 0` — into every
+SUBSEQUENT encounter it's added to, forever, until something explicitly clears it.
+`seedMemberCombatSnapshot`'s new `clearStaleActionEconomy`
+(`internal/orchestrators/lobby/character.go`) fixes this at `StartEncounter` — the sole
+path a new encounter comes into existence, so at that exact moment no member's character
+can legitimately be mid-turn in the encounter about to exist, making it safe to
+unconditionally clear. `SeedTurnEconomyForData` (`hydrate_players.go`) could not have
+fixed this instead — it deliberately treats any non-nil economy as "already legitimately
+seeded, leave it alone" (correct for its own mid-encounter job, unable to distinguish
+live-and-depleted from stale-and-abandoned). **This is a defensive backstop, not the
+complete fix — genuinely open follow-up**: rpg-api's encounter-end handling (or the
+toolkit) should call `ExitCombat()` when an encounter properly ends, so a character never
+carries stale economy into the next one in the first place.
+
 **The Dungeon wave 1 (api half) — walls on the wire + real goblins seeded at StartEncounter (rpg-api#644, 2026-07-15)** —
 `StartEncounter` (`internal/orchestrators/lobby/start_encounter.go`) now calls
 `enc.InitRoom(20, 20, environments.PatternRandom)` right after `tkenc.New` (before any

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.25.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.26.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
+	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
@@ -32,7 +33,6 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 // indirect
 	github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 // indirect
-	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.25.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2
-	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0
+	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0
@@ -32,6 +32,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 // indirect
 	github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 // indirect
+	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.25.0 h1:wVgR/CHbW9+1SvopldlauiTcjR9MRXH3kgOlzVzlN/Q=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.25.0/go.mod h1:1VpHeNNexAMdHxI1SRRhs/5F+/Rr90hqKrt6m5U523o=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.26.0 h1:rwAMVBvWyzUIQfCGI6Hs4JxrwdYfEkOz3plDiy31uZU=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.26.0/go.mod h1:1VpHeNNexAMdHxI1SRRhs/5F+/Rr90hqKrt6m5U523o=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5 h1:oWxo4ivzDvGIW5t35Qe9AgFvrwZF4ml8l1iFDm7lYgY=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.24.5/go.mod h1:huvD72keDai4f699qeE+oJR8fqsK1k+sn17RcLAV0Sc=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.25.0 h1:wVgR/CHbW9+1SvopldlauiTcjR9MRXH3kgOlzVzlN/Q=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.25.0/go.mod h1:1VpHeNNexAMdHxI1SRRhs/5F+/Rr90hqKrt6m5U523o=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -22,12 +22,14 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Y
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2 h1:lxFfE5hShIkvQrR/SPM04uUYf1WnO3Uh/283rZlNS5c=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
-github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0 h1:fyNqBWKRn98giYFAP7oY+e9ygHFMGjeHlF6k68FhOy0=
-github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.0/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2 h1:kPc3FZSRAB/gIzTBvlOYxzqp9mdL0akkeRW/8EZcI9A=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0 h1:weKsLlsRV9kgoD/y68VWy0lpsu5zhwCmbnr5MUkLpsA=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0 h1:YowWFv+oL49f7aRt8O3krJ6BrpA3CrYaLEqInu92SZs=
+github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0/go.mod h1:vRkHHvBU1hXvlPyOySMfXov4S4Tj/bTWJ7lUGSwgVmI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=

--- a/internal/auth/mock/mock_discord.go
+++ b/internal/auth/mock/mock_discord.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	auth "github.com/KirkDiggler/rpg-api/internal/auth"
 	gomock "go.uber.org/mock/gomock"
+
+	auth "github.com/KirkDiggler/rpg-api/internal/auth"
 )
 
 // MockTokenValidator is a mock of TokenValidator interface.

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -45,7 +45,10 @@ func (s *HandlerSuite) seedCombatEncounter() {
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice/bob
+	// (sight range 10, no room) already see the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
 }
 
@@ -313,7 +316,9 @@ func (s *HandlerSuite) TestTakeAction_ActorIDMismatch_PermissionDenied() {
 }
 
 func (s *HandlerSuite) TestTakeAction_NotTurnBased_FailedPrecondition() {
-	// Seed a free-roam encounter (no SetMode). The toolkit's combat verb
+	// Seed a free-roam encounter (no SetMode). The goblin sits outside
+	// alice's sight range (rpg-toolkit#759 combat-entry check runs inline on
+	// AddMonster) so the encounter stays FREE_ROAM. The toolkit's combat verb
 	// returns ErrNotTurnBased which the handler maps to FailedPrecondition.
 	enc := tkenc.New(context.Background(), combatEncID, s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
@@ -322,7 +327,7 @@ func (s *HandlerSuite) TestTakeAction_NotTurnBased_FailedPrecondition() {
 		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4, DamageDice: "1d8+2",
 	}))
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
-		ID: monsterGoblin1, Position: core.Hex{Q: 1, R: 0, S: -1},
+		ID: monsterGoblin1, Position: core.Hex{Q: 20, R: 0, S: -20},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6, MonsterRef: "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: "1d6+2",
 	}))

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -399,6 +399,21 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 //     established pattern here (mirrors the InputRequiredDeliveredEvent
 //     branch immediately above), and a mode-transition event is rare enough
 //     (once per fight) that the extra repo round-trip is not a concern.
+//   - EntityAppearedEvent (rpg-api#644 playtest follow-up): the toolkit
+//     event carries only an entity ID + position — no type, HP, or monster
+//     ref — so the wire Entity would otherwise project as type=UNSPECIFIED
+//     (a real playtest finding: a newly-visible goblin rendered as a
+//     generic capsule instead of its model). Looks the entity up in the
+//     freshly-loaded data and builds the full Entity via the same
+//     playerEntity/monsterEntity builders ProjectFor's snapshot path uses —
+//     see translateEntityAppearedEventWithData's doc for why this read,
+//     unlike the InitiativeRolled one above, is not exposed to the
+//     rpg-api#647 race class and needs no retry. This fires far more often
+//     than ModeChanged during active combat (any LOS-changing move, not
+//     just combat entry); if the extra per-event repo round-trip ever shows
+//     up as a real cost, the natural follow-up is caching the connect-time
+//     snapshot's Players/Monsters in this stream goroutine's own state
+//     instead (see docs/status.md's rough edges).
 //
 // Every other event type continues to use TranslateEvent unchanged.
 func (h *Handler) translateForStream(
@@ -420,6 +435,18 @@ func (h *Handler) translateForStream(
 			prompt = data.PendingReactionPrompts[irEvt.ReactorID]
 		}
 		out, err := TranslateInputRequiredDelivered(irEvt, viewer, h.now(), prompt)
+		if err != nil {
+			return nil, err
+		}
+		return []*encounterv2pb.EncounterEvent{out}, nil
+	}
+
+	if appearEvt, ok := evt.(*tkevents.EntityAppearedEvent); ok {
+		data, err := h.encRepo.Get(ctx, string(encID))
+		if err != nil {
+			return nil, fmt.Errorf("load encounter for entity-appeared enrichment: %w", err)
+		}
+		out, err := translateEntityAppearedEventWithData(appearEvt, viewer, h.now(), data)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -351,7 +351,7 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 			if !ok {
 				return nil
 			}
-			out, translateErr := h.translateForStream(ctx, encID, evt, core.PlayerID(playerID))
+			outs, translateErr := h.translateForStream(ctx, encID, evt, core.PlayerID(playerID))
 			switch {
 			case errors.Is(translateErr, ErrViewerSawNothing):
 				continue
@@ -368,25 +368,45 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 			case translateErr != nil:
 				return status.Errorf(codes.Internal, "translate %q: %v", string(encID), translateErr)
 			}
-			if err := stream.Send(out); err != nil {
-				return err
+			for _, out := range outs {
+				if err := stream.Send(out); err != nil {
+					return err
+				}
 			}
 		}
 	}
 }
 
-// translateForStream wraps TranslateEvent with the data-aware path for
-// InputRequiredDeliveredEvent (Wave 2.11d). Wave 2.11d's reaction prompts
-// store their content on Encounter.Data.PendingReactionPrompts (rather than
-// on the event payload), so the translator needs the encounter snapshot to
-// look up the prompt content. Other event types continue to use
-// TranslateEvent unchanged.
+// translateForStream wraps TranslateEvent with the data-aware paths this
+// stream loop needs. Returns a slice (usually one envelope) so a single
+// broker event can translate to more than one wire envelope when needed —
+// see the InitiativeRolled case below.
+//
+//   - InputRequiredDeliveredEvent (Wave 2.11d): reaction prompts store their
+//     content on Encounter.Data.PendingReactionPrompts (rather than on the
+//     event payload), so the translator needs the encounter snapshot to
+//     look up the prompt content.
+//   - ModeChangedEvent transitioning to TURN_BASED (rpg-api#644 playtest
+//     follow-up): the toolkit's rollInitiative (inside SetMode) rolls
+//     data.Initiative but publishes no dedicated roster event — the client's
+//     initiativeOrder otherwise stays empty until the NEXT full snapshot
+//     (only buildTurnState populates it, and that only runs at connect
+//     time). Broadcasting a synthesized InitiativeRolled envelope alongside
+//     the normal ModeChanged translation closes that gap without a proto
+//     change (InitiativeRolled already exists on the wire, unused — see
+//     translateInitiativeRolledEvent's doc). Loads data fresh rather than
+//     threading it through from elsewhere in the loop: this is the
+//     established pattern here (mirrors the InputRequiredDeliveredEvent
+//     branch immediately above), and a mode-transition event is rare enough
+//     (once per fight) that the extra repo round-trip is not a concern.
+//
+// Every other event type continues to use TranslateEvent unchanged.
 func (h *Handler) translateForStream(
 	ctx context.Context,
 	encID core.EncounterID,
 	evt tkevents.EncounterEvent,
 	viewer core.PlayerID,
-) (*encounterv2pb.EncounterEvent, error) {
+) ([]*encounterv2pb.EncounterEvent, error) {
 	if irEvt, ok := evt.(*tkevents.InputRequiredDeliveredEvent); ok {
 		// Load the encounter to read the pending prompt content. The prompt
 		// lives on Data.PendingReactionPrompts and is the canonical source
@@ -399,7 +419,68 @@ func (h *Handler) translateForStream(
 		if data != nil {
 			prompt = data.PendingReactionPrompts[irEvt.ReactorID]
 		}
-		return TranslateInputRequiredDelivered(irEvt, viewer, h.now(), prompt)
+		out, err := TranslateInputRequiredDelivered(irEvt, viewer, h.now(), prompt)
+		if err != nil {
+			return nil, err
+		}
+		return []*encounterv2pb.EncounterEvent{out}, nil
 	}
-	return TranslateEvent(evt, viewer, h.now())
+
+	out, err := TranslateEvent(evt, viewer, h.now())
+	if err != nil {
+		return nil, err
+	}
+	envelopes := []*encounterv2pb.EncounterEvent{out}
+
+	if modeEvt, ok := evt.(*tkevents.ModeChangedEvent); ok && modeEvt.To == core.ModeTurnBased {
+		initiative, err := h.loadRolledInitiative(ctx, encID)
+		if err != nil {
+			return nil, err
+		}
+		envelopes = append(envelopes, translateInitiativeRolledEvent(modeEvt.Sequence(), initiative, h.now()))
+	}
+
+	return envelopes, nil
+}
+
+// loadRolledInitiative reads the encounter's Initiative back from the repo
+// for the InitiativeRolled synthesis above. This races against the
+// verb-then-persist pattern every combat-capable orchestrator method uses
+// (e.g. MoveEntity: enc.Move(...) — which mutates + PUBLISHES the
+// ModeChangedEvent this function is reacting to, synchronously, INSIDE the
+// call — THEN, only once Move returns, the orchestrator calls Save). So the
+// very broker event that wakes this stream goroutine can arrive before the
+// orchestrator's Save lands, and a single h.encRepo.Get can read the
+// pre-transition (empty-Initiative) snapshot. Bounded retry converts that
+// race into a short, harmless wait — Save is already the very next thing
+// the orchestrator does after Move returns, so this resolves in one or two
+// iterations in practice; initiativePollAttempts/initiativePollInterval
+// bound the worst case at ~150ms so a genuinely stuck load still returns
+// (with whatever — possibly empty — Initiative it last read) rather than
+// hanging the stream.
+const (
+	initiativePollAttempts = 15
+	initiativePollInterval = 10 * time.Millisecond
+)
+
+func (h *Handler) loadRolledInitiative(ctx context.Context, encID core.EncounterID) ([]core.EntityID, error) {
+	var initiative []core.EntityID
+	for attempt := 0; attempt < initiativePollAttempts; attempt++ {
+		data, err := h.encRepo.Get(ctx, string(encID))
+		if err != nil {
+			return nil, fmt.Errorf("load encounter for initiative roster: %w", err)
+		}
+		if data != nil {
+			initiative = data.Initiative
+			if data.Mode == core.ModeTurnBased && len(initiative) > 0 {
+				return initiative, nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return initiative, nil
+		case <-time.After(initiativePollInterval):
+		}
+	}
+	return initiative, nil
 }

--- a/internal/handlers/dnd5e/v2/encounter/integration_barbarian_rage_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_barbarian_rage_test.go
@@ -378,7 +378,10 @@ func (s *BarbarianRageIntegrationSuite) goblinAttackBobHP(
 		DamageType:  "slashing",
 		DataJSON:    gDataJSON,
 	}))
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): bob (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(repo.Save(context.Background(), enc.ToData()))
 
 	// Advance to bob's turn.
@@ -563,7 +566,10 @@ func (s *BarbarianRageIntegrationSuite) seedRageEncounter() {
 	}))
 
 	s.Require().NoError(enc.AddMonster(s.goblinMonsterInput(rageGoblinID, encountercore.Hex{Q: 1, R: 0, S: -1}, rageGoblinHP)))
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): bob (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_monk_unarmed_test.go
@@ -403,7 +403,10 @@ func (s *MonkUnarmedIntegrationSuite) seedMonkEncounter() {
 		DamageType:  "slashing",
 	}))
 
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): charli (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/integration_movement_oa_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_movement_oa_test.go
@@ -523,7 +523,10 @@ func (s *MovementOAIntegrationSuite) seedMovementEncounter() {
 		DataJSON:    goblinDataJSON,
 	}))
 
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
 }
 
@@ -567,7 +570,10 @@ func (s *MovementOAIntegrationSuite) seedMovementEncounterDiagonal() {
 		DataJSON:    goblinDataJSON,
 	}))
 
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/integration_player_shield_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_player_shield_test.go
@@ -301,7 +301,10 @@ func (s *PlayerShieldIntegrationSuite) seedShieldEncounter() {
 		DataJSON:    goblinDataJSON,
 	}))
 
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): wendy (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -594,7 +594,10 @@ func (s *SneakAttackIntegrationSuite) seedSneakEncounter() {
 		DamageType:  "slashing",
 	}))
 
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here. An explicit SetMode would now be
+	// redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
 }
 

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -165,25 +165,7 @@ func ProjectFor(
 		if visibleNow == nil || !visibleNow.Has(m.Position) {
 			continue
 		}
-		me := &encounterv2pb.Entity{
-			Id:       string(m.ID),
-			Position: HexToPosition(m.Position),
-			Type:     encounterv2pb.EntityType_ENTITY_TYPE_MONSTER,
-			Hp: &encounterv2pb.HitPoints{
-				Current: int32(m.HP),
-				Max:     int32(m.MaxHP),
-			},
-			Data: &encounterv2pb.Entity_Monster{
-				Monster: &encounterv2pb.MonsterData{
-					MonsterRef: monsterRefFor(m.MonsterRef),
-				},
-			},
-		}
-		if m.AC > 0 {
-			ac := int32(m.AC)
-			me.ArmorClass = &ac
-		}
-		entities = append(entities, me)
+		entities = append(entities, monsterEntity(m))
 	}
 
 	return &encounterv2pb.Encounter{
@@ -332,6 +314,42 @@ func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
 		e.ArmorClass = &ac
 	}
 	return e
+}
+
+// monsterEntity builds the wire-shape proto Entity for a monster, mirroring
+// playerEntity's shape (type + hp + armor_class + a Data oneof variant).
+// Unlike playerEntity, position is not a separate parameter — a monster's
+// current position always lives on its own MonsterData.Position (there is
+// no "viewer's own entity uses a different position source" case the way
+// players have snap.Position vs pd.View.Position).
+//
+// This is the SAME builder ProjectFor's snapshot path uses AND (rpg-api#644
+// playtest follow-up) the live EntityAppearedEvent translation path uses via
+// entityForID — one authoritative place for "how does a MonsterData become a
+// wire Entity" prevents the two paths from drifting the way they did before
+// this fix (the live path used to hand-build a bare {id, position} Entity
+// with no type, HP, or monster ref — see translateEntityAppearedEventWithData's
+// doc for the full story).
+func monsterEntity(m *tkenc.MonsterData) *encounterv2pb.Entity {
+	me := &encounterv2pb.Entity{
+		Id:       string(m.ID),
+		Position: HexToPosition(m.Position),
+		Type:     encounterv2pb.EntityType_ENTITY_TYPE_MONSTER,
+		Hp: &encounterv2pb.HitPoints{
+			Current: int32(m.HP),
+			Max:     int32(m.MaxHP),
+		},
+		Data: &encounterv2pb.Entity_Monster{
+			Monster: &encounterv2pb.MonsterData{
+				MonsterRef: monsterRefFor(m.MonsterRef),
+			},
+		},
+	}
+	if m.AC > 0 {
+		ac := int32(m.AC)
+		me.ArmorClass = &ac
+	}
+	return me
 }
 
 // monsterRefFor builds a proto Ref for a toolkit monster-ref string.

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -119,7 +119,7 @@ func ProjectFor(
 	// This requires the viewer's sight range from the persisted view.
 	var visibleNow core.HexSet
 	if vp, ok := data.Players[viewer]; ok && vp.View != nil {
-		visibleNow = perception.VisibleHexesAt(snap.Position, vp.View.SightRange)
+		visibleNow = perception.VisibleHexesAt(snap.Position, vp.View.SightRange, enc.Room())
 	}
 
 	// Collect entities visible to the viewer. Start with the viewer's own
@@ -192,9 +192,60 @@ func ProjectFor(
 		TurnState: buildTurnState(data, actorTurnState),
 		Space: &encounterv2pb.Space{
 			Hexes:    hexes,
+			Walls:    wallsToProto(data.Space),
 			Entities: entities,
 		},
 	}, nil
+}
+
+// wallsToProto converts an encounter's persisted room snapshot (rpg-toolkit
+// #757/#759's SpaceData) into the wire Wall list. Wave 1 wall visibility is
+// whole-room (design doc: "no per-viewer wall reveal yet"), so every viewer's
+// snapshot carries every wall unconditionally — unlike Hexes/Entities above,
+// this is NOT gated by RevealedHexes/visibleNow. space is nil for encounters
+// with no room (InitRoom never called — pre-wave-1 fixtures, non-spatial
+// encounters), which projects to an empty Walls list.
+func wallsToProto(space *tkenc.SpaceData) []*encounterv2pb.Wall {
+	if space == nil {
+		return nil
+	}
+	walls := make([]*encounterv2pb.Wall, 0, len(space.Walls))
+	for _, w := range space.Walls {
+		kind, ok := wallKindFor(w.BlocksMovement, w.BlocksLoS)
+		if !ok {
+			continue
+		}
+		// Wave 1 persists one degenerate (Start == End) segment per
+		// discretized wall hex (SpaceData.Walls doc) — From/To both convert
+		// the same cube coordinate.
+		from := HexToPosition(core.HexFromCube(w.Start))
+		to := HexToPosition(core.HexFromCube(w.End))
+		walls = append(walls, &encounterv2pb.Wall{From: from, To: to, Kind: kind})
+	}
+	return walls
+}
+
+// wallKindFor maps a wall segment's persisted BlocksMovement/BlocksLoS flags
+// (environments.WallSegmentData; wave 1 does not persist a WallType — see
+// rebuildRoomFromData's doc in rpg-toolkit/encounter/space.go) onto the
+// proto WallKind enum:
+//   - blocks both: SOLID (the common case for an interior wall)
+//   - blocks movement only: WINDOW (see through, can't walk through)
+//   - blocks LoS only: SOLID as a conservative fallback — wave 1's generator
+//     (environments.QuickRoom) never produces this combination, but a
+//     LoS-blocking segment shouldn't be silently dropped if one ever exists
+//   - blocks neither: not a wall worth putting on the wire (ok=false)
+func wallKindFor(blocksMovement, blocksLoS bool) (kind encounterv2pb.WallKind, ok bool) {
+	switch {
+	case blocksMovement && blocksLoS:
+		return encounterv2pb.WallKind_WALL_KIND_SOLID, true
+	case blocksMovement && !blocksLoS:
+		return encounterv2pb.WallKind_WALL_KIND_WINDOW, true
+	case !blocksMovement && blocksLoS:
+		return encounterv2pb.WallKind_WALL_KIND_SOLID, true
+	default:
+		return encounterv2pb.WallKind_WALL_KIND_UNSPECIFIED, false
+	}
 }
 
 // activeActorID returns the entity id of the actor whose turn it is, or "" when

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -10,6 +10,7 @@ import (
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
@@ -39,7 +40,10 @@ var originHex = core.Hex{Q: 0, R: 0, S: 0}
 // stub LoS at sightRange returns from pos.
 func newPlayerData(pid core.PlayerID, eid core.EntityID, pos core.Hex, sightRange int) *tkenc.PlayerData {
 	view := perception.NewView(pid, pos, sightRange)
-	view.ApplyReveal(perception.VisibleHexesAt(pos, sightRange))
+	// nil room: these fixtures never call InitRoom, matching the pre-wave-1
+	// pure-radius LoS behavior (perception.VisibleHexesAt's documented nil-room
+	// fallback).
+	view.ApplyReveal(perception.VisibleHexesAt(pos, sightRange, nil))
 	return &tkenc.PlayerData{
 		ID:       pid,
 		EntityID: eid,
@@ -433,6 +437,72 @@ func (s *ProjectSuite) TestProjectFor_MonsterRef_TooManyColonsTreatedAsMalformed
 		s.Require().Equal("dnd5e:monsters:goblin:variant", ref.GetId(),
 			"3+ colons -> fallback (raw lands in Id), per splitRef's strict contract")
 	}
+}
+
+// TestProjectFor_PopulatesWalls_WholeRoomVisibility covers rpg-api#644 step
+// 7: Space.Walls must be populated from the encounter's persisted room
+// snapshot (rpg-toolkit#757's SpaceData), converting each WallSegmentData's
+// cube-coordinate Start/End into wire Positions and mapping
+// BlocksMovement/BlocksLoS onto WallKind. Wave 1 wall visibility is
+// whole-room (design doc) — unlike Hexes/Entities, walls are NOT gated by
+// the viewer's RevealedHexes/visibleNow, so even a wall alice has never
+// stood near must still appear.
+func (s *ProjectSuite) TestProjectFor_PopulatesWalls_WholeRoomVisibility() {
+	data := tkenc.NewData("enc-walls")
+	data.Mode = core.ModeFreeRoam
+
+	alice := newPlayerData("player-alice", "char-alice", originHex, 2)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
+
+	// solidHex sits well outside alice's sight range (2) so this test also
+	// proves wall projection is whole-room, not LOS-gated like Hexes/Entities.
+	solidHex := core.Hex{Q: 8, R: -8, S: 0}
+	windowHex := core.Hex{Q: 1, R: -1, S: 0}
+	data.Space = &tkenc.SpaceData{
+		Width:  10,
+		Height: 10,
+		Walls: []environments.WallSegmentData{
+			{Start: solidHex.ToCube(), End: solidHex.ToCube(), BlocksMovement: true, BlocksLoS: true},
+			{Start: windowHex.ToCube(), End: windowHex.ToCube(), BlocksMovement: true, BlocksLoS: false},
+		},
+	}
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+
+	walls := pb.GetSpace().GetWalls()
+	s.Require().Len(walls, 2, "both walls must be emitted regardless of alice's sight range")
+
+	byKind := make(map[encounterv2pb.WallKind]*encounterv2pb.Wall, 2)
+	for _, w := range walls {
+		byKind[w.GetKind()] = w
+	}
+
+	solid := byKind[encounterv2pb.WallKind_WALL_KIND_SOLID]
+	s.Require().NotNil(solid, "BlocksMovement+BlocksLoS must map to WALL_KIND_SOLID")
+	s.Require().Equal(int32(8), solid.GetFrom().GetX())
+	s.Require().Equal(int32(-8), solid.GetFrom().GetY())
+	s.Require().Equal(int32(0), solid.GetFrom().GetZ())
+	s.Require().Equal(solid.GetFrom(), solid.GetTo(), "wave 1 walls are degenerate Start==End segments")
+
+	window := byKind[encounterv2pb.WallKind_WALL_KIND_WINDOW]
+	s.Require().NotNil(window, "BlocksMovement without BlocksLoS must map to WALL_KIND_WINDOW")
+	s.Require().Equal(int32(1), window.GetFrom().GetX())
+	s.Require().Equal(int32(-1), window.GetFrom().GetY())
+}
+
+// TestProjectFor_NilSpace_EmptyWalls covers the pre-wave-1 fallback: an
+// encounter with no room (InitRoom never called, data.Space == nil) must
+// project an empty Walls list, not panic.
+func (s *ProjectSuite) TestProjectFor_NilSpace_EmptyWalls() {
+	data := tkenc.NewData("enc-no-room")
+	data.Mode = core.ModeFreeRoam
+	alice := newPlayerData("player-alice", "char-alice", originHex, 2)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+	s.Require().Empty(pb.GetSpace().GetWalls())
 }
 
 func TestProjectSuite(t *testing.T) {

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -263,11 +263,19 @@ func translateHexRevealedEvent(e *events.HexRevealedEvent, viewer core.PlayerID,
 }
 
 // translateEntityAppearedEvent maps the toolkit's EntityAppearedEvent to the
-// v1alpha2 EntityAppeared proto envelope. The proto carries an Entity message
-// (id + position) plus a free-form reason string. The toolkit event provides
-// only EntityID + Position; the wire form populates a minimal Entity{id,
-// position} and leaves richer fields (type, display_name, hp, etc.) for the
-// web to look up from its snapshot. See gap note in EntityDisappeared below.
+// v1alpha2 EntityAppeared proto envelope, carrying only what the toolkit
+// event itself provides (EntityID + Position) — a bare Entity{id, position}
+// with Type/Hp/ArmorClass/the Character-or-Monster oneof all left unset.
+//
+// The live stream (handler.go's translateForStream) does NOT call this —
+// rpg-api#644's playtest follow-up replaced that call site with
+// translateEntityAppearedEventWithData, which looks the entity up in the
+// already-loaded encounter data to populate the fields this function leaves
+// bare (that gap — a monster appearing over the wire as type=UNSPECIFIED,
+// rendering as a generic capsule instead of its model — was the playtest
+// finding). This function remains the TranslateEvent dispatch's fallback for
+// any caller with only the bare toolkit event and no data to enrich it with
+// (see TestTranslateEvent_EntityAppearedEvent_HappyPath).
 func translateEntityAppearedEvent(e *events.EntityAppearedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
 	if _, ok := e.PerPlayer[viewer]; !ok {
 		return nil, ErrViewerSawNothing
@@ -285,6 +293,107 @@ func translateEntityAppearedEvent(e *events.EntityAppearedEvent, viewer core.Pla
 			},
 		},
 	}, nil
+}
+
+// translateEntityAppearedEventWithData is the data-aware translator for
+// EntityAppearedEvent (rpg-api#644 playtest follow-up). The toolkit event
+// carries only an entity ID + position — see translateEntityAppearedEvent's
+// doc for why: a deliberate minimal cause-event shape the toolkit uses for
+// BOTH "a player becomes visible to another player" (encounter.go's
+// applyAndPublishMove) and, since rpg-toolkit#762, "a monster becomes
+// visible to the mover" (monsterVisibilityTransitions) — in the monster
+// case the toolkit has the full *MonsterData in hand at the publish site but
+// deliberately narrows to just ID+Position before constructing the event,
+// mirroring the DoorOpened/parallel-HexRevealedEvent cause/effect split
+// already established in this file: the toolkit's cause event carries
+// identity, the consumer enriches.
+//
+// entityForID looks the entity up in the already-loaded data to build the
+// FULL wire Entity (type + hp + armor_class + character/monster data),
+// reusing the exact same playerEntity/monsterEntity builders ProjectFor's
+// snapshot path uses — one authoritative place for "how does a
+// PlayerData/MonsterData become a wire Entity" so the live and snapshot
+// paths cannot drift the way they did before this fix.
+//
+// data is loaded fresh by the caller (translateForStream) rather than
+// threaded through TranslateEvent's generic signature — mirrors the
+// InputRequiredDeliveredEvent / InitiativeRolled data-aware branches already
+// in this file. Unlike InitiativeRolled (rpg-api#647: the roster value
+// doesn't exist anywhere until the SAME in-flight request rolls it), this
+// read is NOT racy: the appearing entity's identity was always persisted by
+// an earlier, separate, already-completed request (AddPlayer/AddMonster
+// inside StartEncounter or devcombat.Inject) — the only call site that can
+// ever produce this event is enc.Move(), which always runs against an
+// encounter MoveEntity's orchestrator already loaded from the repo. No
+// retry needed (contrast loadRolledInitiative below).
+func translateEntityAppearedEventWithData(
+	e *events.EntityAppearedEvent, viewer core.PlayerID, now time.Time, data *encounter.Data,
+) (*encounterv2pb.EncounterEvent, error) {
+	if _, ok := e.PerPlayer[viewer]; !ok {
+		return nil, ErrViewerSawNothing
+	}
+
+	entity := entityForID(data, e.Entity)
+	if entity == nil {
+		// Defensive: the entity is gone from data between publish and this
+		// read (e.g. killed the same tick) — fall back to the bare shape
+		// rather than dropping the event outright; the client still learns
+		// something appeared, just without enrichment.
+		entity = &encounterv2pb.Entity{Id: string(e.Entity), Position: HexToPosition(e.Position)}
+	} else {
+		// Position must be the EVENT's own reported position, not the
+		// entity's current/final stored position from data — these can
+		// legitimately differ. The toolkit's ProjectVisibilityTransition can
+		// report "appeared" at an INTERMEDIATE hex of a multi-hex
+		// pass-through move, not the mover's final resting position (a real
+		// case this fix regressed against
+		// TestMovementSlicePerViewerProjection_AsymmetricLoS until caught:
+		// viewer B, SightRange 1, sees mover A only at the one hex A passes
+		// through B's vision, which is not where A ends up after their full
+		// move). entityForID's builders (playerEntity/monsterEntity) get
+		// every OTHER field right from the authoritative stored data — type,
+		// hp, armor_class, character/monster data are not position-scoped
+		// the way this is — only Position needs the event's own value.
+		entity.Position = HexToPosition(e.Position)
+	}
+
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(e.Sequence()),
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_EntityAppeared{
+			EntityAppeared: &encounterv2pb.EntityAppeared{
+				Entity: entity,
+				Reason: "entered LOS",
+			},
+		},
+	}, nil
+}
+
+// entityForID looks up id in data's players/monsters and builds the wire
+// Entity for it via the same playerEntity/monsterEntity builders ProjectFor
+// uses, or nil if id belongs to neither (should not happen for a live
+// EntityAppearedEvent, whose Entity always names a combatant already in
+// this encounter's Players/Monsters at publish time — see
+// translateEntityAppearedEventWithData's doc on why that read isn't racy).
+//
+// The position passed into playerEntity here is a placeholder — the caller
+// (translateEntityAppearedEventWithData) always overwrites .Position with
+// the event's own reported position afterward (see its doc for why), so
+// this does not need pd.View to be populated to enrich the rest of the
+// entity's fields.
+func entityForID(data *encounter.Data, id core.EntityID) *encounterv2pb.Entity {
+	if data == nil {
+		return nil
+	}
+	if m, ok := data.Monsters[id]; ok {
+		return monsterEntity(m)
+	}
+	if pid := playerSeatForEntity(data, id); pid != "" {
+		if pd := data.Players[pid]; pd != nil {
+			return playerEntity(pd, core.Hex{})
+		}
+	}
+	return nil
 }
 
 // translateEntityDisappearedEvent maps the toolkit's EntityDisappearedEvent to

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -606,6 +606,45 @@ func translateModeChangedEvent(e *events.ModeChangedEvent, viewer core.PlayerID,
 	}, nil
 }
 
+// translateInitiativeRolledEvent builds the proto InitiativeRolled envelope
+// carrying the encounter's freshly-rolled turn order (rpg-api#644 playtest
+// follow-up). Unlike every other translator in this file, it has no
+// corresponding toolkit event to translate FROM: rollInitiative (inside
+// SetMode, rpg-toolkit encounter/combat.go) mutates data.Initiative in place
+// but publishes no dedicated roster event — only ModeChangedEvent and
+// TurnStartedEvent fire at the FREE_ROAM->TURN_BASED transition, and neither
+// proto carries a roster field (ModeChanged: from/to/reason; TurnStarted:
+// entity_id/round — see events.proto). InitiativeRolled{order} is a separate
+// message already defined on the wire (events.proto's EncounterEvent oneof,
+// field 41) that no rpg-api code populated until now — zero proto changes
+// needed.
+//
+// The stream loop (handler.go's translateForStream) calls this once,
+// alongside the normal ModeChanged translation, when it observes the
+// transition to TURN_BASED — not on every TurnStartedEvent, which also
+// fires on every later per-turn advance and would otherwise resend the same
+// static roster every turn. seq is shared with the paired ModeChangedEvent:
+// this envelope is that transition's effect, not an independently-caused
+// event of its own (mirrors the DoorOpened/parallel-HexRevealedEvent
+// cause/effect split elsewhere in this file, except here one toolkit cause
+// produces two wire envelopes instead of two toolkit events each producing
+// one).
+func translateInitiativeRolledEvent(seq uint64, initiative []core.EntityID, now time.Time) *encounterv2pb.EncounterEvent {
+	order := make([]string, 0, len(initiative))
+	for _, eid := range initiative {
+		order = append(order, string(eid))
+	}
+	return &encounterv2pb.EncounterEvent{
+		Sequence:  int64(seq), //nolint:gosec // sequence is monotonic; fits int64
+		Timestamp: timestamppb.New(now),
+		Event: &encounterv2pb.EncounterEvent_InitiativeRolled{
+			InitiativeRolled: &encounterv2pb.InitiativeRolled{
+				Order: order,
+			},
+		},
+	}
+}
+
 // translateTurnStartedEvent maps the toolkit's TurnStartedEvent to the proto
 // TurnStarted envelope. Round is 1-indexed in both shapes.
 func translateTurnStartedEvent(e *events.TurnStartedEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -885,7 +885,10 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice/bob
+	// (sight range 10, no room) already see the goblin(s) just added, so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
 
 	// Walk initiative until a player is active so both TakeAction and
@@ -1110,7 +1113,10 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_KillLastHostile_FiresDeath
 		"bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0})))
 	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
 		"goblin-1", core.Hex{Q: 2, R: -1, S: -1})))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice/bob
+	// (sight range 10, no room) already see the goblin(s) just added, so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
 
 	// Cycle past any leading NPC turn so a player is active and TakeAction
@@ -1249,7 +1255,10 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_KillOneOfTwoHostiles_NoEnc
 		"goblin-1", core.Hex{Q: 2, R: -1, S: -1})))
 	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
 		"goblin-2", core.Hex{Q: 3, R: -2, S: -1})))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice/bob
+	// (sight range 10, no room) already see the goblin(s) just added, so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
 
 	s.advanceUntilPlayerActiveByDirectToolkit(enc)

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -220,6 +220,123 @@ func (s *EncounterV2IntegrationSuite) TestModeChangedToTurnBased_StreamCarriesIn
 	s.Require().ElementsMatch([]string{"char-alice", "char-bob", "goblin-1"}, rosterB.GetOrder())
 }
 
+// TestEntityAppearedEvent_StreamCarriesEntityType is the rpg-api#644
+// playtest follow-up gate test: a live EntityAppeared must carry the SAME
+// Type/Hp/ArmorClass/Data enrichment the connect-time snapshot already does.
+// Before this fix, translateEntityAppearedEvent built a bare {id, position}
+// Entity for the live path — a monster becoming visible via a live Move
+// (rpg-toolkit#762) projected as type=UNSPECIFIED, rendering as a generic
+// capsule on the web instead of its model. Covers both directions the
+// toolkit's EntityAppearedEvent serves: a monster appearing to the mover
+// (must carry Type=MONSTER + MonsterRef/Hp/AC), and a player-mover appearing
+// to another player (must still carry Type=CHARACTER).
+func (s *EncounterV2IntegrationSuite) TestEntityAppearedEvent_StreamCarriesEntityType() {
+	encID := "enc-entity-appeared-type"
+
+	enc := tkenc.New(context.Background(), core.EncounterID(encID), s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 3,
+	}))
+	// bob starts far from both alice and the goblin so nothing is visible at
+	// connect — checkCombatEntry must not fire from either player's own
+	// starting position; this test needs FREE_ROAM until the moves below.
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 4, R: 3, S: -7}, SightRange: 3,
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 4, R: -4, S: 0},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "nobody sees anybody from these starting positions")
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	ctxA := s.authCtx("alice")
+	ctxB := s.authCtx("bob")
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxA, &encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxB, &encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+
+	// Drain snapshots.
+	snapA, err := streamA.Recv()
+	s.Require().NoError(err)
+	s.Require().NotNil(snapA.GetSnapshotDelivered())
+	snapB, err := streamB.Recv()
+	s.Require().NoError(err)
+	s.Require().NotNil(snapB.GetSnapshotDelivered())
+
+	// --- Move 1: alice walks onto the goblin's hex — reveals the MONSTER to
+	// her. This also flips the encounter to TURN_BASED by rule (checkCombatEntry);
+	// irrelevant to this test's assertions but a real side effect worth noting.
+	_, err = s.srv.EncounterClientV2.MoveEntity(ctxA, &encounterv2pb.MoveEntityRequest{
+		EncounterId: encID,
+		EntityId:    "char-alice",
+		ProposedPath: []*encounterv2pb.Position{
+			{X: 0, Y: 0, Z: 0}, {X: 1, Y: -1, Z: 0}, {X: 2, Y: -2, Z: 0},
+			{X: 3, Y: -3, Z: 0}, {X: 4, Y: -4, Z: 0},
+		},
+	})
+	s.Require().NoError(err)
+
+	// --- Move 2: bob walks toward alice's new position — a player-mover
+	// (bob) becomes visible to another player (alice). alice's stream must
+	// receive EntityAppeared(char-bob) with Type=CHARACTER.
+	//
+	// Issued before collecting: collectStreamEvents spawns a background
+	// reader that only exits on stream closure, not on its own timeout, so
+	// calling it twice against the SAME stream (once per move) would leave
+	// two goroutines concurrently reading streamA — a real data race in the
+	// test helper's Recv() usage, caught by -race. One collection after both
+	// moves avoids it.
+	_, err = s.srv.EncounterClientV2.MoveEntity(ctxB, &encounterv2pb.MoveEntityRequest{
+		EncounterId: encID,
+		EntityId:    "char-bob",
+		ProposedPath: []*encounterv2pb.Position{
+			{X: 4, Y: 3, Z: -7}, {X: 4, Y: 2, Z: -6}, {X: 4, Y: 1, Z: -5},
+			{X: 4, Y: 0, Z: -4}, {X: 4, Y: -1, Z: -3},
+		},
+	})
+	s.Require().NoError(err)
+
+	eventsA := s.collectStreamEvents(streamA, 30, 3*time.Second)
+	var monsterAppear, playerAppear *encounterv2pb.EntityAppeared
+	for _, ev := range eventsA {
+		a := ev.GetEntityAppeared()
+		if a == nil {
+			continue
+		}
+		switch a.GetEntity().GetId() {
+		case "goblin-1":
+			monsterAppear = a
+		case "char-bob":
+			playerAppear = a
+		}
+	}
+
+	s.Require().NotNil(monsterAppear, "alice's stream must receive EntityAppeared for the goblin she walked up to")
+	gobEntity := monsterAppear.GetEntity()
+	s.Require().Equal(encounterv2pb.EntityType_ENTITY_TYPE_MONSTER, gobEntity.GetType())
+	s.Require().NotNil(gobEntity.GetHp())
+	s.Require().Equal(int32(7), gobEntity.GetHp().GetCurrent())
+	s.Require().Equal(int32(7), gobEntity.GetHp().GetMax())
+	s.Require().Equal(int32(15), gobEntity.GetArmorClass())
+	monsterData := gobEntity.GetMonster()
+	s.Require().NotNil(monsterData, "monster entity must carry the MonsterData oneof variant")
+	s.Require().Equal("goblin", monsterData.GetMonsterRef().GetId())
+
+	s.Require().NotNil(playerAppear, "alice's stream must receive EntityAppeared for bob when he moves into her sight")
+	bobEntity := playerAppear.GetEntity()
+	s.Require().Equal(encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER, bobEntity.GetType())
+	characterData := bobEntity.GetCharacter()
+	s.Require().NotNil(characterData, "player entity must carry the CharacterData oneof variant")
+	s.Require().Equal("bob", characterData.GetPlayerId())
+}
+
 // TestMovementSlicePerViewerProjection_AsymmetricLoS exercises the harder
 // per-viewer-projection case: viewer B has SightRange:1 (sees only adjacent
 // hexes), the mover A walks past B's vision and out the other side.

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -120,6 +120,106 @@ func (s *EncounterV2IntegrationSuite) TestMovementSliceTwoPlayers() {
 	s.Require().Len(movB.ActualPath, 3, "B should see all 3 path hexes in mutual LoS")
 }
 
+// TestModeChangedToTurnBased_StreamCarriesInitiativeRoster is the rpg-api#644
+// playtest follow-up gate test: the toolkit's rollInitiative (inside SetMode,
+// called from the inline checkCombatEntry a Move can trigger) rolls
+// data.Initiative but publishes no dedicated roster event — ModeChangedEvent
+// and TurnStartedEvent carry no initiative field. Before this fix, a
+// mid-stream FREE_ROAM -> TURN_BASED transition left the client's
+// initiativeOrder empty until the next full snapshot (only the connect-time
+// snapshot's TurnState.InitiativeOrder was ever populated). This proves the
+// LIVE transition itself now broadcasts an InitiativeRolled envelope
+// (events.proto field 41, already on the wire, unused until now) carrying
+// the full roster, to every connected viewer — not just the one who moved.
+func (s *EncounterV2IntegrationSuite) TestModeChangedToTurnBased_StreamCarriesInitiativeRoster() {
+	encID := "enc-initiative-roster"
+
+	// alice: SightRange 3, well short of the goblin's starting distance (4)
+	// so the encounter starts FREE_ROAM. bob: a second viewer, also out of
+	// the goblin's initial sight, proving the roster reaches every stream —
+	// not just alice's, who caused the transition.
+	enc := tkenc.New(context.Background(), core.EncounterID(encID), s.srv.BrokerV2)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 3,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: -1, R: 0, S: 1}, SightRange: 3,
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 4, R: -4, S: 0},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "goblin starts outside every player's sight")
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
+
+	ctxA := s.authCtx("alice")
+	ctxB := s.authCtx("bob")
+
+	streamA, err := s.srv.EncounterClientV2.StreamEncounter(ctxA, &encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+	streamB, err := s.srv.EncounterClientV2.StreamEncounter(ctxB, &encounterv2pb.StreamEncounterRequest{EncounterId: encID})
+	s.Require().NoError(err)
+
+	// Drain snapshots (mode still FREE_ROAM at connect).
+	snapA, err := streamA.Recv()
+	s.Require().NoError(err)
+	s.Require().NotNil(snapA.GetSnapshotDelivered())
+	s.Require().Empty(snapA.GetSnapshotDelivered().GetEncounter().GetTurnState().GetInitiativeOrder())
+	snapB, err := streamB.Recv()
+	s.Require().NoError(err)
+	s.Require().NotNil(snapB.GetSnapshotDelivered())
+
+	// alice walks onto the goblin's hex — a Move that forms sight, triggering
+	// the toolkit's inline checkCombatEntry -> SetMode(TURN_BASED).
+	_, err = s.srv.EncounterClientV2.MoveEntity(ctxA, &encounterv2pb.MoveEntityRequest{
+		EncounterId: encID,
+		EntityId:    "char-alice",
+		ProposedPath: []*encounterv2pb.Position{
+			{X: 0, Y: 0, Z: 0}, {X: 1, Y: -1, Z: 0}, {X: 2, Y: -2, Z: 0},
+			{X: 3, Y: -3, Z: 0}, {X: 4, Y: -4, Z: 0},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Persisted state confirms the transition and the rolled roster.
+	loaded, err := s.srv.EncRepoV2.Get(s.ctx, encID)
+	s.Require().NoError(err)
+	s.Require().Equal(core.ModeTurnBased, loaded.Mode, "the move must have formed sight and flipped the mode by rule")
+	s.Require().ElementsMatch(
+		[]core.EntityID{"char-alice", "char-bob", "goblin-1"},
+		loaded.Initiative,
+		"initiative must include every combatant",
+	)
+
+	// Both alice's and bob's streams receive InitiativeRolled — the roster
+	// broadcast is not limited to the player whose Move caused the transition.
+	eventsA := s.collectStreamEvents(streamA, 20, 3*time.Second)
+	var rosterA *encounterv2pb.InitiativeRolled
+	for _, ev := range eventsA {
+		if r := ev.GetInitiativeRolled(); r != nil {
+			rosterA = r
+			break
+		}
+	}
+	s.Require().NotNil(rosterA, "alice's stream must receive InitiativeRolled on the FREE_ROAM->TURN_BASED transition")
+	s.Require().ElementsMatch([]string{"char-alice", "char-bob", "goblin-1"}, rosterA.GetOrder())
+
+	eventsB := s.collectStreamEvents(streamB, 20, 3*time.Second)
+	var rosterB *encounterv2pb.InitiativeRolled
+	for _, ev := range eventsB {
+		if r := ev.GetInitiativeRolled(); r != nil {
+			rosterB = r
+			break
+		}
+	}
+	s.Require().NotNil(rosterB, "bob's stream must ALSO receive InitiativeRolled — it is broadcast, not private to the mover")
+	s.Require().ElementsMatch([]string{"char-alice", "char-bob", "goblin-1"}, rosterB.GetOrder())
+}
+
 // TestMovementSlicePerViewerProjection_AsymmetricLoS exercises the harder
 // per-viewer-projection case: viewer B has SightRange:1 (sees only adjacent
 // hexes), the mover A walks past B's vision and out the other side.

--- a/internal/orchestrators/character/mock/mock_service.go
+++ b/internal/orchestrators/character/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 	gomock "go.uber.org/mock/gomock"
+
+	character "github.com/KirkDiggler/rpg-api/internal/orchestrators/character"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/dice/mock/mock_service.go
+++ b/internal/orchestrators/dice/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 	gomock "go.uber.org/mock/gomock"
+
+	dice "github.com/KirkDiggler/rpg-api/internal/orchestrators/dice"
 )
 
 // MockService is a mock of Service interface.

--- a/internal/orchestrators/encounter/v2/drive_npc_test.go
+++ b/internal/orchestrators/encounter/v2/drive_npc_test.go
@@ -112,7 +112,10 @@ func (s *DriveStalledNPCTurnSuite) seedTurnBased(encID string, monsterIDs []core
 			DamageType:  "slashing",
 		}))
 	}
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): bob (sight
+	// range 10, no room) already sees the first monster added, so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	data := enc.ToData()
 	data.Initiative = initiative
 	data.ActiveIdx = activeIdx

--- a/internal/orchestrators/encounter/v2/end_turn_npc_pause_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_npc_pause_test.go
@@ -161,7 +161,10 @@ func (s *EndTurnNPCPauseSuite) seedGoblinAdjacentToWizard() {
 		DamageType:  "slashing",
 		DataJSON:    rawData,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): wendy (sight
+	// range 10, no room) already sees the goblin at (1,0,-1), so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	data := enc.ToData()
 	// wendy active (idx 0), goblin next (idx 1): ending wendy's turn advances to
 	// the goblin and the NPC dispatch loop runs the goblin's turn.

--- a/internal/orchestrators/encounter/v2/end_turn_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_test.go
@@ -119,7 +119,10 @@ func (s *EndTurnSuite) seedTurnBased(encID string, initiative []core.EntityID, a
 		DamageDice:  "1d6+2",
 		DamageType:  "slashing",
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): bob (sight
+	// range 10, no room) already sees the goblin at (1,0,-1), so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	data := enc.ToData()
 	data.Initiative = initiative
 	data.ActiveIdx = activeIdx
@@ -242,7 +245,9 @@ func (s *EndTurnSuite) TestEndTurn_NPCDispatchLoop_CyclesPastConsecutiveNPCs() {
 		ID: goblin2, Position: core.Hex{Q: 2, R: 0, S: -2}, HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		MonsterRef: "dnd5e:monsters:goblin", AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): the first
+	// goblin add already self-transitions to TURN_BASED, so an explicit
+	// SetMode here would be redundant and error.
 	data := enc.ToData()
 	data.Initiative = []core.EntityID{etEntityBob, etGoblinID, goblin2}
 	data.ActiveIdx = 0

--- a/internal/orchestrators/encounter/v2/take_action_test.go
+++ b/internal/orchestrators/encounter/v2/take_action_test.go
@@ -124,7 +124,10 @@ func (s *TakeActionSuite) seedCombat(encID string, goblinHP int) {
 		DamageDice:  "1d6+2",
 		DamageType:  "slashing",
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): bob (sight
+	// range 10, no room) already sees the goblin at (1,0,-1), so the
+	// encounter self-transitions to TURN_BASED here. An explicit SetMode
+	// would now be redundant and error ("mode is already TURN_BASED").
 	data := enc.ToData()
 	// Force bob active so the active-actor gate passes deterministically.
 	data.Initiative = []core.EntityID{taEntityBob, taGoblinID}
@@ -205,14 +208,16 @@ func (s *TakeActionSuite) TestTakeAction_UnknownTarget_ErrUnknownTarget() {
 }
 
 func (s *TakeActionSuite) TestTakeAction_NotTurnBased_ErrNotTurnBased() {
-	// Free-roam encounter: TakeActionPhased gates on ModeTurnBased.
+	// Free-roam encounter: TakeActionPhased gates on ModeTurnBased. The
+	// goblin sits outside bob's sight range (rpg-toolkit#759 combat-entry
+	// check runs inline on AddMonster) so the encounter stays FREE_ROAM.
 	enc := tkenc.New(s.ctx, "enc-free-roam", s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: taPlayerBob, EntityID: taEntityBob, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
 		HP: 14, MaxHP: 14, AC: 14, AttackBonus: 5, DamageDice: "1d12+3", DamageType: "slashing",
 	}))
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
-		ID: taGoblinID, Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 100, MaxHP: 100, AC: 15, Speed: 6,
+		ID: taGoblinID, Position: core.Hex{Q: 10, R: 0, S: -10}, HP: 100, MaxHP: 100, AC: 15, Speed: 6,
 		MonsterRef: "dnd5e:monsters:goblin", AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
 	}))
 	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))

--- a/internal/orchestrators/lobby/character.go
+++ b/internal/orchestrators/lobby/character.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-api/internal/apierr"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	tkevents "github.com/KirkDiggler/rpg-toolkit/events"
+	tkcharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
 
 // resolveCharacter loads characterID and validates it belongs to playerID
@@ -73,9 +76,66 @@ func (o *Orchestrator) seedMemberCombatSnapshot(ctx context.Context, characterID
 	if out == nil || out.Character == nil || out.Character.Data == nil {
 		return memberCombatSnapshot{}, nil
 	}
+
+	if err := o.clearStaleActionEconomy(ctx, out.Character); err != nil {
+		return memberCombatSnapshot{}, err
+	}
+
 	return memberCombatSnapshot{
 		hp:    out.Character.Data.HitPoints,
 		maxHP: out.Character.Data.MaxHitPoints,
 		ac:    out.Character.Data.ArmorClass,
 	}, nil
+}
+
+// clearStaleActionEconomy resets char's toolkit action economy back to nil
+// (out of combat) and persists that reset, if it's carrying one forward
+// from a PRIOR encounter — a wave-close playtest blocker found live on the
+// dev stack (rpg-api#644): alice's persisted action_economy carried
+// movement_remaining=0 from an earlier session's combat into a brand-new
+// StartEncounter call, and every MoveEntity on that fresh FREE_ROAM
+// encounter failed "insufficient movement remaining: Nft, 0ft remaining" —
+// even though nothing about the NEW encounter had happened yet.
+//
+// Root cause: character.Character.ActionEconomy has no encounter scoping —
+// it is a flat field on the character record, not keyed by which encounter
+// set it. rpg-toolkit's own Move() budget gate (encounter/combat.go's
+// ErrInsufficientMovement) checks InCombat() as "does this character have a
+// non-nil action economy right now", with no way to tell "mid-turn in the
+// encounter I'm currently in" apart from "leftover from a different,
+// already-ended encounter". ExitCombat() exists specifically to clear this
+// ("Call this when the encounter ends, not between turns" — its own doc),
+// but nothing in rpg-api or rpg-toolkit's own encounter package ever calls
+// it (verified: zero call sites for either). SeedTurnEconomyForData
+// (hydrate_players.go) can't fix this either — it deliberately treats ANY
+// non-nil economy as "already legitimately seeded, don't touch it", because
+// mid-encounter it can't tell live-and-depleted apart from stale-and-
+// abandoned; that guard is correct for its own job and cannot double as
+// this one.
+//
+// StartEncounter is the correct, narrowly-scoped place for this: it is the
+// SOLE path a new encounter comes into existence (lobby-service.md), so at
+// this exact moment every member's character is, by definition, not
+// mid-turn in the encounter about to exist — clearing action economy here
+// can never stomp a real in-progress turn. This is a defensive backstop,
+// not the complete fix: the toolkit or rpg-api's encounter-end handling
+// should still call ExitCombat() when an encounter properly ends, so a
+// character never carries stale economy into the NEXT encounter in the
+// first place; that gap remains open (see docs/status.md).
+func (o *Orchestrator) clearStaleActionEconomy(ctx context.Context, char *entities.Character) error {
+	if char.Data == nil || char.Data.ActionEconomy == nil {
+		return nil
+	}
+	live, err := tkcharacter.LoadFromData(ctx, char.Data, tkevents.NewEventBus())
+	if err != nil {
+		return fmt.Errorf("load character %q to clear stale combat economy: %w", char.Data.ID, err)
+	}
+	if _, exitErr := live.ExitCombat(ctx, &tkcharacter.ExitCombatInput{}); exitErr != nil {
+		return fmt.Errorf("clear stale combat economy for character %q: %w", char.Data.ID, exitErr)
+	}
+	char.Data = live.ToData()
+	if _, updErr := o.characterRepo.Update(ctx, characterrepo.UpdateInput{Character: char}); updErr != nil {
+		return fmt.Errorf("persist cleared combat economy for character %q: %w", char.Data.ID, updErr)
+	}
+	return nil
 }

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -2,12 +2,20 @@ package lobby
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
+	rpgcore "github.com/KirkDiggler/rpg-toolkit/core"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spawn"
 )
 
 // StartEncounterInput carries the entity-typed StartEncounter request.
@@ -41,6 +49,41 @@ const spawnPositionSpacing = 1
 // encounters; character-derived vision is future work (deferred per
 // rpg-api#632's correction comment).
 const memberSightRange = 10
+
+// roomWidth/roomHeight are the freshly-created encounter's room dimensions
+// (rpg-api#644, The Dungeon wave 1). Deliberately large relative to
+// memberSightRange (10): PatternRandom's default wall density is sparse
+// (~1 wall per 10 sq units — see environments.RandomPattern) and not
+// reliably enough on its own to hide a monster from a party spawned near
+// the room's origin. A 20x20 room guarantees floor beyond hex-distance 10
+// from a near-origin party purely by distance, so safeGoblinHexes always
+// has a hiding spot regardless of the random wall roll; walls create
+// additional closer-in pockets on top of that. roomPattern is the only
+// pattern besides "empty" the toolkit ships (environments.PatternRandom /
+// PatternEmpty — see tools/environments/wall_patterns.go's WallPatterns
+// registry).
+const (
+	roomWidth   = 20
+	roomHeight  = 20
+	roomPattern = environments.PatternRandom
+)
+
+// goblinCount is the fixed number of goblins StartEncounter seeds into the
+// freshly-walled room (design doc fork 2, Kirk 2026-07-13: "fixed placement
+// of 2 goblins via monster.NewGoblin through the fixed spawn engine";
+// dynamic SpawnConfig-driven counts are wave 2+).
+const goblinCount = 2
+
+// Goblin combat-snapshot constants, matching every other goblin fixture in
+// this codebase (cmd/devseed/main.go, internal/pkg/devcombat/inject.go) so
+// StartEncounter's real goblins behave identically to the dev-tooling ones.
+const (
+	monsterRefGoblin  = "dnd5e:monsters:goblin"
+	goblinDamageDice  = "1d6+2"
+	goblinAttackBonus = 4
+	goblinSpeed       = 6 // 30ft / 5ft per hex
+	goblinDamageType  = "slashing"
+)
 
 // StartEncounter is the lobby -> encounter seam. Host-only, all-ready
 // gated, atomic member-set snapshot (guarded by the per-lobby lock so a
@@ -92,6 +135,14 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		tkenc.WithMovementResolver(o.buildMovementResolver(nil)),
 	)
 
+	// InitRoom must run before any AddPlayer/AddMonster call: AddPlayer's
+	// initial reveal (perception.VisibleHexesAt) and AddMonster's inline
+	// combat-entry check (perception.CanSeeAt) both consult e.room, and
+	// InitRoom is what sets it (rpg-toolkit encounter/space.go's doc).
+	if err := enc.InitRoom(roomWidth, roomHeight, roomPattern); err != nil {
+		return nil, fmt.Errorf("init room for encounter %q: %w", encID, err)
+	}
+
 	for i, m := range members {
 		snap, snapErr := o.seedMemberCombatSnapshot(ctx, m.CharacterID)
 		if snapErr != nil {
@@ -121,6 +172,14 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		}
 	}
 
+	// Seed 2 goblins into the walled room (rpg-api#644, The Dungeon wave 1).
+	// See seedGoblins' doc for why placement is verified via the toolkit's
+	// real perception.CanSeeAt rather than the spawn engine's own (stubbed)
+	// position search.
+	if err := o.seedGoblins(ctx, enc, encID); err != nil {
+		return nil, fmt.Errorf("seed goblins for encounter %q: %w", encID, err)
+	}
+
 	if err := o.encounterRepo.Save(ctx, enc.ToData()); err != nil {
 		return nil, fmt.Errorf("save encounter %q: %w", encID, err)
 	}
@@ -140,3 +199,156 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 
 	return &StartEncounterOutput{EncounterID: string(encID)}, nil
 }
+
+// seedGoblins selects goblinCount goblins via the tools/spawn engine (wired
+// to the encounter's own RoomOrchestrator, exercising rpg-toolkit#757/#759's
+// getRoomFromSpatial/placeEntityInRoom fix from a real caller) and adds them
+// to enc at positions verified to be outside every current player's sight —
+// via the toolkit's own wall-aware perception.CanSeeAt, the SAME predicate
+// checkCombatEntry uses internally, never hand-rolled LOS math. This is the
+// design doc's hard requirement (ideas/the-dungeon/design.md fork 2):
+// combat must not start at spawn. AddMonster inline-checks combat entry
+// (rpg-toolkit#759) on every call — a goblin added within a player's sight
+// would flip the encounter to TURN_BASED immediately, so placement has to be
+// pre-verified before AddMonster runs, not after.
+//
+// KNOWN TOOLKIT GAP (flag for a follow-up rpg-toolkit issue): the spawn
+// engine's own position search — BasicSpawnEngine.findValidPosition (a raw
+// random X,Y in [0,10), zero room awareness) and, when SpatialRules are
+// configured, ConstraintSolver.FindValidPositions (a hardcoded 1.0-10.0
+// grid sweep) — never calls room.CanPlaceEntity or room.IsLineOfSightBlocked
+// against the actual spatial.Room this wave built. Its optional LineOfSight
+// constraint is a Euclidean-distance stub (tools/spawn/constraints.go's
+// hasLineOfSight: "Real implementation would use spatial room queries for
+// wall intersections" — distance <= 8.0, walls not considered at all).
+// SpawnConfig also has no fixed/target-position injection point for a
+// caller that already knows where it wants an entity. So PopulateRoom's own
+// SpawnedEntity.Position is unusable for this wave's correctness bar and is
+// deliberately discarded below in favor of a position computed from real
+// toolkit predicates (safeGoblinHexes). PopulateRoom is still called (not
+// bypassed) so the RoomOrchestrator wiring is genuinely exercised end to
+// end; this does leave each goblin also registered as a room occupant at
+// that discarded scattered position, a side effect that's inert for wave 1
+// (monsters aren't otherwise tracked in the spatial room — only walls
+// occupy it, see rpg-toolkit encounter/space.go's wallCheckEntity doc — and
+// nothing in this flow queries room occupancy for monster positions).
+func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, encID core.EncounterID) error {
+	goblinIDs := make([]core.EntityID, goblinCount)
+	goblins := make([]*monster.Monster, goblinCount)
+	entities := make([]rpgcore.Entity, goblinCount)
+	for i := 0; i < goblinCount; i++ {
+		id := core.EntityID(fmt.Sprintf("goblin-%d", i+1))
+		g := monster.NewGoblin(string(id))
+		goblinIDs[i] = id
+		goblins[i] = g
+		entities[i] = g
+	}
+
+	registry := spawn.NewBasicSelectablesRegistry()
+	if err := registry.RegisterTable("goblins", entities); err != nil {
+		return fmt.Errorf("register goblin selection table: %w", err)
+	}
+	engine := spawn.NewBasicSpawnEngine(spawn.BasicSpawnEngineConfig{
+		ID:               "startencounter-goblins",
+		SelectablesReg:   registry,
+		RoomOrchestrator: enc.RoomOrchestrator(),
+	})
+	quantity := goblinCount
+	if _, err := engine.PopulateRoom(ctx, string(encID), spawn.SpawnConfig{
+		EntityGroups: []spawn.EntityGroup{{
+			ID:             "goblins",
+			Type:           "monster",
+			SelectionTable: "goblins",
+			Quantity:       spawn.QuantitySpec{Fixed: &quantity},
+		}},
+		Pattern: spawn.PatternScattered,
+	}); err != nil {
+		return fmt.Errorf("spawn engine populate room: %w", err)
+	}
+
+	safeHexes, err := safeGoblinHexes(enc, goblinCount)
+	if err != nil {
+		return err
+	}
+
+	for i, id := range goblinIDs {
+		goblinData := goblins[i].ToData()
+		goblinDataJSON, marshalErr := json.Marshal(goblinData)
+		if marshalErr != nil {
+			return fmt.Errorf("marshal goblin %q data: %w", id, marshalErr)
+		}
+		if addErr := enc.AddMonster(tkenc.MonsterInput{
+			ID:          id,
+			Position:    safeHexes[i],
+			HP:          goblinData.HitPoints,
+			MaxHP:       goblinData.MaxHitPoints,
+			AC:          goblinData.ArmorClass,
+			Speed:       goblinSpeed,
+			MonsterRef:  monsterRefGoblin,
+			AttackBonus: goblinAttackBonus,
+			DamageDice:  goblinDamageDice,
+			DamageType:  goblinDamageType,
+			DataJSON:    goblinDataJSON,
+		}); addErr != nil {
+			return fmt.Errorf("add goblin %q to encounter: %w", id, addErr)
+		}
+	}
+	return nil
+}
+
+// safeGoblinHexes returns n distinct hexes within the encounter's room that
+// are (a) not wall-occupied (room.CanPlaceEntity) and (b) not currently
+// visible to ANY player in the encounter, verified via the toolkit's own
+// wall-aware perception.CanSeeAt. Enumerates every offset-coordinate cell in
+// the room's bounds — core.HexFromPosition is the same offset<->cube bridge
+// rpg-toolkit's rebuildRoomFromData uses to place walls, so this walks
+// exactly the grid the room's wall placements are snapped to.
+func safeGoblinHexes(enc *tkenc.Encounter, n int) ([]core.Hex, error) {
+	room := enc.Room()
+	if room == nil {
+		return nil, errors.New("lobby orchestrator: encounter has no room to place goblins in (InitRoom not called)")
+	}
+	data := enc.ToData()
+
+	var candidates []core.Hex
+	for x := 0; x < roomWidth; x++ {
+		for y := 0; y < roomHeight; y++ {
+			hex := core.HexFromPosition(spatial.Position{X: float64(x), Y: float64(y)})
+			if !room.CanPlaceEntity(placementProbe{}, hex.ToPosition()) {
+				continue // wall-occupied
+			}
+			visibleToSomeone := false
+			for _, p := range data.Players {
+				if p.View != nil && perception.CanSeeAt(p.View, hex, room) {
+					visibleToSomeone = true
+					break
+				}
+			}
+			if !visibleToSomeone {
+				candidates = append(candidates, hex)
+			}
+		}
+	}
+	if len(candidates) < n {
+		return nil, fmt.Errorf(
+			"lobby orchestrator: found only %d safe (unwalled, unseen) hex(es) for %d goblins in a %dx%d room",
+			len(candidates), n, roomWidth, roomHeight)
+	}
+
+	// Random, distinct pick from the safe set so goblins scatter rather than
+	// always landing in the same corner. #nosec G404: game placement, not
+	// security-sensitive.
+	rand.Shuffle(len(candidates), func(i, j int) { candidates[i], candidates[j] = candidates[j], candidates[i] })
+	return candidates[:n], nil
+}
+
+// placementProbe is a throwaway core.Entity used only to query
+// room.CanPlaceEntity for wall-occupancy. Mirrors rpg-toolkit's own
+// wallCheckEntity (encounter/space.go), which is unexported: goblins
+// themselves are never placed into the spatial room (only walls occupy it —
+// see that same doc), so this identity is never compared against a real
+// occupant.
+type placementProbe struct{}
+
+func (placementProbe) GetID() string               { return "placement-probe" }
+func (placementProbe) GetType() rpgcore.EntityType { return "placement-probe" }

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -7,6 +7,7 @@ import (
 	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
@@ -176,4 +177,60 @@ func (s *LobbySuite) TestStartEncounter_PublishesEncounterStarted_AfterPersist()
 	// observable — that ordering is what makes the event safe to act on.
 	_, err = s.encRepo.Get(s.ctx, out.EncounterID)
 	s.Require().NoError(err)
+}
+
+// TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSightedMove is the
+// rpg-api#644 headline proof (The Dungeon wave 1, design doc "Done when"
+// bar): StartEncounter creates the encounter WITH a walled room and 2
+// goblins, combat does NOT start at spawn (the goblins are placed outside
+// alice's initial sight), and a Move that brings a goblin into sight flips
+// the encounter to TURN_BASED BY RULE — the toolkit's own inline
+// checkCombatEntry, not anything rpg-api triggers directly. No devseed
+// --inject-combat involved.
+func (s *LobbySuite) TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSightedMove() {
+	s.seedReadyLobby("lobby-dungeon", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-dungeon",
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+
+	// Walls on the wire: the encounter was created with a real room snapshot.
+	s.Require().NotNil(encData.Space, "StartEncounter must create the encounter with a room (rpg-toolkit#757 SpaceData)")
+	s.Require().Equal(20, encData.Space.Width)
+	s.Require().Equal(20, encData.Space.Height)
+
+	// 2 goblins seeded.
+	s.Require().Len(encData.Monsters, 2, "StartEncounter must seed exactly 2 goblins")
+	for id, m := range encData.Monsters {
+		s.Require().Positive(m.HP, "goblin %q must have positive HP", id)
+		s.Require().NotEmpty(m.DataJSON, "goblin %q must carry DataJSON (monster.NewGoblin, not a hand-rolled stub)", id)
+	}
+
+	// Combat must NOT have started at spawn: the goblins were placed outside
+	// alice's initial sight, so AddMonster's inline combat-entry check
+	// (rpg-toolkit#759) must not have fired.
+	s.Require().Equal(core.ModeFreeRoam, encData.Mode, "combat must not start at spawn — goblins are placed outside initial LOS")
+
+	// Rehydrate the live encounter (same broker StartEncounter used) and move
+	// alice directly onto one goblin's hex — a Move that forms sight. This
+	// must flip the encounter to TURN_BASED BY RULE (the toolkit's own inline
+	// checkCombatEntry), not via any rpg-api-side trigger.
+	enc, err := tkenc.LoadFromData(s.ctx, encData, s.encBroker)
+	s.Require().NoError(err)
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "rehydration must not itself flip mode")
+
+	var targetGoblin core.Hex
+	for _, m := range encData.Monsters {
+		targetGoblin = m.Position
+		break
+	}
+	s.Require().NoError(enc.Move("alice", []core.Hex{targetGoblin}),
+		"moving onto a pre-vetted (non-wall) goblin hex must not be blocked")
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
+		"a Move that brings a goblin into sight must flip the encounter to TURN_BASED by rule")
 }

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -4,11 +4,13 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/KirkDiggler/rpg-api/internal/apierr"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
 	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
 
 func (s *LobbySuite) seedReadyLobby(id, host string, others ...string) {
@@ -87,6 +89,58 @@ func (s *LobbySuite) TestStartEncounter_SeedsHonestCombatSnapshot() {
 	s.Require().Empty(alice.DamageDice, "no stored field to honestly derive damage dice from")
 	s.Require().Empty(alice.DamageType, "no stored field to honestly derive a damage type from")
 	s.Require().Empty(alice.DataJSON, "hydration is the v2 orchestrator's characterData.Attach cascade's job, not StartEncounter's")
+}
+
+// TestStartEncounter_ClearsStaleActionEconomy is the wave-close playtest
+// blocker regression test (rpg-api#644): a character carrying a non-nil
+// ActionEconomy left over from a PRIOR encounter (character.ActionEconomy
+// has no encounter scoping — see clearStaleActionEconomy's doc) must have
+// it cleared by StartEncounter, or the toolkit's Move() budget gate
+// (InCombat() == ActionEconomy != nil) rejects every move on the brand-new
+// FREE_ROAM encounter with "insufficient movement remaining", even though
+// nothing about the new encounter has happened yet — reproduced live on the
+// dev stack with alice's real character data (movement_remaining: 0,
+// turn_number: 1, carried over from an earlier playtest's combat).
+func (s *LobbySuite) TestStartEncounter_ClearsStaleActionEconomy() {
+	s.seedReadyLobby("lobby-stale-economy", "alice")
+
+	staleEconomy := &toolkitchar.ActionEconomyData{
+		TurnNumber: 1, ActionsRemaining: 0, BonusActionsRemaining: 0,
+		ReactionsRemaining: 0, MovementRemaining: 0,
+	}
+	s.charRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{
+			Character: &entities.Character{
+				Data: &toolkitchar.Data{
+					ID: "char-alice", PlayerID: "alice", Name: "Alice",
+					HitPoints: 12, MaxHitPoints: 12,
+					ActionEconomy: staleEconomy,
+				},
+			},
+		}, nil)
+	var persisted *toolkitchar.Data
+	s.charRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			persisted = input.Character.Data
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		})
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-stale-economy",
+	})
+	s.Require().NoError(err, "a stale action economy must not block StartEncounter")
+	s.Require().NotEmpty(out.EncounterID)
+
+	s.Require().NotNil(persisted, "the cleared character must be persisted back to the character store")
+	s.Require().Nil(persisted.ActionEconomy, "ActionEconomy must be cleared (ExitCombat) so the fresh encounter's Move() is not budget-gated")
+
+	// HP/MaxHP still seed correctly onto the new encounter — clearing the
+	// stale economy must not disturb the honest combat-snapshot seed.
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	s.Require().Equal(12, encData.Players[core.PlayerID("alice")].HP)
 }
 
 func (s *LobbySuite) TestStartEncounter_CharacterNotFound_SeedsZeroHP_NotFatal() {

--- a/internal/pkg/devcombat/inject.go
+++ b/internal/pkg/devcombat/inject.go
@@ -125,6 +125,14 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 		return nil, fmt.Errorf("load encounter %q from data: %w", input.EncounterID, err)
 	}
 
+	// Captured BEFORE AddMonster: LoadFromData aliases the *Data pointer
+	// (e.data = data, encounter.go), so AddMonster's inline combat-entry
+	// check (rpg-toolkit#759) can flip data.Mode to TURN_BASED in place —
+	// e.g. the goblin lands within an existing player's sight range. Reading
+	// data.Mode AFTER AddMonster would then report "already turn-based" even
+	// when this call is the one that started the fight.
+	alreadyTurnBased := data.Mode == core.ModeTurnBased
+
 	goblinID := core.EntityID(fmt.Sprintf("goblin-%d", len(data.Monsters)+1))
 	goblin := monster.NewGoblin(string(goblinID))
 	goblinData := goblin.ToData()
@@ -157,16 +165,28 @@ func Inject(ctx context.Context, repo encountersv2.Repository, input InjectInput
 		return nil, fmt.Errorf("add goblin to encounter %q: %w", input.EncounterID, addErr)
 	}
 
-	alreadyTurnBased := data.Mode == core.ModeTurnBased
-	if alreadyTurnBased {
-		// Round-trip to force rollInitiative to include the just-added
-		// monster — see the doc comment above.
+	switch {
+	case alreadyTurnBased:
+		// Mid-fight injection: round-trip to force rollInitiative to include
+		// the just-added monster — see the doc comment above.
 		if setErr := enc.SetMode(core.ModeFreeRoam); setErr != nil {
 			return nil, fmt.Errorf("reset encounter %q to free_roam before re-rolling initiative: %w", input.EncounterID, setErr)
 		}
-	}
-	if setErr := enc.SetMode(core.ModeTurnBased); setErr != nil {
-		return nil, fmt.Errorf("set mode turn_based on encounter %q: %w", input.EncounterID, setErr)
+		if setErr := enc.SetMode(core.ModeTurnBased); setErr != nil {
+			return nil, fmt.Errorf("set mode turn_based on encounter %q: %w", input.EncounterID, setErr)
+		}
+	case enc.Mode() == core.ModeTurnBased:
+		// AddMonster's inline combat-entry check (rpg-toolkit#759) already
+		// flipped FREE_ROAM -> TURN_BASED and rolled initiative INCLUDING
+		// this goblin (checkCombatEntry runs after the monster is added to
+		// e.data.Monsters) — nothing left to do.
+	default:
+		// The goblin landed outside every player's current sight range, so
+		// the inline check didn't fire. Inject is dev tooling for forcing a
+		// fight on demand regardless of a real sightline, so force it here.
+		if setErr := enc.SetMode(core.ModeTurnBased); setErr != nil {
+			return nil, fmt.Errorf("set mode turn_based on encounter %q: %w", input.EncounterID, setErr)
+		}
 	}
 
 	updated := enc.ToData()

--- a/internal/repositories/character/mock/mock_repository.go
+++ b/internal/repositories/character/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	gomock "go.uber.org/mock/gomock"
+
+	character "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/character_draft/mock/mock_repository.go
+++ b/internal/repositories/character_draft/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 	gomock "go.uber.org/mock/gomock"
+
+	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/repositories/dice_session/mock/mock_repository.go
+++ b/internal/repositories/dice_session/mock/mock_repository.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 	gomock "go.uber.org/mock/gomock"
+
+	dicesession "github.com/KirkDiggler/rpg-api/internal/repositories/dice_session"
 )
 
 // MockRepository is a mock of Repository interface.

--- a/internal/services/sandboxroom/mock/mock_service.go
+++ b/internal/services/sandboxroom/mock/mock_service.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
 	gomock "go.uber.org/mock/gomock"
+
+	sandboxroom "github.com/KirkDiggler/rpg-api/internal/services/sandboxroom"
 )
 
 // MockService is a mock of Service interface.


### PR DESCRIPTION
Closes #644

API half of **The Dungeon wave 1** (design doc [`ideas/the-dungeon/design.md`](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/the-dungeon/design.md), steps 7-8). Toolkit half already merged: rpg-toolkit#759 (encounter v0.25.0 + tools/spawn v0.2.0).

## What's here

1. **Bump rides this PR**: `rpg-toolkit/encounter` → v0.25.0, `rpg-toolkit/tools/spawn` v0.2.0 added, `rpg-toolkit/tools/environments` → v0.4.2 (transitively required). No local replace directives.
2. **StartEncounter creates the encounter WITH a walled room**: `enc.InitRoom(20, 20, environments.PatternRandom)` runs right after `tkenc.New`, before any `AddPlayer`/`AddMonster` (both consult `e.room` internally — `AddPlayer`'s initial reveal, `AddMonster`'s inline combat-entry check).
3. **2 goblins seeded via the spawn engine**, placed outside the party's initial line of sight. `spawn.BasicSpawnEngine` is wired to `enc.RoomOrchestrator()` and genuinely exercises rpg-toolkit#757/#759's `getRoomFromSpatial`/`placeEntityInRoom` fix from a real caller. Placement itself is verified via the toolkit's own wall-aware `perception.CanSeeAt` — see Pushback below for why the engine's own position search isn't trustworthy for this.
4. **Projector populates `Space.Walls`** from the encounter's persisted room snapshot — whole-room visibility for wave 1 (not LOS-gated like `Hexes`/`Entities`). Zero proto changes.
5. **Integration test** proves the full "Done when" bar end-to-end.

## Load-bearing

- Combat does not start at spawn: goblin placement is pre-verified against every player's current sight (real `perception.CanSeeAt`, not hand-rolled math) before `AddMonster` runs, because the toolkit's inline `checkCombatEntry` would otherwise flip the mode immediately.
- `tools/spawn`'s own position search is a stub untethered from the real walled room — it's wired and exercised for the entity-selection/RoomOrchestrator plumbing, but its returned position is discarded in favor of a toolkit-predicate-verified one. Full reasoning in `seedGoblins`'/`safeGoblinHexes`' doc comments in `start_encounter.go`.
- The room is 20x20 (not 10x10) so a safe (unwalled, unseen) hiding spot for goblins exists by distance alone, independent of the random wall roll's luck.
- Found and fixed a latent bug in `devcombat.Inject` that the toolkit's new inline combat-entry check exposed (see Pushback).

## Tests

- `internal/handlers/dnd5e/v2/encounter/project_test.go`: `TestProjectFor_PopulatesWalls_WholeRoomVisibility` (SOLID/WINDOW kind mapping, whole-room visibility regardless of sight range), `TestProjectFor_NilSpace_EmptyWalls` (pre-wave-1 fallback).
- `internal/orchestrators/lobby/start_encounter_test.go`: `TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSightedMove` — real `StartEncounter` call → walled room + 2 goblins persisted, `Mode == FREE_ROAM` at spawn, then a rehydrated `enc.Move` onto a goblin's hex flips `Mode == TURN_BASED` by rule. Stress-run 70x clean (20 + 50 across two passes) since room generation and goblin placement are both randomized.
- Toolkit bump required updating ~13 existing fixtures across `internal/orchestrators/encounter/v2`, `internal/handlers/dnd5e/v2/encounter`, and `internal/integration` that manually forced `SetMode(TURN_BASED)` after adding an already-visible monster — now redundant since `AddMonster` inline-checks combat entry (mirrors what rpg-toolkit#759 did in its own 13 fixtures).
- Full suite: `go build ./...`, `go vet ./...`, `go test ./... -race` all clean. `TestStartEncounter_NotTurnBased_FailedPrecondition` and its lobby-orchestrator counterpart needed goblin positions moved out of sight range for the same reason.

## Pushback

1. **Real toolkit gap, not fixed here**: `tools/spawn` v0.2.0's `BasicSpawnEngine` position search (`findValidPosition` — a raw random X,Y in [0,10) with zero room awareness — and the constraint-aware `ConstraintSolver.FindValidPositions` — a hardcoded 1.0-10.0 grid sweep) never consults the real `spatial.Room` this wave introduced: no `room.CanPlaceEntity`/`room.IsLineOfSightBlocked` calls anywhere in that path. Its optional `LineOfSight` constraint is a Euclidean-distance stub (`constraints.go`'s `hasLineOfSight`, doc-flagged "Real implementation would use spatial room queries for wall intersections"). `SpawnConfig` also has no fixed/target-position injection point for a caller that already knows where it wants an entity. Recommend a toolkit follow-up issue before wave 2 needs dynamic (non-fixed-2) monster placement through this engine — I did not write LOS math in rpg-api to work around it; I used the toolkit's own `perception.CanSeeAt` predicate instead, discarding the spawn engine's position output.
2. **Found a latent `devcombat.Inject` bug** the toolkit's new inline combat-entry check exposed: `LoadFromData` aliases the `*Data` pointer (`e.data = data`), so `AddMonster`'s inline `checkCombatEntry` can flip `data.Mode` to `TURN_BASED` in place before `Inject`'s own `alreadyTurnBased := data.Mode == core.ModeTurnBased` check ran — reading post-mutation state. Fixed by capturing the flag before `AddMonster`, and by handling the case where the inline check already did the flip (skipping the redundant `SetMode` round-trip in that branch).
3. **Pre-existing, unrelated repo debt found along the way** (not touched, out of scope): `make lint`/`golangci-lint run` reports ~29 issues on a clean `origin/main` checkout (goconst/errcheck/govet/staticcheck/unconvert across `internal/components/dungeon`, `internal/handlers/dnd5e/v1alpha1/character`, `internal/orchestrators/dice`, `internal/integration/harness`) — verified via a throwaway worktree at `origin/main`. None are in files this PR touches (confirmed via a lint run scoped to just this PR's packages: zero findings). The actual GitHub Actions CI (`test.yml`) doesn't run `golangci-lint` at all, only `go test -race`. Also found a genuine `mockgen`-vs-`goimports` disagreement on import ordering for 7 unrelated generated mock files (`internal/auth/mock`, `internal/orchestrators/{character,dice}/mock`, etc.) — `go generate` and `make fmt` fight over import grouping in a loop; pre-existing tooling inconsistency, not touched here.
4. **`docs/status.md` and `docs/architecture/components/lobby-service.md` updated** in this PR (the doc-drift lines about "no room/spawn-point system exists yet" and "the real combat-entry trigger is future room/encounter-design work" are now corrected with pointers to this wave).

The full MCP playtest (web step 9 of the design doc) still closes the wave — this PR is the api half only.
