### PR TITLE
feat(lobby): GetMyActiveLobby lookup for resume-after-refresh

### DIFF
--- a/docs/architecture/components/lobby-service.md
+++ b/docs/architecture/components/lobby-service.md
@@ -40,10 +40,18 @@ shape rpg-api#616 flags on the old v2 encounter create/hydrate path.
 ### Handler (`internal/handlers/dnd5e/lobby/v1alpha1/`)
 
 One file per RPC (`create_lobby.go`, `join_lobby.go`, `set_ready.go`,
-`leave_lobby.go`, `start_encounter.go`, `stream_lobby.go`), plus `handler.go`
-(Config/New only), `translate.go` (entity <-> proto), and `status.go` (one shared
-`lobbyStatusError` switch covering every sentinel — each RPC only ever returns a
-subset, so one exhaustive mapper beats six near-duplicates).
+`leave_lobby.go`, `start_encounter.go`, `stream_lobby.go`, `get_my_active_lobby.go`),
+plus `handler.go` (Config/New only), `translate.go` (entity <-> proto), and
+`status.go` (one shared `lobbyStatusError` switch covering every sentinel — each RPC
+only ever returns a subset, so one exhaustive mapper beats six near-duplicates).
+
+`get_my_active_lobby.go` (rpg-api#653) is the resume-after-refresh lookup
+(rpg-dnd5e-web#444): unlike every other RPC here, it takes no request fields —
+identity comes entirely from `auth.GetPlayerID(ctx)`, matching `StreamLobby`'s
+pattern (a client-supplied `player_id` would let a caller query another player's
+lobby). "No active lobby" is a valid empty response, not an error — see the
+Repository section below for the index it reads and the orchestrator's
+`GetMyActiveLobby` doc comment for the STARTED-lobby liveness cross-check.
 
 `StartEncounter` needs the SAME production combat/movement resolvers the v2
 encounter handler builds (`Dnd5eCombatResolver` / `Dnd5eMovementResolver` —
@@ -99,6 +107,16 @@ secondary index (`JoinLobby` is the only RPC that addresses a lobby by ref inste
 ID), both refreshed with the same TTL on every `Save`, mirroring
 `internal/repositories/encounters/v2/redis.go`. In-memory variant for tests, same
 JSON-round-trip-on-every-call contract.
+
+A third index, `player:<playerID>:lobby` (rpg-api#653), backs `GetByPlayerID` —
+`GetMyActiveLobby`'s resume-after-refresh lookup. `Save` writes/refreshes this entry,
+same TTL, same transaction, for every player currently in `data.Members` — one
+active lobby per player, last write wins, no dual-membership tracking (nothing stops
+a player being a member of two lobbies at once; the index just points at whichever
+was `Save`d most recently). Because `Save` can only add or refresh entries from a
+`Data` snapshot — it has no way to see who was removed — `LeaveLobby` calls the
+repository's `ClearPlayerIndex` explicitly for the departing player; no other RPC
+needs to.
 
 ## Contract edge cases (decided in the design, implemented here)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-api
 go 1.25.3
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0
@@ -23,7 +23,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.40.0
 	go.uber.org/mock v0.6.0
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274 h1:ds8HGAt94sLuwIdFWerjD9zKiOtL1bWlaLAZesfnYT4=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260706205140-e1dbc19e7274/go.mod h1:MpM/QRlRQ80AOmISTdzELXp7d+Xr3g/R6bxDlksyjJ8=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a h1:LgG4irkwQhw46/b8oaE6vUEVTFLkVPoQgjUYivtsSVQ=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a/go.mod h1:CiSz9niTulIpKnOnHNwbwjhgWDAhR90YM6xmZcqS16c=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
@@ -213,8 +213,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/handlers/dnd5e/lobby/v1alpha1/get_my_active_lobby.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/get_my_active_lobby.go
@@ -1,0 +1,37 @@
+package lobby
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	lobbyv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
+)
+
+// GetMyActiveLobby handles the GetMyActiveLobby RPC: resolves the
+// authenticated caller's own active lobby (resume-after-refresh,
+// rpg-dnd5e-web#444). No request fields — identity comes entirely from the
+// authenticated context, matching StreamLobby's pattern.
+func (h *Handler) GetMyActiveLobby(
+	ctx context.Context,
+	_ *lobbyv1alpha1.GetMyActiveLobbyRequest,
+) (*lobbyv1alpha1.GetMyActiveLobbyResponse, error) {
+	playerID := auth.GetPlayerID(ctx)
+	if playerID == "" {
+		return nil, status.Error(codes.Unauthenticated, "no player id in context")
+	}
+
+	out, err := h.orch.GetMyActiveLobby(ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: playerID})
+	if err != nil {
+		return nil, lobbyStatusError(err)
+	}
+
+	return &lobbyv1alpha1.GetMyActiveLobbyResponse{
+		LobbyId:     out.LobbyID,
+		EncounterId: out.EncounterID,
+		LobbyStatus: translateLobbyStatus(out.Status),
+	}, nil
+}

--- a/internal/handlers/dnd5e/lobby/v1alpha1/get_my_active_lobby_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/get_my_active_lobby_test.go
@@ -1,0 +1,34 @@
+package lobby_test
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	lobbyv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1"
+)
+
+func (s *HandlerSuite) TestGetMyActiveLobby_Unauthenticated() {
+	_, err := s.handler.GetMyActiveLobby(context.Background(), &lobbyv1alpha1.GetMyActiveLobbyRequest{})
+	s.Require().Error(err)
+	s.Require().Equal(codes.Unauthenticated, status.Code(err))
+}
+
+func (s *HandlerSuite) TestGetMyActiveLobby_NoActiveLobby_ReturnsEmptyResponse() {
+	resp, err := s.handler.GetMyActiveLobby(s.ctx, &lobbyv1alpha1.GetMyActiveLobbyRequest{})
+	s.Require().NoError(err)
+	s.Require().Empty(resp.GetLobbyId())
+	s.Require().Empty(resp.GetEncounterId())
+	s.Require().Equal(lobbyv1alpha1.LobbyStatus_LOBBY_STATUS_UNSPECIFIED, resp.GetLobbyStatus())
+}
+
+func (s *HandlerSuite) TestGetMyActiveLobby_WaitingLobby_TranslatesStatusAndID() {
+	lobbyID, _ := s.createLobby("alice", "char-alice", "Alice")
+
+	resp, err := s.handler.GetMyActiveLobby(s.ctx, &lobbyv1alpha1.GetMyActiveLobbyRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(lobbyID, resp.GetLobbyId())
+	s.Require().Empty(resp.GetEncounterId())
+	s.Require().Equal(lobbyv1alpha1.LobbyStatus_LOBBY_STATUS_WAITING, resp.GetLobbyStatus())
+}

--- a/internal/handlers/dnd5e/lobby/v1alpha1/translate.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/translate.go
@@ -8,6 +8,22 @@ import (
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
 )
 
+// translateLobbyStatus converts the entity-layer lobby Status to its proto
+// mirror. lobbyrepo.StatusUnspecified (the zero value, used by
+// GetMyActiveLobbyOutput's "no active lobby" empty response) maps to
+// LOBBY_STATUS_UNSPECIFIED, proto3's own zero value — no explicit case
+// needed, the switch's default covers it.
+func translateLobbyStatus(s lobbyrepo.Status) lobbyv1alpha1.LobbyStatus {
+	switch s {
+	case lobbyrepo.StatusWaiting:
+		return lobbyv1alpha1.LobbyStatus_LOBBY_STATUS_WAITING
+	case lobbyrepo.StatusStarted:
+		return lobbyv1alpha1.LobbyStatus_LOBBY_STATUS_STARTED
+	default:
+		return lobbyv1alpha1.LobbyStatus_LOBBY_STATUS_UNSPECIFIED
+	}
+}
+
 // translateMember converts one entity-layer Member to its proto mirror.
 func translateMember(m *lobbyrepo.Member) *lobbyv1alpha1.LobbyMember {
 	if m == nil {

--- a/internal/orchestrators/lobby/get_my_active_lobby.go
+++ b/internal/orchestrators/lobby/get_my_active_lobby.go
@@ -1,0 +1,89 @@
+package lobby
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// GetMyActiveLobbyInput carries the entity-typed GetMyActiveLobby request.
+type GetMyActiveLobbyInput struct {
+	// PlayerID is the authenticated caller. Required.
+	PlayerID string
+}
+
+// GetMyActiveLobbyOutput reports the caller's active lobby, if any.
+//
+// A zero-value Output (LobbyID == "") means no active lobby — the normal
+// response for the common case of a player who isn't currently in one, not
+// an error.
+//
+// EncounterID is set if and only if Status is StatusStarted AND the
+// encounter has been verified still live (exists, Mode != ModeEnded). A
+// STARTED lobby whose encounter is not live has nothing left for a client
+// to resume into — the lobby record itself is a terminal, dead husk at that
+// point (WAITING -> STARTED never reverses; see lobbyrepo.Status) — so this
+// method reports that case identically to "no active lobby": the whole
+// Output is zeroed, not just EncounterID. That keeps callers to one branch
+// ("is LobbyID empty?") instead of a second STARTED-but-unusable case they
+// would otherwise have to special-case.
+type GetMyActiveLobbyOutput struct {
+	LobbyID     string
+	EncounterID string
+	Status      lobbyrepo.Status
+}
+
+// GetMyActiveLobby resolves the authenticated player's own active lobby —
+// resume-after-refresh support (rpg-dnd5e-web#444: a client that has lost
+// all in-memory session state calls this once to learn whether it should
+// skip straight back into a lobby or a running encounter instead of landing
+// on Home). Pure lookup: no lock, no mutation, no broadcast.
+func (o *Orchestrator) GetMyActiveLobby(ctx context.Context, in *GetMyActiveLobbyInput) (*GetMyActiveLobbyOutput, error) {
+	if in == nil {
+		return nil, errors.New("lobby orchestrator: GetMyActiveLobbyInput is required")
+	}
+
+	data, err := o.lobbyRepo.GetByPlayerID(ctx, in.PlayerID)
+	if err != nil {
+		if errors.Is(err, lobbyrepo.ErrNotFound) {
+			return &GetMyActiveLobbyOutput{}, nil
+		}
+		return nil, fmt.Errorf("load active lobby for player %q: %w", in.PlayerID, err)
+	}
+
+	if data.Status != lobbyrepo.StatusStarted {
+		return &GetMyActiveLobbyOutput{LobbyID: data.ID, Status: data.Status}, nil
+	}
+
+	// STARTED: the lobby record never learns when its encounter later ends
+	// (see Repository's doc comment — StartEncounter's Save is the last
+	// write a STARTED lobby ever gets), so liveness has to be checked
+	// against the encounter's own current state before trusting
+	// encounter_id. A STARTED lobby with no encounter_id at all would be a
+	// StartEncounter bug (it always sets both together) — treated the same
+	// as "not live" rather than as a hard error, since the caller-visible
+	// outcome (nothing to resume) is identical either way.
+	if data.EncounterID == "" {
+		return &GetMyActiveLobbyOutput{}, nil
+	}
+	encData, err := o.encounterRepo.Get(ctx, data.EncounterID)
+	if err != nil {
+		if errors.Is(err, encountersv2.ErrNotFound) {
+			return &GetMyActiveLobbyOutput{}, nil
+		}
+		return nil, fmt.Errorf("load encounter %q for liveness check: %w", data.EncounterID, err)
+	}
+	if encData.Mode == core.ModeEnded {
+		return &GetMyActiveLobbyOutput{}, nil
+	}
+
+	return &GetMyActiveLobbyOutput{
+		LobbyID:     data.ID,
+		EncounterID: data.EncounterID,
+		Status:      data.Status,
+	}, nil
+}

--- a/internal/orchestrators/lobby/get_my_active_lobby.go
+++ b/internal/orchestrators/lobby/get_my_active_lobby.go
@@ -58,6 +58,23 @@ func (o *Orchestrator) GetMyActiveLobby(ctx context.Context, in *GetMyActiveLobb
 		return nil, fmt.Errorf("load active lobby for player %q: %w", in.PlayerID, err)
 	}
 
+	// The index is a pointer, not a source of truth — verify the player is
+	// actually still in the lobby it points at before trusting it. Save only
+	// adds/refreshes an index entry for players CURRENTLY in data.Members
+	// (see Repository.Save's doc comment) and never removes a departed
+	// player's entry itself; LeaveLobby's ClearPlayerIndex call is what's
+	// supposed to do that, and it's deliberately best-effort (leave_lobby.go)
+	// so an infra hiccup there can leave a stale entry pointing at a lobby
+	// the player already left. Catching that here, not just at write time,
+	// means the discarded-error path in LeaveLobby is fully safe: the write
+	// side stays best-effort, this read side is authoritative. Self-heals
+	// the stale entry so it doesn't keep costing a lookup until its TTL
+	// expires.
+	if _, isMember := data.Members[in.PlayerID]; !isMember {
+		_ = o.lobbyRepo.ClearPlayerIndex(ctx, in.PlayerID)
+		return &GetMyActiveLobbyOutput{}, nil
+	}
+
 	if data.Status != lobbyrepo.StatusStarted {
 		return &GetMyActiveLobbyOutput{LobbyID: data.ID, Status: data.Status}, nil
 	}

--- a/internal/orchestrators/lobby/get_my_active_lobby.go
+++ b/internal/orchestrators/lobby/get_my_active_lobby.go
@@ -46,6 +46,9 @@ func (o *Orchestrator) GetMyActiveLobby(ctx context.Context, in *GetMyActiveLobb
 	if in == nil {
 		return nil, errors.New("lobby orchestrator: GetMyActiveLobbyInput is required")
 	}
+	if in.PlayerID == "" {
+		return nil, errors.New("lobby orchestrator: GetMyActiveLobbyInput.PlayerID is required")
+	}
 
 	data, err := o.lobbyRepo.GetByPlayerID(ctx, in.PlayerID)
 	if err != nil {

--- a/internal/orchestrators/lobby/get_my_active_lobby_test.go
+++ b/internal/orchestrators/lobby/get_my_active_lobby_test.go
@@ -1,0 +1,79 @@
+package lobby_test
+
+import (
+	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
+	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+func (s *LobbySuite) TestGetMyActiveLobby_NoActiveLobby_ReturnsEmptyOutput() {
+	out, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: "stranger"})
+	s.Require().NoError(err)
+	s.Require().Empty(out.LobbyID)
+	s.Require().Empty(out.EncounterID)
+	s.Require().Equal(lobbyrepo.StatusUnspecified, out.Status)
+}
+
+func (s *LobbySuite) TestGetMyActiveLobby_WaitingLobby_ReturnsLobbyOnly() {
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-g1", HostPlayerID: "alice", Status: lobbyrepo.StatusWaiting,
+		Members:     map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice", IsHost: true}},
+		MemberOrder: []string{"alice"},
+	})
+
+	out, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-g1", out.LobbyID)
+	s.Require().Empty(out.EncounterID)
+	s.Require().Equal(lobbyrepo.StatusWaiting, out.Status)
+}
+
+func (s *LobbySuite) TestGetMyActiveLobby_StartedWithLiveEncounter_ReturnsBothIDs() {
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-g2", HostPlayerID: "alice", Status: lobbyrepo.StatusStarted, EncounterID: "enc-live",
+		Members:     map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice", IsHost: true}},
+		MemberOrder: []string{"alice"},
+	})
+	s.Require().NoError(s.encRepo.Save(s.ctx, &tkenc.Data{ID: core.EncounterID("enc-live"), Mode: core.ModeFreeRoam}))
+
+	out, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-g2", out.LobbyID)
+	s.Require().Equal("enc-live", out.EncounterID)
+	s.Require().Equal(lobbyrepo.StatusStarted, out.Status)
+}
+
+func (s *LobbySuite) TestGetMyActiveLobby_StartedWithEndedEncounter_ReturnsEmptyOutput() {
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-g3", HostPlayerID: "alice", Status: lobbyrepo.StatusStarted, EncounterID: "enc-ended",
+		Members:     map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice", IsHost: true}},
+		MemberOrder: []string{"alice"},
+	})
+	s.Require().NoError(s.encRepo.Save(s.ctx, &tkenc.Data{ID: core.EncounterID("enc-ended"), Mode: core.ModeEnded}))
+
+	out, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: "alice"})
+	s.Require().NoError(err)
+	s.Require().Empty(out.LobbyID, "a STARTED lobby whose encounter has ended has nothing to resume")
+	s.Require().Empty(out.EncounterID)
+}
+
+func (s *LobbySuite) TestGetMyActiveLobby_StartedWithMissingEncounter_ReturnsEmptyOutput() {
+	// Started lobby whose encounter record is simply gone (e.g. expired) —
+	// same "nothing to resume" outcome as an explicitly ended one.
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-g4", HostPlayerID: "alice", Status: lobbyrepo.StatusStarted, EncounterID: "enc-missing",
+		Members:     map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice", IsHost: true}},
+		MemberOrder: []string{"alice"},
+	})
+
+	out, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: "alice"})
+	s.Require().NoError(err)
+	s.Require().Empty(out.LobbyID)
+	s.Require().Empty(out.EncounterID)
+}
+
+func (s *LobbySuite) TestGetMyActiveLobby_NilInput_Errors() {
+	_, err := s.orch.GetMyActiveLobby(s.ctx, nil)
+	s.Require().Error(err)
+}

--- a/internal/orchestrators/lobby/get_my_active_lobby_test.go
+++ b/internal/orchestrators/lobby/get_my_active_lobby_test.go
@@ -77,3 +77,11 @@ func (s *LobbySuite) TestGetMyActiveLobby_NilInput_Errors() {
 	_, err := s.orch.GetMyActiveLobby(s.ctx, nil)
 	s.Require().Error(err)
 }
+
+func (s *LobbySuite) TestGetMyActiveLobby_EmptyPlayerID_Errors() {
+	// An empty PlayerID must fail loudly, not silently resolve to "no active
+	// lobby" — that would mask a caller bug (e.g. an auth-context wiring
+	// mistake upstream) as a legitimate empty result.
+	_, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: ""})
+	s.Require().Error(err)
+}

--- a/internal/orchestrators/lobby/get_my_active_lobby_test.go
+++ b/internal/orchestrators/lobby/get_my_active_lobby_test.go
@@ -73,6 +73,39 @@ func (s *LobbySuite) TestGetMyActiveLobby_StartedWithMissingEncounter_ReturnsEmp
 	s.Require().Empty(out.EncounterID)
 }
 
+func (s *LobbySuite) TestGetMyActiveLobby_PlayerNoLongerMember_SelfHealsStaleIndex() {
+	// Set up a lobby where bob is a member (Save writes bob's index entry),
+	// then Save the SAME lobby again with bob removed from Members. Save
+	// only adds/refreshes index entries for players CURRENTLY in Members
+	// (see Repository.Save's doc comment) — it never removes a departed
+	// player's entry — so this reproduces exactly the window LeaveLobby's
+	// best-effort ClearPlayerIndex (leave_lobby.go) can leave behind if that
+	// cleanup call fails: an index entry pointing at a lobby the player is
+	// no longer actually a member of.
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-g5", HostPlayerID: "alice", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{
+			"alice": {PlayerID: "alice", IsHost: true},
+			"bob":   {PlayerID: "bob"},
+		},
+		MemberOrder: []string{"alice", "bob"},
+	})
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-g5", HostPlayerID: "alice", Status: lobbyrepo.StatusWaiting,
+		Members:     map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice", IsHost: true}},
+		MemberOrder: []string{"alice"},
+	})
+
+	out, err := s.orch.GetMyActiveLobby(s.ctx, &lobbyorch.GetMyActiveLobbyInput{PlayerID: "bob"})
+	s.Require().NoError(err)
+	s.Require().Empty(out.LobbyID, "a stale index entry pointing at a lobby the player is no longer a member of must resolve to no active lobby")
+	s.Require().Empty(out.EncounterID)
+
+	_, err = s.lobbyRepo.GetByPlayerID(s.ctx, "bob")
+	s.Require().Error(err, "the stale index entry must be self-healed (cleared) by the read path, not left for TTL to eventually reap")
+	s.Require().ErrorIs(err, lobbyrepo.ErrNotFound)
+}
+
 func (s *LobbySuite) TestGetMyActiveLobby_NilInput_Errors() {
 	_, err := s.orch.GetMyActiveLobby(s.ctx, nil)
 	s.Require().Error(err)

--- a/internal/orchestrators/lobby/leave_lobby.go
+++ b/internal/orchestrators/lobby/leave_lobby.go
@@ -70,11 +70,20 @@ func (o *Orchestrator) LeaveLobby(ctx context.Context, in *LeaveLobbyInput) (*Le
 	// Save only adds/refreshes index entries for members still present in
 	// data.Members — it cannot infer removal from a single Data value (see
 	// Repository.Save's doc comment). The departing player's stale entry
-	// must be cleared explicitly, or GetMyActiveLobby would keep resolving
-	// them to a lobby they already left.
-	if err := o.lobbyRepo.ClearPlayerIndex(ctx, in.PlayerID); err != nil {
-		return nil, fmt.Errorf("clear player index for %q: %w", in.PlayerID, err)
-	}
+	// should be cleared explicitly, or GetMyActiveLobby could keep resolving
+	// them to a lobby they already left (until the entry's TTL expires).
+	//
+	// Best-effort, deliberately non-fatal: by this line the membership
+	// mutation above is already durable — that Save succeeding is what
+	// "the leave happened" means. Failing the RPC here would report an
+	// error for a leave that actually went through, skip the MemberLeft/
+	// HostChanged broadcast other connected clients depend on, and make a
+	// caller's retry hit ErrPlayerNotInLobby (the member is already gone)
+	// even though they saw a failure — non-idempotent from the caller's
+	// point of view. No logger exists in this package to record the
+	// failure; the narrow cost of swallowing it is a stale index entry
+	// bounded by the same TTL every other index entry already relies on.
+	_ = o.lobbyRepo.ClearPlayerIndex(ctx, in.PlayerID)
 
 	o.lobbyBroker.Publish(in.LobbyID, &Event{
 		Kind:       EventKindMemberLeft,

--- a/internal/orchestrators/lobby/leave_lobby.go
+++ b/internal/orchestrators/lobby/leave_lobby.go
@@ -67,6 +67,14 @@ func (o *Orchestrator) LeaveLobby(ctx context.Context, in *LeaveLobbyInput) (*Le
 	if err := o.lobbyRepo.Save(ctx, data); err != nil {
 		return nil, fmt.Errorf("save lobby %q: %w", in.LobbyID, err)
 	}
+	// Save only adds/refreshes index entries for members still present in
+	// data.Members — it cannot infer removal from a single Data value (see
+	// Repository.Save's doc comment). The departing player's stale entry
+	// must be cleared explicitly, or GetMyActiveLobby would keep resolving
+	// them to a lobby they already left.
+	if err := o.lobbyRepo.ClearPlayerIndex(ctx, in.PlayerID); err != nil {
+		return nil, fmt.Errorf("clear player index for %q: %w", in.PlayerID, err)
+	}
 
 	o.lobbyBroker.Publish(in.LobbyID, &Event{
 		Kind:       EventKindMemberLeft,

--- a/internal/orchestrators/lobby/leave_lobby_test.go
+++ b/internal/orchestrators/lobby/leave_lobby_test.go
@@ -80,3 +80,25 @@ func (s *LobbySuite) TestLeaveLobby_LobbyStarted_FailedPrecondition() {
 	_, err := s.orch.LeaveLobby(s.ctx, &lobbyorch.LeaveLobbyInput{PlayerID: "alice", LobbyID: "lobby-l5"})
 	s.Require().ErrorIs(err, lobbyorch.ErrLobbyAlreadyStarted)
 }
+
+func (s *LobbySuite) TestLeaveLobby_ClearsPlayerActiveLobbyIndex() {
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-l6", HostPlayerID: "alice", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{
+			"alice": {PlayerID: "alice", IsHost: true},
+			"bob":   {PlayerID: "bob"},
+		},
+		MemberOrder: []string{"alice", "bob"},
+	})
+
+	_, err := s.orch.LeaveLobby(s.ctx, &lobbyorch.LeaveLobbyInput{PlayerID: "bob", LobbyID: "lobby-l6"})
+	s.Require().NoError(err)
+
+	_, err = s.lobbyRepo.GetByPlayerID(s.ctx, "bob")
+	s.Require().Error(err, "a departed member's active-lobby index entry must be cleared, not left stale")
+	s.Require().ErrorIs(err, lobbyrepo.ErrNotFound)
+
+	stillActive, err := s.lobbyRepo.GetByPlayerID(s.ctx, "alice")
+	s.Require().NoError(err, "the remaining member's index entry must be untouched")
+	s.Require().Equal("lobby-l6", stillActive.ID)
+}

--- a/internal/orchestrators/lobby/leave_lobby_test.go
+++ b/internal/orchestrators/lobby/leave_lobby_test.go
@@ -1,9 +1,27 @@
 package lobby_test
 
 import (
+	"context"
+	"errors"
+
 	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
 )
+
+// clearIndexFailingRepo wraps a real Repository and forces every
+// ClearPlayerIndex call to fail, so tests can pin LeaveLobby's behavior when
+// the index-cleanup step hits an infra error after the membership mutation
+// (Save) has already durably succeeded. Not a gomock double — a small
+// hand-rolled wrapper is simpler than a full interface mock for one
+// overridden method (feedback_test_double_naming: reserve "mock" for
+// gomock-generated types).
+type clearIndexFailingRepo struct {
+	lobbyrepo.Repository
+}
+
+func (r *clearIndexFailingRepo) ClearPlayerIndex(context.Context, string) error {
+	return errors.New("clearIndexFailingRepo: simulated infra failure")
+}
 
 func (s *LobbySuite) TestLeaveLobby_NonHostLeaves_RemovesSeat() {
 	s.seedLobby(&lobbyrepo.Data{
@@ -101,4 +119,40 @@ func (s *LobbySuite) TestLeaveLobby_ClearsPlayerActiveLobbyIndex() {
 	stillActive, err := s.lobbyRepo.GetByPlayerID(s.ctx, "alice")
 	s.Require().NoError(err, "the remaining member's index entry must be untouched")
 	s.Require().Equal("lobby-l6", stillActive.ID)
+}
+
+// TestLeaveLobby_ClearPlayerIndexFails_StillSucceedsAndBroadcasts pins the
+// Copilot-flagged correctness fix on rpg-api#654: the membership mutation
+// (Save) is the durable, authoritative "did the leave happen" — a failure in
+// the secondary index cleanup that follows it must NOT turn a real leave
+// into a reported error (that would make the RPC non-idempotent: a retry
+// would immediately hit ErrPlayerNotInLobby since the member is already
+// gone) and must NOT suppress the MemberLeft broadcast other connected
+// clients depend on.
+func (s *LobbySuite) TestLeaveLobby_ClearPlayerIndexFails_StillSucceedsAndBroadcasts() {
+	s.seedLobby(&lobbyrepo.Data{
+		ID: "lobby-l7", HostPlayerID: "alice", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{
+			"alice": {PlayerID: "alice", IsHost: true},
+			"bob":   {PlayerID: "bob"},
+		},
+		MemberOrder: []string{"alice", "bob"},
+	})
+
+	sub, err := s.broker.Subscribe("lobby-l7")
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	failingOrch := s.newOrchestratorWithLobbyRepo(&clearIndexFailingRepo{Repository: s.lobbyRepo})
+
+	_, err = failingOrch.LeaveLobby(s.ctx, &lobbyorch.LeaveLobbyInput{PlayerID: "bob", LobbyID: "lobby-l7"})
+	s.Require().NoError(err, "a ClearPlayerIndex failure must not fail the leave itself")
+
+	data, err := s.lobbyRepo.Get(s.ctx, "lobby-l7")
+	s.Require().NoError(err)
+	s.Require().NotContains(data.Members, "bob", "the membership mutation must still have happened")
+
+	evt := <-sub.Events()
+	s.Require().Equal(lobbyorch.EventKindMemberLeft, evt.Kind, "the broadcast must still fire despite the index-cleanup failure")
+	s.Require().Equal("bob", evt.MemberLeft.PlayerID)
 }

--- a/internal/orchestrators/lobby/lobby_test.go
+++ b/internal/orchestrators/lobby/lobby_test.go
@@ -111,6 +111,34 @@ func (s *LobbySuite) expectCharacterNotFound(characterID string) {
 		Return(nil, apierr.NotFound("character not found"))
 }
 
+// newOrchestratorWithLobbyRepo builds a second Orchestrator sharing every
+// other suite dependency (broker, character repo, encounter repo/broker,
+// generators) but backed by repo instead of s.lobbyRepo — for tests that
+// need to observe behavior when the lobby repository itself misbehaves
+// (e.g. a wrapped repo that forces one method to fail).
+func (s *LobbySuite) newOrchestratorWithLobbyRepo(repo lobbyrepo.Repository) *lobbyorch.Orchestrator {
+	orch, err := lobbyorch.New(&lobbyorch.Config{
+		LobbyRepo:         repo,
+		LobbyBroker:       s.broker,
+		CharacterRepo:     s.charRepo,
+		EncounterRepo:     s.encRepo,
+		EncounterBroker:   s.encBroker,
+		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		LobbyIDGenerator:     idgen.NewSequential("lobby"),
+		JoinRefGenerator:     idgen.NewSequential("ref"),
+		EncounterIDGenerator: idgen.NewSequential("enc"),
+		Now:                  func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	return orch
+}
+
 // seedLobby writes data directly to s.lobbyRepo, bypassing CreateLobby /
 // JoinLobby (and their character-repo lookups) so tests that exercise a
 // LATER RPC (SetReady, LeaveLobby, StartEncounter, SetConnected) can set up

--- a/internal/repositories/lobby/in_memory.go
+++ b/internal/repositories/lobby/in_memory.go
@@ -17,8 +17,9 @@ import (
 // write.
 func NewInMemory() Repository {
 	return &inMemory{
-		byID:    make(map[string][]byte),
-		idByRef: make(map[string]string),
+		byID:       make(map[string][]byte),
+		idByRef:    make(map[string]string),
+		idByPlayer: make(map[string]string),
 	}
 }
 
@@ -27,6 +28,10 @@ type inMemory struct {
 	byID map[string][]byte
 	// idByRef maps join_ref -> lobby id, the secondary index GetByJoinRef reads.
 	idByRef map[string]string
+	// idByPlayer maps player id -> lobby id, the secondary index
+	// GetByPlayerID reads. Save keeps this in lockstep with data.Members on
+	// every write; ClearPlayerIndex is the only way an entry is removed.
+	idByPlayer map[string]string
 }
 
 func (r *inMemory) Get(_ context.Context, id string) (*Data, error) {
@@ -42,6 +47,20 @@ func (r *inMemory) Get(_ context.Context, id string) (*Data, error) {
 func (r *inMemory) GetByJoinRef(_ context.Context, joinRef string) (*Data, error) {
 	r.mu.Lock()
 	id, ok := r.idByRef[joinRef]
+	var b []byte
+	if ok {
+		b, ok = r.byID[id]
+	}
+	r.mu.Unlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return decode(b, id)
+}
+
+func (r *inMemory) GetByPlayerID(_ context.Context, playerID string) (*Data, error) {
+	r.mu.Lock()
+	id, ok := r.idByPlayer[playerID]
 	var b []byte
 	if ok {
 		b, ok = r.byID[id]
@@ -70,6 +89,16 @@ func (r *inMemory) Save(_ context.Context, data *Data) error {
 	if data.JoinRef != "" {
 		r.idByRef[data.JoinRef] = data.ID
 	}
+	for playerID := range data.Members {
+		r.idByPlayer[playerID] = data.ID
+	}
+	return nil
+}
+
+func (r *inMemory) ClearPlayerIndex(_ context.Context, playerID string) error {
+	r.mu.Lock()
+	delete(r.idByPlayer, playerID)
+	r.mu.Unlock()
 	return nil
 }
 

--- a/internal/repositories/lobby/in_memory_test.go
+++ b/internal/repositories/lobby/in_memory_test.go
@@ -73,6 +73,67 @@ func (s *InMemorySuite) TestSave_EmptyID_ReturnsError() {
 	s.Require().Error(err)
 }
 
+func (s *InMemorySuite) TestGetByPlayerID_ReturnsErrNotFound_ForMissingPlayer() {
+	_, err := s.repo.GetByPlayerID(s.ctx, "missing-player")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, lobbyrepo.ErrNotFound))
+}
+
+func (s *InMemorySuite) TestSave_IndexesMembersByPlayerID() {
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-3", JoinRef: "ref-3", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{
+			"alice": {PlayerID: "alice", IsHost: true},
+			"bob":   {PlayerID: "bob"},
+		},
+		MemberOrder: []string{"alice", "bob"},
+	}))
+
+	loadedAlice, err := s.repo.GetByPlayerID(s.ctx, "alice")
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-3", loadedAlice.ID)
+
+	loadedBob, err := s.repo.GetByPlayerID(s.ctx, "bob")
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-3", loadedBob.ID)
+}
+
+func (s *InMemorySuite) TestSave_PlayerIndex_SecondLobbyOverwrites() {
+	// A player who is (or was) a member of two different lobbies has their
+	// index entry point at whichever lobby was Saved most recently — the
+	// documented one-active-lobby-per-player, last-write-wins semantic.
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-a", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice"}},
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-b", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice"}},
+	}))
+
+	loaded, err := s.repo.GetByPlayerID(s.ctx, "alice")
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-b", loaded.ID)
+}
+
+func (s *InMemorySuite) TestClearPlayerIndex_RemovesEntry() {
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-4", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice"}},
+	}))
+
+	s.Require().NoError(s.repo.ClearPlayerIndex(s.ctx, "alice"))
+
+	_, err := s.repo.GetByPlayerID(s.ctx, "alice")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, lobbyrepo.ErrNotFound))
+}
+
+func (s *InMemorySuite) TestClearPlayerIndex_NoOpForAbsentPlayer() {
+	err := s.repo.ClearPlayerIndex(s.ctx, "nobody")
+	s.Require().NoError(err)
+}
+
 func TestInMemorySuite(t *testing.T) {
 	suite.Run(t, new(InMemorySuite))
 }

--- a/internal/repositories/lobby/redis.go
+++ b/internal/repositories/lobby/redis.go
@@ -22,6 +22,17 @@ const redisKeyPrefix = "lobby:"
 // index is the only way to serve it in O(1).
 const redisJoinRefPrefix = "lobby:joinref:"
 
+// redisPlayerPrefix namespaces the player id -> lobby id secondary index
+// GetByPlayerID reads (GetMyActiveLobby / resume-after-refresh,
+// rpg-dnd5e-web#444). Deliberately its own top-level prefix ("player:...",
+// not "lobby:player:...") since this index is conceptually owned by the
+// player, not the lobby — a future non-lobby feature keyed by player id
+// would want the same namespace root.
+const redisPlayerPrefix = "player:"
+
+// redisPlayerSuffix closes the player key: player:{playerID}:lobby.
+const redisPlayerSuffix = ":lobby"
+
 // NewRedis returns a Redis-backed Repository.
 //
 // ttl is refreshed on every Save (both the primary record and the join_ref
@@ -60,10 +71,27 @@ func (r *redisRepo) GetByJoinRef(ctx context.Context, joinRef string) (*Data, er
 	return r.Get(ctx, id)
 }
 
-// Save writes the primary record and the join_ref index in one MULTI/EXEC
-// pipeline, so the two keys never observe a partially-updated state (a crash
-// or network failure between two independent SETs could otherwise leave a
-// record with no working join_ref index, or vice versa).
+func (r *redisRepo) GetByPlayerID(ctx context.Context, playerID string) (*Data, error) {
+	id, err := r.client.Get(ctx, redisPlayerKey(playerID)).Result()
+	if err != nil {
+		if errors.Is(err, goredis.Nil) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get lobby by player %q: %w", playerID, err)
+	}
+	return r.Get(ctx, id)
+}
+
+// Save writes the primary record, the join_ref index, and a player index
+// entry per current member in one MULTI/EXEC pipeline, so no reader ever
+// observes a partially-updated state (a crash or network failure between
+// independent SETs could otherwise leave a record with a stale or missing
+// secondary index).
+//
+// Save only ever adds/refreshes player index entries for members present in
+// data.Members — see the Repository.Save doc comment for why a removed
+// member's stale entry is a caller responsibility (ClearPlayerIndex), not
+// something Save can infer from a single Data value.
 func (r *redisRepo) Save(ctx context.Context, data *Data) error {
 	if data == nil {
 		return errors.New("data is required")
@@ -80,8 +108,18 @@ func (r *redisRepo) Save(ctx context.Context, data *Data) error {
 	if data.JoinRef != "" {
 		pipe.Set(ctx, redisJoinRefKey(data.JoinRef), data.ID, r.ttl)
 	}
+	for playerID := range data.Members {
+		pipe.Set(ctx, redisPlayerKey(playerID), data.ID, r.ttl)
+	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("save lobby %q: %w", data.ID, err)
+	}
+	return nil
+}
+
+func (r *redisRepo) ClearPlayerIndex(ctx context.Context, playerID string) error {
+	if err := r.client.Del(ctx, redisPlayerKey(playerID)).Err(); err != nil {
+		return fmt.Errorf("clear player index %q: %w", playerID, err)
 	}
 	return nil
 }
@@ -92,4 +130,8 @@ func redisKey(id string) string {
 
 func redisJoinRefKey(joinRef string) string {
 	return redisJoinRefPrefix + joinRef
+}
+
+func redisPlayerKey(playerID string) string {
+	return redisPlayerPrefix + playerID + redisPlayerSuffix
 }

--- a/internal/repositories/lobby/redis_test.go
+++ b/internal/repositories/lobby/redis_test.go
@@ -123,6 +123,64 @@ func (s *RedisSuite) TestSave_EmptyID_ReturnsError() {
 	s.Require().Error(err)
 }
 
+func (s *RedisSuite) TestGetByPlayerID_ReturnsErrNotFound_ForMissingPlayer() {
+	_, err := s.repo.GetByPlayerID(s.ctx, "missing-player")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, lobbyrepo.ErrNotFound))
+}
+
+func (s *RedisSuite) TestSave_IndexesMembersByPlayerID() {
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-3", JoinRef: "ref-3", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{
+			"alice": {PlayerID: "alice", IsHost: true},
+			"bob":   {PlayerID: "bob"},
+		},
+		MemberOrder: []string{"alice", "bob"},
+	}))
+
+	loadedAlice, err := s.repo.GetByPlayerID(s.ctx, "alice")
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-3", loadedAlice.ID)
+
+	loadedBob, err := s.repo.GetByPlayerID(s.ctx, "bob")
+	s.Require().NoError(err)
+	s.Require().Equal("lobby-3", loadedBob.ID)
+}
+
+func (s *RedisSuite) TestSave_PlayerIndex_AppliesTTL() {
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-ttl-player", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice"}},
+	}))
+
+	ttl := s.miniredis.TTL("player:alice:lobby")
+	s.Require().Equal(24*time.Hour, ttl, "Save must apply the configured TTL to the player index")
+
+	s.miniredis.FastForward(25 * time.Hour)
+	_, err := s.repo.GetByPlayerID(s.ctx, "alice")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, lobbyrepo.ErrNotFound))
+}
+
+func (s *RedisSuite) TestClearPlayerIndex_RemovesEntry() {
+	s.Require().NoError(s.repo.Save(s.ctx, &lobbyrepo.Data{
+		ID: "lobby-4", Status: lobbyrepo.StatusWaiting,
+		Members: map[string]*lobbyrepo.Member{"alice": {PlayerID: "alice"}},
+	}))
+
+	s.Require().NoError(s.repo.ClearPlayerIndex(s.ctx, "alice"))
+
+	_, err := s.repo.GetByPlayerID(s.ctx, "alice")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, lobbyrepo.ErrNotFound))
+}
+
+func (s *RedisSuite) TestClearPlayerIndex_NoOpForAbsentPlayer() {
+	err := s.repo.ClearPlayerIndex(s.ctx, "nobody")
+	s.Require().NoError(err)
+}
+
 func TestRedisSuite(t *testing.T) {
 	suite.Run(t, new(RedisSuite))
 }

--- a/internal/repositories/lobby/repository.go
+++ b/internal/repositories/lobby/repository.go
@@ -64,8 +64,9 @@ type Data struct {
 }
 
 // Repository persists lobby Data. Implementations MUST support lookup by
-// both ID (every RPC except JoinLobby) and JoinRef (JoinLobby's only
-// membership key, per the CreateLobby -> {lobby_id, join_ref} split).
+// ID (every RPC except JoinLobby), JoinRef (JoinLobby's only membership key,
+// per the CreateLobby -> {lobby_id, join_ref} split), and PlayerID (the
+// resume-after-refresh lookup, GetMyActiveLobby — rpg-dnd5e-web#444).
 type Repository interface {
 	// Get returns ErrNotFound if id has no stored data.
 	Get(ctx context.Context, id string) (*Data, error)
@@ -73,7 +74,28 @@ type Repository interface {
 	// GetByJoinRef returns ErrNotFound if joinRef has no stored data.
 	GetByJoinRef(ctx context.Context, joinRef string) (*Data, error)
 
-	// Save replaces the stored data for data.ID, indexed by both ID and
-	// JoinRef.
+	// GetByPlayerID returns the lobby playerID is currently indexed against,
+	// or ErrNotFound if playerID has no active index entry. One active lobby
+	// per player: Save re-indexes every member present in data.Members on
+	// every call, so a player who is (or becomes) a member of a second lobby
+	// has their entry silently overwritten to point at whichever lobby was
+	// Saved most recently — last write wins, no error, no dual-membership
+	// tracking. Callers needing liveness (is the STARTED lobby's encounter
+	// still running) must check separately; this method returns raw stored
+	// Data with no cross-check.
+	GetByPlayerID(ctx context.Context, playerID string) (*Data, error)
+
+	// Save replaces the stored data for data.ID, indexed by ID, JoinRef, and
+	// PlayerID for every member currently in data.Members. Save only ever
+	// ADDS/refreshes player index entries for members present in data — it
+	// never removes an entry for a player who is no longer a member (a
+	// removed member's stale entry would otherwise keep resolving to this
+	// lobby). Callers that remove a member (LeaveLobby) MUST pair their Save
+	// with an explicit ClearPlayerIndex for that player.
 	Save(ctx context.Context, data *Data) error
+
+	// ClearPlayerIndex removes playerID's active-lobby index entry. No-op
+	// (nil error) if playerID has no entry. LeaveLobby calls this for the
+	// departing player; nothing else needs to.
+	ClearPlayerIndex(ctx context.Context, playerID string) error
 }


### PR DESCRIPTION
## Summary

Leg 2 of 3 (protos -> **rpg-api** -> rpg-dnd5e-web) for rpg-dnd5e-web#444's (https://github.com/KirkDiggler/rpg-dnd5e-web/issues/444) resume-after-refresh fix. Bumps generated protos to pick up rpg-api-protos#180's (https://github.com/KirkDiggler/rpg-api-protos/pull/180, merged) `GetMyActiveLobby` RPC, then implements the data orchestration behind it: a player -> active-lobby reverse index plus a liveness-checked lookup.

Closes #653 (https://github.com/KirkDiggler/rpg-api/issues/653).

## What's in this PR

- **Repository** (`internal/repositories/lobby`): `player:{playerId}:lobby` reverse index, both Redis and in-memory. `Save` writes/refreshes an index entry for every player currently in `data.Members`, TTL-matched to the lobby's own 24h. New `GetByPlayerID` and `ClearPlayerIndex` methods on `Repository`.
- **Orchestrator** (`internal/orchestrators/lobby`):
  - `LeaveLobby` now calls `ClearPlayerIndex` for the departing player — `Save` can only add/refresh entries from a `Data` snapshot, it has no way to infer a removal from a single value, so the caller that knows who left has to say so explicitly.
  - New `GetMyActiveLobby` method: resolves the caller's lobby via the player index, then — only for a `STARTED` lobby — cross-checks the encounter is still live (`encounterRepo.Get` succeeds, `Mode != ModeEnded`) before reporting `encounter_id`.
- **Handler** (`internal/handlers/dnd5e/lobby/v1alpha1`): `GetMyActiveLobby` RPC wiring + `LobbyStatus` proto translation. Identity from `auth.GetPlayerID(ctx)`, no request fields — matches `StreamLobby`'s existing pattern.

## Load-bearing

A lobby's `Status` field is a one-way transition: `WAITING -> STARTED` and nothing ever writes to the record again after that (confirmed no `lobbyrepo.` references anywhere under `internal/orchestrators/encounter/v2`). That means `STARTED` alone can't tell "still fighting" from "this fight ended three hours ago" — the lobby record has no way to learn about it. `GetMyActiveLobby` treats a `STARTED`-but-not-live lobby identically to "no active lobby at all": the whole output is zeroed, not just `encounter_id`, so leg 3's client only ever needs one branch (`is lobby_id empty?`) instead of a second STARTED-but-unusable case to special-case. This is documented on `GetMyActiveLobbyOutput` and mirrored in the proto's own doc comments from leg 1.

One-active-lobby-per-player is last-write-wins, not enforced: nothing stops a player from being a member of two lobbies simultaneously (no such check exists in `CreateLobby`/`JoinLobby` today), so the index just points at whichever lobby was `Save`d most recently. Documented on `Repository.GetByPlayerID`; pinned by `TestSave_PlayerIndex_SecondLobbyOverwrites`.

## Test plan

- [x] TDD throughout — every new method has a test that was verified to fail for the right reason before being made to pass (repository index/clear behavior, `LeaveLobby`'s index-clear, `GetMyActiveLobby`'s four branches: waiting-lobby, started+live, started+ended, started+missing-encounter, plus nil-input and no-active-lobby).
- [x] `go build ./...` clean.
- [x] `go test ./... -race` — full suite green.
- [x] `golangci-lint run` scoped to the three touched packages (`internal/repositories/lobby`, `internal/orchestrators/lobby`, `internal/handlers/dnd5e/lobby/v1alpha1`) — 0 issues. (Repo-wide `golangci-lint`/`make lint` currently reports 29 pre-existing issues on a clean `origin/main` checkout, entirely in files this PR never touches — `internal/components/dungeon/*`, `internal/handlers/dnd5e/v1alpha1/character/converters.go`, `internal/orchestrators/dice`, `internal/integration/harness/harness.go` — unrelated tool-version drift, not something this PR should absorb. Flagging for visibility, not blocking: GitHub Actions CI (`test.yml`) doesn't run lint at all, only `go test -race` + coverage.)
- [x] `gofmt -l` / `goimports -l` clean on all touched files.
- [x] `go vet ./...` clean.

## Test plan for reviewers

- [ ] Confirm the "STARTED lobby returns fully empty, not partial" semantic reads right — this is the one real design call in this PR, not just plumbing.