### PR TITLE
feat(dungeon): adopt toolkit roster event + room-aware spawn

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-15
-confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests
+updated: 2026-07-17
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite
 ---
 
 # rpg-api: Where We Are
@@ -54,7 +54,7 @@ Goblin placement is verified NOT visible to any player at spawn — `AddMonster`
 inline-checks combat entry (rpg-toolkit#759's `checkCombatEntry`), so a goblin seeded
 within sight would flip the encounter to `TURN_BASED` immediately, violating the design
 bar ("walk into a room, the fight starts" — combat starts on a `Move` that forms sight,
-never at spawn). **Known toolkit gap, not fixed here:** `tools/spawn`'s own
+never at spawn). ~~**Known toolkit gap, not fixed here:** `tools/spawn`'s own
 `BasicSpawnEngine` position search (`findValidPosition`, and the constraint-aware
 `ConstraintSolver.FindValidPositions`) never consults the real `spatial.Room` this wave
 introduced — no `room.CanPlaceEntity`/`room.IsLineOfSightBlocked` calls anywhere in that
@@ -67,7 +67,21 @@ but discards its returned position in favor of one computed from the toolkit's o
 wall-aware `perception.CanSeeAt` — see `seedGoblins`'/`safeGoblinHexes`' doc comments in
 `start_encounter.go` for the full reasoning. A toolkit follow-up issue for
 fixed-position spawn support is recommended before wave 2 needs dynamic (non-fixed-2)
-monster placement through this engine.
+monster placement through this engine.~~ **RESOLVED by rpg-api#650 (2026-07-17):**
+rpg-toolkit#760 (`tools/spawn` v0.3.0) made the position search itself room-aware and
+added `EntityGroup.PositionOracle` — a caller predicate ANDed into the search.
+`seedGoblins` now expresses the out-of-sight requirement as a `PositionOracle` built on
+`perception.CanSeeAt` and uses the engine's own returned position directly; `safeGoblinHexes`
+and `placementProbe` are deleted. One new toolkit gap found and routed around while
+migrating: `BasicSelectablesRegistry.GetEntities` samples WITH replacement
+(`selectables_registry.go`), so a single 2-entity table asked for 2 could return the same
+goblin twice — invisible to the old discard-and-recompute code, a real bug once positions
+are correlated back to specific goblins by ID. Fixed in rpg-api by giving each goblin its
+own single-entity table/`EntityGroup` (these are individually pre-identified fixed
+entities, not a random pick from a pool, so this is the more honest modeling, not a
+workaround) — no toolkit issue filed for the sampling-with-replacement behavior itself
+since rpg-api no longer depends on it, but any future caller wanting N>1 *distinct* random
+picks from a shared table would hit the same gap.
 
 Verified via `internal/orchestrators/lobby/start_encounter_test.go`'s
 `TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSightedMove`: real `StartEncounter`
@@ -81,16 +95,16 @@ design work" — see the correction inline. The full MCP playtest (web step 9, w
 9 in `ideas/the-dungeon/design.md`) still closes the wave; this PR is the api half only
 (design doc steps 7-8).
 
-**Playtest follow-up: live initiative roster broadcast on combat entry (rpg-api#644,
+~~**Playtest follow-up: live initiative roster broadcast on combat entry (rpg-api#644,
 2026-07-15)** — the connect-time snapshot's `TurnState.InitiativeOrder` was the only
 place a client ever learned the turn order; a mid-stream `FREE_ROAM` → `TURN_BASED`
 transition (the toolkit's `rollInitiative`, inside `SetMode`) published no roster of its
 own, so a client watching the fight start live saw an empty initiative list until its
-next full snapshot. `internal/handlers/dnd5e/v2/encounter/handler.go`'s stream loop now
-synthesizes a proto `InitiativeRolled` envelope (`order=[]string`, `EncounterEvent` oneof
-field 41 — already defined on the wire, unused until now, zero proto changes) and sends
-it right after the `ModeChanged` translation whenever a `ModeChangedEvent` transitions
-`To==TURN_BASED`; `translateForStream` returns a slice so one broker event can produce
+next full snapshot. `internal/handlers/dnd5e/v2/encounter/handler.go`'s stream loop
+synthesized a proto `InitiativeRolled` envelope (`order=[]string`, `EncounterEvent` oneof
+field 41 — already defined on the wire, unused until now, zero proto changes) and sent
+it right after the `ModeChanged` translation whenever a `ModeChangedEvent` transitioned
+`To==TURN_BASED`; `translateForStream` returned a slice so one broker event could produce
 two wire envelopes. Broadcast to every connected viewer, not just whoever moved.
 
 **Known rough edge: the roster read races the orchestrator's save (rpg-api#647)** — every
@@ -98,17 +112,21 @@ combat-capable orchestrator verb follows a mutate-then-persist pattern where the
 SDK call (e.g. `MoveEntity`'s `enc.Move(...)`) mutates state AND synchronously publishes
 its broker events *before returning*, and only once it returns does the orchestrator
 `Save` the result. The stream goroutine that wakes on the just-published `ModeChangedEvent`
-can therefore call `h.encRepo.Get` before that `Save` lands, reading the pre-transition
+could therefore call `h.encRepo.Get` before that `Save` landed, reading the pre-transition
 (empty-`Initiative`) snapshot — reproduced reliably under `go test -race -count=10` before
 the fix, intermittent without `-race`. Worked around with a bounded retry
 (`loadRolledInitiative`, up to 15 attempts / 10ms apart / ~150ms worst case) rather than a
-longer fixed delay, since the real `Save` is the very next thing the orchestrator does.
-This is an interim workaround, not the fix: rpg-api#647 tracks both the general race class
-(the same pattern already exists in the `InputRequiredDeliveredEvent` prompt-lookup path,
-untested under sustained `-race` load) and the toolkit-side seam that would delete the
-retry outright — e.g. the SDK deferring its publish until after an explicit persist
-callback, or exposing the freshly-rolled `Initiative` directly on the event instead of
-requiring a repo round-trip at all.
+longer fixed delay, since the real `Save` was the very next thing the orchestrator did.~~
+**RESOLVED by rpg-api#650 (2026-07-17): the toolkit publishes `InitiativeRolledEvent`
+directly now (rpg-toolkit#765, encounter v0.28.0), sequenced between `ModeChanged` and
+`TurnStarted` with its own real sequence number, broadcast to all players — no read-back,
+no synthesis, no retry. Both the synthesis branch and `loadRolledInitiative` are deleted;
+`translateInitiativeRolledEvent` is now a plain `TranslateEvent` case.** This closes ONE of
+rpg-api#647's two known manifestations, not the issue itself: #647 still tracks the general
+mutate-then-persist race class (the `InputRequiredDeliveredEvent` prompt-lookup path still
+has it, untested under sustained `-race` load) and a related, distinct gap found during the
+reconnect-fidelity wave investigation — `persistWithCharacterData`'s two sequential,
+non-atomic Redis writes (character store, then encounter snapshot) — both still open.
 
 **Playtest follow-up: live EntityAppeared carries entity type (rpg-api#644, 2026-07-15)** —
 a monster (or player) becoming visible via a live `Move` (rpg-toolkit#762's monster

--- a/docs/status.md
+++ b/docs/status.md
@@ -118,7 +118,8 @@ the fix, intermittent without `-race`. Worked around with a bounded retry
 (`loadRolledInitiative`, up to 15 attempts / 10ms apart / ~150ms worst case) rather than a
 longer fixed delay, since the real `Save` was the very next thing the orchestrator did.~~
 **RESOLVED by rpg-api#650 (2026-07-17): the toolkit publishes `InitiativeRolledEvent`
-directly now (rpg-toolkit#765, encounter v0.28.0), sequenced between `ModeChanged` and
+directly now (rpg-toolkit#765, PR #771 — the seam was introduced in encounter v0.28.0;
+this repo pins whatever is current, see go.mod), sequenced between `ModeChanged` and
 `TurnStarted` with its own real sequence number, broadcast to all players — no read-back,
 no synthesis, no retry. Both the synthesis branch and `loadRolledInitiative` are deleted;
 `translateInitiativeRolledEvent` is now a plain `TranslateEvent` case.** This closes ONE of

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.26.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0
+	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.26.0 h1:rwAMVBvWyzUIQfCGI6Hs4JxrwdYfEkOz3plDiy31uZU=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.26.0/go.mod h1:1VpHeNNexAMdHxI1SRRhs/5F+/Rr90hqKrt6m5U523o=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0 h1:A+cA5VcMUKRakk8bqvullCz93rrMQU3wpPaASQ1Oc+E=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0/go.mod h1:1VpHeNNexAMdHxI1SRRhs/5F+/Rr90hqKrt6m5U523o=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -28,8 +28,8 @@ github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgc
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0 h1:weKsLlsRV9kgoD/y68VWy0lpsu5zhwCmbnr5MUkLpsA=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
-github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0 h1:YowWFv+oL49f7aRt8O3krJ6BrpA3CrYaLEqInu92SZs=
-github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.2.0/go.mod h1:vRkHHvBU1hXvlPyOySMfXov4S4Tj/bTWJ7lUGSwgVmI=
+github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0 h1:G3Fbc88oko5o0yM1jQ2wB7bAeaHRRWPAiZRpsub36uk=
+github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0/go.mod h1:vRkHHvBU1hXvlPyOySMfXov4S4Tj/bTWJ7lUGSwgVmI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -351,7 +351,7 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 			if !ok {
 				return nil
 			}
-			outs, translateErr := h.translateForStream(ctx, encID, evt, core.PlayerID(playerID))
+			out, translateErr := h.translateForStream(ctx, encID, evt, core.PlayerID(playerID))
 			switch {
 			case errors.Is(translateErr, ErrViewerSawNothing):
 				continue
@@ -368,7 +368,7 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 			case translateErr != nil:
 				return status.Errorf(codes.Internal, "translate %q: %v", string(encID), translateErr)
 			}
-			for _, out := range outs {
+			if out != nil {
 				if err := stream.Send(out); err != nil {
 					return err
 				}
@@ -378,8 +378,10 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 }
 
 // translateForStream wraps TranslateEvent with the data-aware paths this
-// stream loop needs. Returns a slice (usually one envelope) so a single
-// broker event can translate to more than one wire envelope when needed.
+// stream loop needs — every broker event maps to exactly one wire envelope
+// (previously a slice, back when the now-deleted InitiativeRolled synthesis
+// made one broker event produce two; simplified to a single return per the
+// gate review on rpg-api#650's PR now that nothing does that anymore).
 //
 //   - InputRequiredDeliveredEvent (Wave 2.11d): reaction prompts store their
 //     content on Encounter.Data.PendingReactionPrompts (rather than on the
@@ -413,7 +415,7 @@ func (h *Handler) translateForStream(
 	encID core.EncounterID,
 	evt tkevents.EncounterEvent,
 	viewer core.PlayerID,
-) ([]*encounterv2pb.EncounterEvent, error) {
+) (*encounterv2pb.EncounterEvent, error) {
 	if irEvt, ok := evt.(*tkevents.InputRequiredDeliveredEvent); ok {
 		// Load the encounter to read the pending prompt content. The prompt
 		// lives on Data.PendingReactionPrompts and is the canonical source
@@ -426,11 +428,7 @@ func (h *Handler) translateForStream(
 		if data != nil {
 			prompt = data.PendingReactionPrompts[irEvt.ReactorID]
 		}
-		out, err := TranslateInputRequiredDelivered(irEvt, viewer, h.now(), prompt)
-		if err != nil {
-			return nil, err
-		}
-		return []*encounterv2pb.EncounterEvent{out}, nil
+		return TranslateInputRequiredDelivered(irEvt, viewer, h.now(), prompt)
 	}
 
 	if appearEvt, ok := evt.(*tkevents.EntityAppearedEvent); ok {
@@ -438,16 +436,8 @@ func (h *Handler) translateForStream(
 		if err != nil {
 			return nil, fmt.Errorf("load encounter for entity-appeared enrichment: %w", err)
 		}
-		out, err := translateEntityAppearedEventWithData(appearEvt, viewer, h.now(), data)
-		if err != nil {
-			return nil, err
-		}
-		return []*encounterv2pb.EncounterEvent{out}, nil
+		return translateEntityAppearedEventWithData(appearEvt, viewer, h.now(), data)
 	}
 
-	out, err := TranslateEvent(evt, viewer, h.now())
-	if err != nil {
-		return nil, err
-	}
-	return []*encounterv2pb.EncounterEvent{out}, nil
+	return TranslateEvent(evt, viewer, h.now())
 }

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -379,26 +379,12 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 
 // translateForStream wraps TranslateEvent with the data-aware paths this
 // stream loop needs. Returns a slice (usually one envelope) so a single
-// broker event can translate to more than one wire envelope when needed —
-// see the InitiativeRolled case below.
+// broker event can translate to more than one wire envelope when needed.
 //
 //   - InputRequiredDeliveredEvent (Wave 2.11d): reaction prompts store their
 //     content on Encounter.Data.PendingReactionPrompts (rather than on the
 //     event payload), so the translator needs the encounter snapshot to
 //     look up the prompt content.
-//   - ModeChangedEvent transitioning to TURN_BASED (rpg-api#644 playtest
-//     follow-up): the toolkit's rollInitiative (inside SetMode) rolls
-//     data.Initiative but publishes no dedicated roster event — the client's
-//     initiativeOrder otherwise stays empty until the NEXT full snapshot
-//     (only buildTurnState populates it, and that only runs at connect
-//     time). Broadcasting a synthesized InitiativeRolled envelope alongside
-//     the normal ModeChanged translation closes that gap without a proto
-//     change (InitiativeRolled already exists on the wire, unused — see
-//     translateInitiativeRolledEvent's doc). Loads data fresh rather than
-//     threading it through from elsewhere in the loop: this is the
-//     established pattern here (mirrors the InputRequiredDeliveredEvent
-//     branch immediately above), and a mode-transition event is rare enough
-//     (once per fight) that the extra repo round-trip is not a concern.
 //   - EntityAppearedEvent (rpg-api#644 playtest follow-up): the toolkit
 //     event carries only an entity ID + position — no type, HP, or monster
 //     ref — so the wire Entity would otherwise project as type=UNSPECIFIED
@@ -406,14 +392,19 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 //     generic capsule instead of its model). Looks the entity up in the
 //     freshly-loaded data and builds the full Entity via the same
 //     playerEntity/monsterEntity builders ProjectFor's snapshot path uses —
-//     see translateEntityAppearedEventWithData's doc for why this read,
-//     unlike the InitiativeRolled one above, is not exposed to the
-//     rpg-api#647 race class and needs no retry. This fires far more often
-//     than ModeChanged during active combat (any LOS-changing move, not
-//     just combat entry); if the extra per-event repo round-trip ever shows
-//     up as a real cost, the natural follow-up is caching the connect-time
-//     snapshot's Players/Monsters in this stream goroutine's own state
-//     instead (see docs/status.md's rough edges).
+//     see translateEntityAppearedEventWithData's doc for why this read is
+//     not exposed to the rpg-api#647 race class and needs no retry. This
+//     fires far more often than ModeChanged during active combat (any
+//     LOS-changing move, not just combat entry); if the extra per-event repo
+//     round-trip ever shows up as a real cost, the natural follow-up is
+//     caching the connect-time snapshot's Players/Monsters in this stream
+//     goroutine's own state instead (see docs/status.md's rough edges).
+//
+// InitiativeRolled no longer needs a data-aware branch here: rpg-toolkit#765
+// (encounter v0.28.0) publishes it directly, sequenced between ModeChanged
+// and TurnStarted with its own real sequence number, so the plain
+// TranslateEvent case in translate.go handles it like any other broadcast
+// event — no synthesis, no repo read-back, no retry.
 //
 // Every other event type continues to use TranslateEvent unchanged.
 func (h *Handler) translateForStream(
@@ -457,57 +448,5 @@ func (h *Handler) translateForStream(
 	if err != nil {
 		return nil, err
 	}
-	envelopes := []*encounterv2pb.EncounterEvent{out}
-
-	if modeEvt, ok := evt.(*tkevents.ModeChangedEvent); ok && modeEvt.To == core.ModeTurnBased {
-		initiative, err := h.loadRolledInitiative(ctx, encID)
-		if err != nil {
-			return nil, err
-		}
-		envelopes = append(envelopes, translateInitiativeRolledEvent(modeEvt.Sequence(), initiative, h.now()))
-	}
-
-	return envelopes, nil
-}
-
-// loadRolledInitiative reads the encounter's Initiative back from the repo
-// for the InitiativeRolled synthesis above. This races against the
-// verb-then-persist pattern every combat-capable orchestrator method uses
-// (e.g. MoveEntity: enc.Move(...) — which mutates + PUBLISHES the
-// ModeChangedEvent this function is reacting to, synchronously, INSIDE the
-// call — THEN, only once Move returns, the orchestrator calls Save). So the
-// very broker event that wakes this stream goroutine can arrive before the
-// orchestrator's Save lands, and a single h.encRepo.Get can read the
-// pre-transition (empty-Initiative) snapshot. Bounded retry converts that
-// race into a short, harmless wait — Save is already the very next thing
-// the orchestrator does after Move returns, so this resolves in one or two
-// iterations in practice; initiativePollAttempts/initiativePollInterval
-// bound the worst case at ~150ms so a genuinely stuck load still returns
-// (with whatever — possibly empty — Initiative it last read) rather than
-// hanging the stream.
-const (
-	initiativePollAttempts = 15
-	initiativePollInterval = 10 * time.Millisecond
-)
-
-func (h *Handler) loadRolledInitiative(ctx context.Context, encID core.EncounterID) ([]core.EntityID, error) {
-	var initiative []core.EntityID
-	for attempt := 0; attempt < initiativePollAttempts; attempt++ {
-		data, err := h.encRepo.Get(ctx, string(encID))
-		if err != nil {
-			return nil, fmt.Errorf("load encounter for initiative roster: %w", err)
-		}
-		if data != nil {
-			initiative = data.Initiative
-			if data.Mode == core.ModeTurnBased && len(initiative) > 0 {
-				return initiative, nil
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return initiative, nil
-		case <-time.After(initiativePollInterval):
-		}
-	}
-	return initiative, nil
+	return []*encounterv2pb.EncounterEvent{out}, nil
 }

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -401,10 +401,11 @@ func (h *Handler) StreamEncounter(req *encounterv2pb.StreamEncounterRequest, str
 //     goroutine's own state instead (see docs/status.md's rough edges).
 //
 // InitiativeRolled no longer needs a data-aware branch here: rpg-toolkit#765
-// (encounter v0.28.0) publishes it directly, sequenced between ModeChanged
-// and TurnStarted with its own real sequence number, so the plain
-// TranslateEvent case in translate.go handles it like any other broadcast
-// event — no synthesis, no repo read-back, no retry.
+// (encounter v0.28.0 introduced the seam; this repo pins whatever is current —
+// see go.mod) publishes it directly, sequenced between ModeChanged and
+// TurnStarted with its own real sequence number, so the plain TranslateEvent
+// case in translate.go handles it like any other broadcast event — no
+// synthesis, no repo read-back, no retry.
 //
 // Every other event type continues to use TranslateEvent unchanged.
 func (h *Handler) translateForStream(

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -88,6 +88,8 @@ func TranslateEvent(evt events.EncounterEvent, viewer core.PlayerID, now time.Ti
 		return translateResourceChangedEvent(e, viewer, now)
 	case *events.ModeChangedEvent:
 		return translateModeChangedEvent(e, viewer, now)
+	case *events.InitiativeRolledEvent:
+		return translateInitiativeRolledEvent(e, viewer, now)
 	case *events.TurnStartedEvent:
 		return translateTurnStartedEvent(e, viewer, now)
 	case *events.TurnEndedEvent:
@@ -317,15 +319,13 @@ func translateEntityAppearedEvent(e *events.EntityAppearedEvent, viewer core.Pla
 //
 // data is loaded fresh by the caller (translateForStream) rather than
 // threaded through TranslateEvent's generic signature — mirrors the
-// InputRequiredDeliveredEvent / InitiativeRolled data-aware branches already
-// in this file. Unlike InitiativeRolled (rpg-api#647: the roster value
-// doesn't exist anywhere until the SAME in-flight request rolls it), this
+// InputRequiredDeliveredEvent data-aware branch already in this file. This
 // read is NOT racy: the appearing entity's identity was always persisted by
 // an earlier, separate, already-completed request (AddPlayer/AddMonster
 // inside StartEncounter or devcombat.Inject) — the only call site that can
 // ever produce this event is enc.Move(), which always runs against an
 // encounter MoveEntity's orchestrator already loaded from the repo. No
-// retry needed (contrast loadRolledInitiative below).
+// retry needed.
 func translateEntityAppearedEventWithData(
 	e *events.EntityAppearedEvent, viewer core.PlayerID, now time.Time, data *encounter.Data,
 ) (*encounterv2pb.EncounterEvent, error) {
@@ -715,43 +715,33 @@ func translateModeChangedEvent(e *events.ModeChangedEvent, viewer core.PlayerID,
 	}, nil
 }
 
-// translateInitiativeRolledEvent builds the proto InitiativeRolled envelope
-// carrying the encounter's freshly-rolled turn order (rpg-api#644 playtest
-// follow-up). Unlike every other translator in this file, it has no
-// corresponding toolkit event to translate FROM: rollInitiative (inside
-// SetMode, rpg-toolkit encounter/combat.go) mutates data.Initiative in place
-// but publishes no dedicated roster event — only ModeChangedEvent and
-// TurnStartedEvent fire at the FREE_ROAM->TURN_BASED transition, and neither
-// proto carries a roster field (ModeChanged: from/to/reason; TurnStarted:
-// entity_id/round — see events.proto). InitiativeRolled{order} is a separate
-// message already defined on the wire (events.proto's EncounterEvent oneof,
-// field 41) that no rpg-api code populated until now — zero proto changes
-// needed.
-//
-// The stream loop (handler.go's translateForStream) calls this once,
-// alongside the normal ModeChanged translation, when it observes the
-// transition to TURN_BASED — not on every TurnStartedEvent, which also
-// fires on every later per-turn advance and would otherwise resend the same
-// static roster every turn. seq is shared with the paired ModeChangedEvent:
-// this envelope is that transition's effect, not an independently-caused
-// event of its own (mirrors the DoorOpened/parallel-HexRevealedEvent
-// cause/effect split elsewhere in this file, except here one toolkit cause
-// produces two wire envelopes instead of two toolkit events each producing
-// one).
-func translateInitiativeRolledEvent(seq uint64, initiative []core.EntityID, now time.Time) *encounterv2pb.EncounterEvent {
-	order := make([]string, 0, len(initiative))
-	for _, eid := range initiative {
+// translateInitiativeRolledEvent maps the toolkit's InitiativeRolledEvent
+// (rpg-toolkit#765) to the proto InitiativeRolled envelope. The toolkit now
+// publishes this directly on the FREE_ROAM->TURN_BASED transition, sequenced
+// between ModeChanged and TurnStarted with its own real sequence number — the
+// api no longer synthesizes this envelope or reads the roster back from the
+// repo (see git history for the retired loadRolledInitiative retry, which
+// papered over the publish-before-Save race this event structurally avoids).
+// Audience is all players (the roster is shared knowledge, not fog-of-war
+// gated), gated the same way as translateTurnStartedEvent/ConditionApplied.
+func translateInitiativeRolledEvent(e *events.InitiativeRolledEvent, viewer core.PlayerID, now time.Time) (*encounterv2pb.EncounterEvent, error) {
+	slice, ok := e.PerPlayer[viewer]
+	if !ok || !slice.Visible {
+		return nil, ErrViewerSawNothing
+	}
+	order := make([]string, 0, len(e.Order))
+	for _, eid := range e.Order {
 		order = append(order, string(eid))
 	}
 	return &encounterv2pb.EncounterEvent{
-		Sequence:  int64(seq), //nolint:gosec // sequence is monotonic; fits int64
+		Sequence:  int64(e.Sequence()), //nolint:gosec // sequence is monotonic; fits int64
 		Timestamp: timestamppb.New(now),
 		Event: &encounterv2pb.EncounterEvent_InitiativeRolled{
 			InitiativeRolled: &encounterv2pb.InitiativeRolled{
 				Order: order,
 			},
 		},
-	}
+	}, nil
 }
 
 // translateTurnStartedEvent maps the toolkit's TurnStartedEvent to the proto

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
 	rpgcore "github.com/KirkDiggler/rpg-toolkit/core"
@@ -212,66 +211,113 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 // would flip the encounter to TURN_BASED immediately, so placement has to be
 // pre-verified before AddMonster runs, not after.
 //
-// KNOWN TOOLKIT GAP (flag for a follow-up rpg-toolkit issue): the spawn
-// engine's own position search — BasicSpawnEngine.findValidPosition (a raw
-// random X,Y in [0,10), zero room awareness) and, when SpatialRules are
-// configured, ConstraintSolver.FindValidPositions (a hardcoded 1.0-10.0
-// grid sweep) — never calls room.CanPlaceEntity or room.IsLineOfSightBlocked
-// against the actual spatial.Room this wave built. Its optional LineOfSight
-// constraint is a Euclidean-distance stub (tools/spawn/constraints.go's
-// hasLineOfSight: "Real implementation would use spatial room queries for
-// wall intersections" — distance <= 8.0, walls not considered at all).
-// SpawnConfig also has no fixed/target-position injection point for a
-// caller that already knows where it wants an entity. So PopulateRoom's own
-// SpawnedEntity.Position is unusable for this wave's correctness bar and is
-// deliberately discarded below in favor of a position computed from real
-// toolkit predicates (safeGoblinHexes). PopulateRoom is still called (not
-// bypassed) so the RoomOrchestrator wiring is genuinely exercised end to
-// end; this does leave each goblin also registered as a room occupant at
-// that discarded scattered position, a side effect that's inert for wave 1
-// (monsters aren't otherwise tracked in the spatial room — only walls
-// occupy it, see rpg-toolkit encounter/space.go's wallCheckEntity doc — and
-// nothing in this flow queries room occupancy for monster positions).
+// rpg-toolkit#760 (tools/spawn v0.3.0) made the position search itself
+// room-aware (Room.CanPlaceEntity/bounds are consulted by the search, not
+// just by a post-hoc discard-and-recompute) and added EntityGroup's
+// PositionOracle: a caller predicate ANDed into that search. The
+// out-of-sight requirement is expressed here as a PositionOracle closing
+// over the toolkit's own perception.CanSeeAt — the same predicate this
+// function's doc above already required, just handed to the engine instead
+// of re-derived by a manual grid walk afterward. The engine's returned
+// SpawnedEntity.Position is now used directly; there is no discarded
+// position and no separate double-registration side effect (previously
+// noted as inert — see PR #645 gate note N1 — now gone because there is
+// only one placement per goblin, not a scattered one PopulateRoom picks
+// plus a recomputed one this function used to override it with).
+//
+// Each goblin gets its OWN single-entity selection table and its own
+// EntityGroup (Quantity.Fixed=1), rather than one shared "goblins" table
+// with Quantity.Fixed=goblinCount. This is deliberate, not cosmetic:
+// BasicSelectablesRegistry.GetEntities samples WITH replacement
+// (selectables_registry.go: `index := r.random.Intn(len(table))` per pick,
+// independently each iteration, no dedup) — a 2-entity table asked for 2
+// entities can return the same *monster.Monster pointer twice. That was
+// invisible to the OLD seedGoblins (it discarded the selection's identity
+// entirely and matched by slice index against its own separately-tracked
+// goblinIDs), but this function now correlates each SpawnedEntity back to a
+// specific pre-built goblin via Entity.GetID() (see the position-matching
+// loop below), so a duplicate selection would silently place one goblin
+// twice and drop the other. A 1-entity table can never return a duplicate
+// (there is nothing else to duplicate against), which sidesteps the gap
+// entirely without depending on a toolkit-side sampling fix — these are
+// individually pre-identified fixed entities (monster.NewGoblin per ID), not
+// a random pick from a shared pool, so one-group-per-entity is the more
+// honest modeling anyway, not a workaround bolted onto the wrong tool.
 func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, encID core.EncounterID) error {
+	room := enc.Room()
+	if room == nil {
+		return errors.New("lobby orchestrator: encounter has no room to place goblins in (InitRoom not called)")
+	}
+
 	goblinIDs := make([]core.EntityID, goblinCount)
 	goblins := make([]*monster.Monster, goblinCount)
-	entities := make([]rpgcore.Entity, goblinCount)
+	registry := spawn.NewBasicSelectablesRegistry()
+	groups := make([]spawn.EntityGroup, goblinCount)
+
+	// The oracle re-derives the players' view each call rather than
+	// snapshotting once: the search may probe many candidates per entity, and
+	// re-reading enc.ToData() per candidate keeps this in lockstep with
+	// whatever the engine has placed so far in this same call (no player
+	// positions change mid-seed, so this is for safety against future
+	// reordering, not a currently-observed staleness risk).
+	outOfSight := func(pos spatial.Position) bool {
+		hex := core.HexFromPosition(pos)
+		for _, p := range enc.ToData().Players {
+			if p.View != nil && perception.CanSeeAt(p.View, hex, room) {
+				return false
+			}
+		}
+		return true
+	}
+
+	one := 1
 	for i := 0; i < goblinCount; i++ {
 		id := core.EntityID(fmt.Sprintf("goblin-%d", i+1))
 		g := monster.NewGoblin(string(id))
 		goblinIDs[i] = id
 		goblins[i] = g
-		entities[i] = g
+
+		tableID := string(id)
+		if err := registry.RegisterTable(tableID, []rpgcore.Entity{g}); err != nil {
+			return fmt.Errorf("register goblin selection table %q: %w", tableID, err)
+		}
+		groups[i] = spawn.EntityGroup{
+			ID:             tableID,
+			Type:           "monster",
+			SelectionTable: tableID,
+			Quantity:       spawn.QuantitySpec{Fixed: &one},
+			PositionOracle: outOfSight,
+		}
 	}
 
-	registry := spawn.NewBasicSelectablesRegistry()
-	if err := registry.RegisterTable("goblins", entities); err != nil {
-		return fmt.Errorf("register goblin selection table: %w", err)
-	}
 	engine := spawn.NewBasicSpawnEngine(spawn.BasicSpawnEngineConfig{
 		ID:               "startencounter-goblins",
 		SelectablesReg:   registry,
 		RoomOrchestrator: enc.RoomOrchestrator(),
 	})
-	quantity := goblinCount
-	if _, err := engine.PopulateRoom(ctx, string(encID), spawn.SpawnConfig{
-		EntityGroups: []spawn.EntityGroup{{
-			ID:             "goblins",
-			Type:           "monster",
-			SelectionTable: "goblins",
-			Quantity:       spawn.QuantitySpec{Fixed: &quantity},
-		}},
-		Pattern: spawn.PatternScattered,
-	}); err != nil {
+
+	result, err := engine.PopulateRoom(ctx, string(encID), spawn.SpawnConfig{
+		EntityGroups: groups,
+		Pattern:      spawn.PatternScattered,
+	})
+	if err != nil {
 		return fmt.Errorf("spawn engine populate room: %w", err)
 	}
+	if len(result.Failures) > 0 {
+		return fmt.Errorf("lobby orchestrator: spawn engine failed to place %d of %d goblin(s): %+v",
+			len(result.Failures), goblinCount, result.Failures)
+	}
 
-	safeHexes, err := safeGoblinHexes(enc, goblinCount)
-	if err != nil {
-		return err
+	positions := make(map[core.EntityID]core.Hex, len(result.SpawnedEntities))
+	for _, spawned := range result.SpawnedEntities {
+		positions[core.EntityID(spawned.Entity.GetID())] = core.HexFromPosition(spawned.Position)
 	}
 
 	for i, id := range goblinIDs {
+		pos, ok := positions[id]
+		if !ok {
+			return fmt.Errorf("lobby orchestrator: spawn engine reported no position for goblin %q", id)
+		}
 		goblinData := goblins[i].ToData()
 		goblinDataJSON, marshalErr := json.Marshal(goblinData)
 		if marshalErr != nil {
@@ -279,7 +325,7 @@ func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, en
 		}
 		if addErr := enc.AddMonster(tkenc.MonsterInput{
 			ID:          id,
-			Position:    safeHexes[i],
+			Position:    pos,
 			HP:          goblinData.HitPoints,
 			MaxHP:       goblinData.MaxHitPoints,
 			AC:          goblinData.ArmorClass,
@@ -295,60 +341,3 @@ func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, en
 	}
 	return nil
 }
-
-// safeGoblinHexes returns n distinct hexes within the encounter's room that
-// are (a) not wall-occupied (room.CanPlaceEntity) and (b) not currently
-// visible to ANY player in the encounter, verified via the toolkit's own
-// wall-aware perception.CanSeeAt. Enumerates every offset-coordinate cell in
-// the room's bounds — core.HexFromPosition is the same offset<->cube bridge
-// rpg-toolkit's rebuildRoomFromData uses to place walls, so this walks
-// exactly the grid the room's wall placements are snapped to.
-func safeGoblinHexes(enc *tkenc.Encounter, n int) ([]core.Hex, error) {
-	room := enc.Room()
-	if room == nil {
-		return nil, errors.New("lobby orchestrator: encounter has no room to place goblins in (InitRoom not called)")
-	}
-	data := enc.ToData()
-
-	var candidates []core.Hex
-	for x := 0; x < roomWidth; x++ {
-		for y := 0; y < roomHeight; y++ {
-			hex := core.HexFromPosition(spatial.Position{X: float64(x), Y: float64(y)})
-			if !room.CanPlaceEntity(placementProbe{}, hex.ToPosition()) {
-				continue // wall-occupied
-			}
-			visibleToSomeone := false
-			for _, p := range data.Players {
-				if p.View != nil && perception.CanSeeAt(p.View, hex, room) {
-					visibleToSomeone = true
-					break
-				}
-			}
-			if !visibleToSomeone {
-				candidates = append(candidates, hex)
-			}
-		}
-	}
-	if len(candidates) < n {
-		return nil, fmt.Errorf(
-			"lobby orchestrator: found only %d safe (unwalled, unseen) hex(es) for %d goblins in a %dx%d room",
-			len(candidates), n, roomWidth, roomHeight)
-	}
-
-	// Random, distinct pick from the safe set so goblins scatter rather than
-	// always landing in the same corner. #nosec G404: game placement, not
-	// security-sensitive.
-	rand.Shuffle(len(candidates), func(i, j int) { candidates[i], candidates[j] = candidates[j], candidates[i] })
-	return candidates[:n], nil
-}
-
-// placementProbe is a throwaway core.Entity used only to query
-// room.CanPlaceEntity for wall-occupancy. Mirrors rpg-toolkit's own
-// wallCheckEntity (encounter/space.go), which is unexported: goblins
-// themselves are never placed into the spatial room (only walls occupy it —
-// see that same doc), so this identity is never compared against a real
-// occupant.
-type placementProbe struct{}
-
-func (placementProbe) GetID() string               { return "placement-probe" }
-func (placementProbe) GetType() rpgcore.EntityType { return "placement-probe" }

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -73,6 +73,10 @@ const (
 // dynamic SpawnConfig-driven counts are wave 2+).
 const goblinCount = 2
 
+// entityGroupTypeMonster is the spawn.EntityGroup.Type tag for goblin
+// placement groups in seedGoblins below.
+const entityGroupTypeMonster = "monster"
+
 // Goblin combat-snapshot constants, matching every other goblin fixture in
 // this codebase (cmd/devseed/main.go, internal/pkg/devcombat/inject.go) so
 // StartEncounter's real goblins behave identically to the dev-tooling ones.
@@ -283,7 +287,7 @@ func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, en
 		}
 		groups[i] = spawn.EntityGroup{
 			ID:             tableID,
-			Type:           "monster",
+			Type:           entityGroupTypeMonster,
 			SelectionTable: tableID,
 			Quantity:       spawn.QuantitySpec{Fixed: &one},
 			PositionOracle: outOfSight,

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -55,12 +55,12 @@ const memberSightRange = 10
 // (~1 wall per 10 sq units — see environments.RandomPattern) and not
 // reliably enough on its own to hide a monster from a party spawned near
 // the room's origin. A 20x20 room guarantees floor beyond hex-distance 10
-// from a near-origin party purely by distance, so safeGoblinHexes always
-// has a hiding spot regardless of the random wall roll; walls create
-// additional closer-in pockets on top of that. roomPattern is the only
-// pattern besides "empty" the toolkit ships (environments.PatternRandom /
-// PatternEmpty — see tools/environments/wall_patterns.go's WallPatterns
-// registry).
+// from a near-origin party purely by distance, so seedGoblins' PositionOracle
+// (out-of-sight requirement) always has a hiding spot regardless of the
+// random wall roll; walls create additional closer-in pockets on top of
+// that. roomPattern is the only pattern besides "empty" the toolkit ships
+// (environments.PatternRandom / PatternEmpty — see
+// tools/environments/wall_patterns.go's WallPatterns registry).
 const (
 	roomWidth   = 20
 	roomHeight  = 20
@@ -264,7 +264,23 @@ func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, en
 	// whatever the engine has placed so far in this same call (no player
 	// positions change mid-seed, so this is for safety against future
 	// reordering, not a currently-observed staleness risk).
-	outOfSight := func(pos spatial.Position) bool {
+	//
+	// Also rejects positions already occupied by an entity placed earlier in
+	// THIS SAME PopulateRoom call (i.e. an already-seeded goblin): room's
+	// baseline CanPlaceEntity (which the engine's search already runs)
+	// type-asserts the occupant to spatial.Placeable and only blocks if
+	// BlocksMovement() is true — monster.Monster implements neither, so two
+	// goblins could otherwise land on the exact same hex with only
+	// probability (not a guarantee) preventing it. This restores the
+	// distinctness the old safeGoblinHexes gave for free by construction
+	// (picking N distinct cells from one candidate set) — flagged by the gate
+	// review on rpg-api#650's PR. GetEntitiesInRange(pos, 0) is an exact-cell
+	// occupancy check (Distance(...) <= 0), type-agnostic, so it catches
+	// players too, not just other goblins.
+	validGoblinPosition := func(pos spatial.Position) bool {
+		if len(room.GetEntitiesInRange(pos, 0)) > 0 {
+			return false
+		}
 		hex := core.HexFromPosition(pos)
 		for _, p := range enc.ToData().Players {
 			if p.View != nil && perception.CanSeeAt(p.View, hex, room) {
@@ -290,7 +306,7 @@ func (o *Orchestrator) seedGoblins(ctx context.Context, enc *tkenc.Encounter, en
 			Type:           entityGroupTypeMonster,
 			SelectionTable: tableID,
 			Quantity:       spawn.QuantitySpec{Fixed: &one},
-			PositionOracle: outOfSight,
+			PositionOracle: validGoblinPosition,
 		}
 	}
 

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -260,10 +260,22 @@ func (s *LobbySuite) TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSight
 
 	// 2 goblins seeded.
 	s.Require().Len(encData.Monsters, 2, "StartEncounter must seed exactly 2 goblins")
+	goblinPositions := make([]core.Hex, 0, len(encData.Monsters))
 	for id, m := range encData.Monsters {
 		s.Require().Positive(m.HP, "goblin %q must have positive HP", id)
 		s.Require().NotEmpty(m.DataJSON, "goblin %q must carry DataJSON (monster.NewGoblin, not a hand-rolled stub)", id)
+		goblinPositions = append(goblinPositions, m.Position)
 	}
+	// Distinct positions: monster.Monster doesn't implement spatial.Placeable,
+	// so the spawn engine's baseline CanPlaceEntity occupancy check silently
+	// no-ops for goblin-on-goblin placement (it only blocks when the existing
+	// occupant type-asserts to Placeable and BlocksMovement() is true).
+	// seedGoblins' PositionOracle explicitly rejects already-occupied cells
+	// (room.GetEntitiesInRange(pos, 0)) to restore the distinctness guarantee
+	// the deleted safeGoblinHexes gave for free by construction — this pins
+	// that guarantee so a future regression here is caught, not silently
+	// probable-but-unverified (gate finding on rpg-api#650's PR).
+	s.Require().NotEqual(goblinPositions[0], goblinPositions[1], "goblins must not be placed on the same hex")
 
 	// Combat must NOT have started at spawn: the goblins were placed outside
 	// alice's initial sight, so AddMonster's inline combat-entry check


### PR DESCRIPTION
## Summary

Adopts two just-merged toolkit seams and deletes both rpg-api interim workarounds they replace. Net deletion: this PR removes more code than it adds (215 deletions vs. 133 insertions across the two commits).

Closes #650

## Load-bearing (what got DELETED)

- **`loadRolledInitiative` and its 15×10ms bounded retry — gone entirely.** rpg-toolkit#765 (encounter v0.28.0+) now publishes `InitiativeRolledEvent` directly on the FREE_ROAM→TURN_BASED transition, sequenced between `ModeChanged` and `TurnStarted` with its own real sequence number, broadcast to all players. The publish-before-Save race this retry papered over is structurally gone for this event — there's no repo read-back to race against anymore.
- **The `ModeChanged`-triggered envelope-append branch in `translateForStream` — gone.** `translateInitiativeRolledEvent` is now a plain `TranslateEvent` case (`case *events.InitiativeRolledEvent:`), mapping the toolkit event 1:1 like every other broadcast translator in the file. No more "one broker event produces two wire envelopes" special case.
- **`safeGoblinHexes` and `placementProbe` — gone entirely.** rpg-toolkit#760 (tools/spawn v0.3.0) made the spawn engine's own position search room-aware and added `EntityGroup.PositionOracle`. `seedGoblins` expresses the out-of-sight requirement as a `PositionOracle` closing over the same `perception.CanSeeAt` predicate the deleted manual grid-walk used, and now uses the engine's own returned position directly instead of discarding it. The "KNOWN TOOLKIT GAP" comment block documenting the old discard-and-recompute workaround is deleted along with the workaround.
- **The inert double-registration side effect (PR #645 gate note N1) — gone as a side effect of the above.** There's only one placement per goblin now, not a scattered one `PopulateRoom` picked plus a recomputed one overriding it.

## What's new (not deletion)

While migrating `seedGoblins`, found and routed around a real, previously-invisible toolkit gap: `BasicSelectablesRegistry.GetEntities` samples **with replacement** — a single 2-entity table asked for 2 entities could return the same goblin twice (confirmed via an isolated repro: `[goblin-2, goblin-2]`, not `[goblin-1, goblin-2]`). This was harmless to the OLD code (it discarded spawn-selection identity entirely and matched goblins to positions by slice index), but became a real correctness bug once positions are correlated back to specific goblins by `Entity.GetID()`. Fixed by giving each goblin its own single-entity selection table and `EntityGroup` (`Quantity.Fixed=1`) instead of one shared table with `Quantity.Fixed=2` — these are individually pre-identified fixed entities (`monster.NewGoblin` per known ID), not a random pick from a pool, so this is more honest modeling, not a workaround bolted onto the wrong tool. No toolkit issue filed for the underlying sampling-with-replacement behavior since rpg-api no longer depends on it, but flagged in `docs/status.md` since any future caller wanting N>1 *distinct* random picks from a shared table would hit the same gap.

## Bumps (ride this PR, no api code changes needed beyond the above)

- `rpg-toolkit/encounter` v0.26.0 → **v0.29.0** (rpg-toolkit#765 / PR #771 for `InitiativeRolledEvent`, this branch's own bump target moved twice more while in flight — v0.28.1 via toolkit#775 added the `ExitCombat` wire, v0.29.0 via toolkit#776 added `PlayerData`/`MonsterData.ActiveConditions` — took latest each time per the wave lead's direction rather than stopping at the first tag that unblocked #765; neither later addition is consumed by this PR's code, both are picked up automatically by whatever consumes #650's follow-up)
- `rpg-toolkit/tools/spawn` v0.2.0 → v0.3.0 (rpg-toolkit#760 / PR #770)

Verified the new toolkit event ordering on combat entry (appear → `ModeChanged` → `InitiativeRolled` → `TurnStarted`) doesn't break anything: `TestModeChangedToTurnBased_StreamCarriesInitiativeRoster` and `TestEntityAppearedEvent_StreamCarriesEntityType` both pass unchanged, 10x/5x under `-race`.

## Docs

`docs/status.md`: both the "InitiativeRolled synthesis + bounded retry" and spawn-workaround rough-edge entries are struck through per this doc's established retirement convention, each with a `RESOLVED by rpg-api#650` note. Important nuance preserved: this closes only ONE of rpg-api#647's two known manifestations — #647 stays open for the `InputRequiredDeliveredEvent` prompt-lookup path (same race pattern, untested under sustained `-race` load) and a newly-found, related gap from the reconnect-fidelity wave investigation (`persistWithCharacterData`'s two sequential non-atomic Redis writes).

## Test plan
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `golangci-lint run` scoped to touched packages (`internal/orchestrators/lobby`, `internal/handlers/dnd5e/v2/encounter`) — 0 issues (repo-wide `make pre-commit`/`make ci-check` lint fails on 29 pre-existing issues confirmed identical on a pristine `origin/main` clone — unrelated to this PR, not touched, flagged below)
- [x] `go test ./... -race` — full suite green
- [x] `TestStartEncounter_WalledRoomAndGoblins_CombatStartsOnSightedMove` — 30x under `-race`, stable (goblin placement is randomized; this is the wave-1 behavior-contract pin)
- [x] `TestModeChangedToTurnBased_StreamCarriesInitiativeRoster` — 10x under `-race`
- [x] `TestEntityAppearedEvent_StreamCarriesEntityType` — 5x under `-race`
- [x] Full `internal/integration/...` suite — green
- [x] `make ci-check` — full test suite passes; flags two items below
- [x] Re-verified full suite `-race` and the 20x goblin-placement stress run again after the encounter v0.28.0→v0.29.0 bump landed mid-branch, plus a small in-flight cleanup (extracted `entityGroupTypeMonster` for the magic-string-avoidance convention) — all still green at the final pinned versions

## Pushback / things worth knowing before merge

1. **`make pre-commit`'s lint step fails on 29 pre-existing issues repo-wide**, none in this PR's diff. Verified byte-for-byte identical on a pristine clone of `origin/main` (same 29 issues, same category breakdown: errcheck 2, goconst 19, govet 3, staticcheck 1, unconvert 3, unused 1) — this is accumulated debt across `internal/integration/harness`, `internal/components/dungeon/*`, `internal/handlers/dnd5e/v1alpha1/character/converters.go`, and `internal/orchestrators/dice`, unrelated to toolkit-seam adoption. `golangci-lint run` scoped to just this PR's touched packages is clean. Also confirmed: GitHub Actions CI (`test.yml`/`docker.yml`) doesn't actually run `golangci-lint` at all — it's a local-only hygiene check with no git hook installed in this environment to enforce it. Flagging rather than fixing 29 unrelated files in a toolkit-adoption PR; worth a follow-up issue if it should stay a hard local gate.
2. **`make ci-check`'s "mocks need regeneration" check also fails, unrelated to this PR.** `go generate ./...` produces a 7-file diff (`internal/auth/mock`, `internal/orchestrators/character/mock`, `internal/orchestrators/dice/mock`, three repo mocks, `sandboxroom/mock`) that is pure `mockgen`-tool-version import-reordering noise (verified: every file's diff is just gomock's import moving above/below a blank line), not a real interface-shape change, and touches zero files this PR modifies. Reverted rather than committed, to keep this PR scoped to #650.

Neither of the two items above is something this PR should absorb — happy to file follow-up issues for either if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9
