### PR TITLE
feat(dungeon): project ActiveConditions into Entity.status_effects

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -189,21 +189,29 @@ not a synthetic monster-removal shortcut) sweeps the rage badge from the
 post-end snapshot, pinning the `checkEncounterEnd`/`endCombatForPlayers`
 (rpg-toolkit#767/#752) sweep-before-persist ordering.
 
-**Known rough edge, rpg-api-side only, not a toolkit gap:** `Encounter.ActivateFeature`
-deliberately does not use the shared #689 hydration cascade
+**Known rough edge: `ActiveConditions` can lag a just-activated feature until the
+next combat-capable verb — root cause is toolkit#691, rpg-api's projection is
+faithful to what's persisted:** `Encounter.ActivateFeature` deliberately does not
+use the shared #689 hydration cascade
 (`internal/orchestrators/encounter/v2/activate_feature.go`'s doc comment; tracked as
-the OPEN toolkit#691) — a character who activates a feature (e.g. Rage) via
-`ActivateFeature` does NOT immediately show that condition in `ActiveConditions`,
-because the toolkit's `syncCombatantsToData` (which computes `ActiveConditions`) only
-runs for entities currently held in `e.combatants`, and `ActivateFeature`'s
-self-load path never adds the actor there (by design, to avoid a double-subscribe
-collision — the #684 class). The condition IS correctly persisted to the character
-store immediately; it only becomes visible in a SNAPSHOT once some OTHER
-combat-capable verb (e.g. `MoveEntity`, `TakeAction`) that DOES use the #689 cascade
-touches the same actor and, as a side effect of its own hold-then-persist cycle,
-backfills `ActiveConditions` from the character's current (already-correct)
-condition state. Not fixed here — out of scope for #651, which is the projection
-layer; the fix belongs in toolkit#691.
+the OPEN toolkit#691, to avoid a double-subscribe collision with `ActivateFeature`'s
+own `CharDataJSON` self-load — the #684 class). `ProjectFor` — the function behind
+both `StreamEncounter`'s connect snapshot and `GetEncounter` — never calls
+`enc.ToData()` itself (confirmed by direct read: zero `ToData()`/`Save()` calls in
+`project.go`); it projects `PlayerData.ActiveConditions` exactly as last persisted,
+for every viewer including the active actor. So a feature activated via
+`ActivateFeature` IS correctly persisted to the character store immediately, but
+does NOT appear on any snapshot — not even the activating character's own
+reconnect — until some OTHER combat-capable verb (`MoveEntity`, `TakeAction`,
+anything using the #689 `WithCharacterData: true` cascade) runs: that cascade
+attaches and holds EVERY player's fresh character blob, not just the acting one
+(`attachPlayerCharacterData` loops `data.Players` unconditionally), so its own
+persist backfills `ActiveConditions` for every held player as a side effect, not
+just whoever the verb targeted. The precise trigger map is "activate a feature,
+then read a snapshot with zero combat-capable verb calls in between" — connecting
+does not itself sync, so there is no self-heal via reconnect alone. Not fixed
+here — out of scope for #651, which is the projection layer; the fix belongs in
+toolkit#691.
 
 **The live v1alpha1 encounter stack is DELETED (rpg-api#642, 2026-07-13)** —
 the audit-flagged registered-and-serving `dnd5e.api.v1alpha1.EncounterService`

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,7 +2,7 @@
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
 updated: 2026-07-17
-confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite
 ---
 
 # rpg-api: Where We Are
@@ -157,6 +157,53 @@ per-event repo read ever shows up as a real cost, the natural follow-up is cachi
 connect-time snapshot's Players/Monsters in the stream goroutine's own state instead of
 round-tripping Redis per appearance; not built now, flagged here so it's discoverable
 rather than re-derived.
+
+**Active battlefield conditions survive reconnect (rpg-api#651, 2026-07-17)** —
+`PlayerData.ActiveConditions` / `MonsterData.ActiveConditions` (rpg-toolkit#754,
+encounter v0.29.0+) are now projected into `Entity.status_effects` at snapshot time,
+in the shared `playerEntity`/`monsterEntity` builders (`project.go`'s
+`statusEffectsFrom`), matching the live `translateConditionAppliedEvent`'s
+`StatusEffect{Source: conditionRefFor(...)}` shape exactly (via the same
+`conditionRefFor` helper) so a reconnecting client's snapshot and a
+continuously-connected client's stream agree on wire shape. `ActiveConditions`
+itself needed no filtering on the rpg-api side: it's already narrowed toolkit-side
+(rpg-toolkit#778, encounter v0.29.1) to exclude conditions attached permanently at
+character/monster construction (class-grant passives like a Monk's `MartialArts`,
+monster traits like `PackTactics`) — a namespace filter (`dnd5e:conditions:*` vs
+`dnd5e:monster_traits:*`) provably could not make this distinction (`MartialArts`
+and `Raging` are both `dnd5e:conditions:*`; see rpg-toolkit#778's investigation
+trail), so rpg-api trusts the toolkit's attachment-provenance-aware filter
+completely rather than re-deriving it.
+
+Verified end to end via `integration_conditions_projection_test.go`
+(`ConditionsProjectionIntegrationSuite`): a raging character's connect snapshot
+carries the rage status effect with zero live events involved (no verb called in
+the test — the character fixture starts already-raging, mirroring
+rpg-toolkit's own `active_conditions_test.go` "NoVerbCalled" pattern, which is
+the honest shape of "hydrated after a restart"); a Monk fixture with a real,
+round-tripped `MartialArts` condition proves the provenance-chain filter holds
+end to end (confirmed as a true positive, not an empty pipe — verified the
+condition genuinely round-trips into `character.Data.Conditions` while
+`ActiveConditions` still excludes it); and ending an encounter (via a real kill,
+not a synthetic monster-removal shortcut) sweeps the rage badge from the
+post-end snapshot, pinning the `checkEncounterEnd`/`endCombatForPlayers`
+(rpg-toolkit#767/#752) sweep-before-persist ordering.
+
+**Known rough edge, rpg-api-side only, not a toolkit gap:** `Encounter.ActivateFeature`
+deliberately does not use the shared #689 hydration cascade
+(`internal/orchestrators/encounter/v2/activate_feature.go`'s doc comment; tracked as
+the OPEN toolkit#691) — a character who activates a feature (e.g. Rage) via
+`ActivateFeature` does NOT immediately show that condition in `ActiveConditions`,
+because the toolkit's `syncCombatantsToData` (which computes `ActiveConditions`) only
+runs for entities currently held in `e.combatants`, and `ActivateFeature`'s
+self-load path never adds the actor there (by design, to avoid a double-subscribe
+collision — the #684 class). The condition IS correctly persisted to the character
+store immediately; it only becomes visible in a SNAPSHOT once some OTHER
+combat-capable verb (e.g. `MoveEntity`, `TakeAction`) that DOES use the #689 cascade
+touches the same actor and, as a side effect of its own hold-then-persist cycle,
+backfills `ActiveConditions` from the character's current (already-correct)
+condition state. Not fixed here — out of scope for #651, which is the projection
+layer; the fix belongs in toolkit#691.
 
 **The live v1alpha1 encounter stack is DELETED (rpg-api#642, 2026-07-13)** —
 the audit-flagged registered-and-serving `dnd5e.api.v1alpha1.EncounterService`

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.1
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0 h1:A+cA5VcMUKRakk8bqvullCz93rrMQU3wpPaASQ1Oc+E=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.0/go.mod h1:1VpHeNNexAMdHxI1SRRhs/5F+/Rr90hqKrt6m5U523o=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.1 h1:TYXlu4BentfCyIbGTC6sRGE/FfSPYsv8h0coQxTjmPA=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.1/go.mod h1:tKTfCSHoKFXKD4vAfKRb13C3BnHeL2NN4d516B3E7fs=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2 h1:lxFfE5hShIkvQrR/SPM04uUYf1WnO3Uh/283rZlNS5c=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.2/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3 h1:wn7yHxmyKI3u1W1rRgcSjRkszaHLXhYg5PfWyw5ZGkM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2 h1:kPc3FZSRAB/gIzTBvlOYxzqp9mdL0akkeRW/8EZcI9A=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/handlers/dnd5e/v2/encounter/integration_conditions_projection_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_conditions_projection_test.go
@@ -1,0 +1,610 @@
+package encounter_test
+
+// integration_conditions_projection_test.go — rpg-api#651 sign-off integration
+// tests: PlayerData.ActiveConditions / MonsterData.ActiveConditions
+// (rpg-toolkit#754, filtered per rpg-toolkit#778) projected into
+// Entity.status_effects at snapshot time, so a reconnecting client sees active
+// battlefield statuses instead of nothing until the next live event.
+//
+// Three end-to-end proofs:
+//  1. A character already raging (hydrated at load, not activated during
+//     THIS test's observed window — no verb called) — a fresh StreamEncounter
+//     connect's snapshot carries the rage status effect, and nothing further
+//     arrives (no live event fires from the connect itself).
+//  2. A Monk character carrying a permanently-granted MartialArts condition —
+//     the toolkit's rpg-toolkit#778 filter excludes it from ActiveConditions,
+//     so it never reaches status_effects. This is the whole provenance chain
+//     end to end: a namespace filter in rpg-api could not make this
+//     distinction (see rpg-toolkit#778's investigation trail); only the
+//     toolkit's attachment-provenance-aware filter can.
+//  3. Ending the encounter sweeps rage (rpg-toolkit#767/#752's
+//     endCombatForPlayers, called from checkEncounterEnd) BEFORE the terminal
+//     ToData() runs — a post-end snapshot must not show a stale rage badge.
+//
+// Fixture construction note: all three tests attach each character's
+// DataJSON directly on tkenc.PlayerInput at AddPlayer time, then round-trip
+// once through ToData -> json.Marshal -> json.Unmarshal -> LoadFromData
+// before the FIRST repo.Save — mirroring the toolkit's own
+// active_conditions_test.go's loadEncounterFromData helper exactly (its
+// TestReconnect_PlayerCondition_VisibleInSnapshot_NoVerbCalled is this
+// pattern's origin). This is deliberate, not incidental: ActiveConditions is
+// computed by encounter.syncCombatantsToData, which only runs for entities
+// currently held in e.combatants — and Encounter.ActivateFeature (the
+// toolkit verb) deliberately does NOT hold the actor (rpg-api's orchestrator
+// comment on WithCharacterData explains why: it would collide with
+// ActivateFeature's own CharDataJSON self-load, the #684 class — tracked
+// as the OPEN toolkit#691, out of scope here). So a character that only
+// just activated Rage via ActivateFeature within this same test would NOT
+// show up in ActiveConditions yet — a real, separate, already-tracked gap
+// this suite deliberately routes around by building "already raging at
+// load" fixtures instead, which is what "hydrated" means in the issue's own
+// language anyway.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	dnd5eResources "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	condProjEncID       = "enc-conditions-projection"
+	condProjPlayerRurik = "rurik"
+	condProjEntityRurik = "char-rurik"
+	condProjGoblinID    = "goblin-conditions-projection"
+
+	// condProjGoblinKillableHP is under raging Rurik's deterministic attack
+	// damage (15, same fixedRoller{val:10} math as integration_barbarian_rage_
+	// test.go's header comment: 1d12 rolled-to-10 + STR(+3) + Rage(+2) = 15) so
+	// one successful attack kills it outright, triggering checkEncounterEnd.
+	condProjGoblinKillableHP = 10
+
+	// condProjMonkPlayer / condProjMonkEntity are the Monk fixture (test 2):
+	// carries a permanently-granted MartialArts condition that must never
+	// badge, proving the toolkit's rpg-toolkit#778 filter end to end.
+	condProjMonkPlayer = "charli"
+	condProjMonkEntity = "char-charli"
+)
+
+// ConditionsProjectionIntegrationSuite exercises the same handler-level
+// scaffolding as BarbarianRageIntegrationSuite (real broker, real in-memory
+// encounter repo, real handler, mocked character repo backed by an
+// inMemoryCharStore) — a fresh instance, not a shared one, so each test's
+// fixtures don't leak into another's.
+type ConditionsProjectionIntegrationSuite struct {
+	suite.Suite
+	ctrl         *gomock.Controller
+	mockCharRepo *charactermock.MockRepository
+	charStore    *inMemoryCharStore
+	broker       *tkenc.Broker
+	repo         encountersv2.Repository
+	handler      *v2encounter.Handler
+	rurikCtx     context.Context
+}
+
+func TestConditionsProjectionIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(ConditionsProjectionIntegrationSuite))
+}
+
+func (s *ConditionsProjectionIntegrationSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
+	s.charStore = newInMemoryCharStore()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	h, err := v2encounter.New(&v2encounter.HandlerConfig{
+		Broker: s.broker,
+		Repo:   s.repo,
+		Now:    func() time.Time { return fixedNow },
+		CombatResolverConfig: &v2encounter.Dnd5eCombatResolverConfig{
+			CharacterRepo: s.mockCharRepo,
+			Roller:        fixedRoller{val: 10},
+		},
+	})
+	s.Require().NoError(err)
+	s.handler = h
+
+	s.rurikCtx = auth.WithPlayerID(context.Background(), condProjPlayerRurik)
+}
+
+func (s *ConditionsProjectionIntegrationSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// TestIntegration_RagingCharacter_ReconnectSnapshotCarriesStatusEffect_NoLiveEvent
+// is the issue's headline proof: a character already raging when a client
+// connects sees the rage badge in the connect snapshot. No verb is called in
+// this test at all — rurik's RagingCondition is baked into his character
+// fixture from the start, exactly matching what a reconnect after a server
+// restart looks like (the character store has no memory of "how" the
+// condition got there).
+func (s *ConditionsProjectionIntegrationSuite) TestIntegration_RagingCharacter_ReconnectSnapshotCarriesStatusEffect_NoLiveEvent() {
+	rurikData := s.buildRurikBarbarianData(true /* alreadyRaging */)
+	s.setupCharRepoMock(rurikData)
+	s.seedSoloRurikEncounter(rurikData)
+
+	stream := newCapturingStream(s.rurikCtx)
+	go func() {
+		_ = s.handler.StreamEncounter(&encounterv2pb.StreamEncounterRequest{
+			EncounterId: condProjEncID,
+		}, stream)
+	}()
+
+	first := stream.WaitForSend(s.T(), 2*time.Second)
+	snap := first.GetSnapshotDelivered()
+	s.Require().NotNil(snap, "first envelope on connect must be SnapshotDelivered")
+
+	var rurikEntity *encounterv2pb.Entity
+	for _, e := range snap.GetEncounter().GetSpace().GetEntities() {
+		if e.GetId() == condProjEntityRurik {
+			rurikEntity = e
+			break
+		}
+	}
+	s.Require().NotNil(rurikEntity, "rurik must be in the connect snapshot")
+	s.Require().Len(rurikEntity.GetStatusEffects(), 1,
+		"a reconnecting client must see the already-active rage status effect in the snapshot")
+	s.Equal("dnd5e", rurikEntity.GetStatusEffects()[0].GetSource().GetModule())
+	s.Equal("conditions", rurikEntity.GetStatusEffects()[0].GetSource().GetType())
+	s.Equal("raging", rurikEntity.GetStatusEffects()[0].GetSource().GetId())
+
+	// Zero live events: nothing in this test does anything after the connect
+	// that should produce a second envelope beyond the snapshot + its normal
+	// replay set (EntityAppeared for rurik himself, GeometryRevealed).
+	s.drainReplayThenAssertNoMore(stream)
+}
+
+// TestIntegration_MonkCharacter_MartialArtsDoesNotBadge is the provenance-chain
+// proof: MartialArts is permanently granted at character construction
+// (classes.Grant.Conditions, same mechanism as monster traits — see
+// rpg-toolkit#778's investigation), never through ActivateFeature, so it must
+// never appear as a status effect no matter how the character is hydrated.
+// A ref-namespace filter in rpg-api could not make this distinction (both
+// MartialArts and Raging are dnd5e:conditions:*); only the toolkit's
+// attachment-provenance-aware ActiveConditions filter can, and this proves it
+// actually does end to end — not just at the toolkit's own unit-test layer.
+func (s *ConditionsProjectionIntegrationSuite) TestIntegration_MonkCharacter_MartialArtsDoesNotBadge() {
+	charliData := s.buildCharliMonkDataWithMartialArts()
+	s.setupCharliCharRepoMock(charliData)
+
+	charliJSON, err := json.Marshal(charliData)
+	s.Require().NoError(err, "marshal charli fixture")
+
+	enc := tkenc.New(context.Background(), condProjEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   encountercore.PlayerID(condProjMonkPlayer),
+		EntityID:   encountercore.EntityID(condProjMonkEntity),
+		Position:   encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		HP:         10,
+		MaxHP:      10,
+		AC:         15,
+		DataJSON:   charliJSON,
+	}))
+	loaded := s.roundTripThroughLoadFromData(enc)
+	s.Require().NoError(s.repo.Save(context.Background(), loaded.ToData()))
+
+	monkCtx := auth.WithPlayerID(context.Background(), condProjMonkPlayer)
+	stream := newCapturingStream(monkCtx)
+	go func() {
+		_ = s.handler.StreamEncounter(&encounterv2pb.StreamEncounterRequest{
+			EncounterId: condProjEncID,
+		}, stream)
+	}()
+
+	first := stream.WaitForSend(s.T(), 2*time.Second)
+	snap := first.GetSnapshotDelivered()
+	s.Require().NotNil(snap, "first envelope on connect must be SnapshotDelivered")
+
+	var charliEntity *encounterv2pb.Entity
+	for _, e := range snap.GetEncounter().GetSpace().GetEntities() {
+		if e.GetId() == condProjMonkEntity {
+			charliEntity = e
+			break
+		}
+	}
+	s.Require().NotNil(charliEntity, "charli must be in the connect snapshot")
+	s.Require().Empty(charliEntity.GetStatusEffects(),
+		"MartialArts is a permanent class-grant condition, never activated live — "+
+			"it must never appear as a status effect, on any snapshot, ever")
+}
+
+// TestIntegration_EncounterEnd_SweepsRageFromSnapshot proves the sweep
+// interaction: checkEncounterEnd's endCombatForPlayers (rpg-toolkit#767/#752)
+// calls ExitCombat for every HELD player BEFORE the terminal ToData() runs,
+// so ActiveConditions (and therefore status_effects) must NOT show a stale
+// rage badge once the encounter has ended. Rurik starts already-raging (the
+// DataJSON fixture, same as test 1); killing the goblin runs through
+// TakeAction — a genuinely combat-capable verb that DOES use the #689
+// hydration cascade (unlike ActivateFeature), so checkEncounterEnd's
+// e.heldCharacter(rurik) lookup succeeds and the sweep actually runs.
+func (s *ConditionsProjectionIntegrationSuite) TestIntegration_EncounterEnd_SweepsRageFromSnapshot() {
+	rurikData := s.buildRurikBarbarianData(true /* alreadyRaging */)
+	s.setupCharRepoMock(rurikData)
+	s.seedKillableGoblinEncounter(rurikData)
+	s.advanceToRurik()
+
+	// Sanity: rage is visible before the kill (proves the sweep, not an
+	// absence of rage in the first place, is what clears it later).
+	preKill, err := s.handler.GetEncounter(s.rurikCtx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: condProjEncID,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(s.entityStatusEffects(preKill.GetEncounter(), condProjEntityRurik), 1,
+		"rage must be visible before the kill, or this test proves nothing about the sweep")
+
+	// One raging attack (15 damage, deterministic with fixedRoller{val:10})
+	// kills the 10-HP goblin, dropping monster count to zero and triggering
+	// checkEncounterEnd's sweep.
+	_, err = s.handler.TakeAction(s.rurikCtx, &encounterv2pb.TakeActionRequest{
+		EncounterId:   condProjEncID,
+		ActorEntityId: condProjEntityRurik,
+		ActionRef:     &encounterv2pb.Ref{Module: "dnd5e", Type: "action", Id: "attack"},
+		Target: &encounterv2pb.ActionTarget{
+			Kind: &encounterv2pb.ActionTarget_EntityId{EntityId: condProjGoblinID},
+		},
+	})
+	s.Require().NoError(err, "raging rurik's kill-shot attack must resolve without error")
+
+	loaded, err := s.repo.Get(context.Background(), condProjEncID)
+	s.Require().NoError(err)
+	s.Require().Equal(encountercore.ModeEnded, loaded.Mode,
+		"encounter must be ModeEnded once the sole monster is dead")
+
+	postKill, err := s.handler.GetEncounter(s.rurikCtx, &encounterv2pb.GetEncounterRequest{
+		EncounterId: condProjEncID,
+	})
+	s.Require().NoError(err)
+	s.Require().Empty(s.entityStatusEffects(postKill.GetEncounter(), condProjEntityRurik),
+		"the post-encounter-end snapshot must not carry the swept rage condition")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (s *ConditionsProjectionIntegrationSuite) entityStatusEffects(
+	enc *encounterv2pb.Encounter, entityID string,
+) []*encounterv2pb.StatusEffect {
+	for _, e := range enc.GetSpace().GetEntities() {
+		if e.GetId() == entityID {
+			return e.GetStatusEffects()
+		}
+	}
+	s.Failf("entity not found in snapshot", "id=%q", entityID)
+	return nil
+}
+
+// roundTripThroughLoadFromData mirrors rpg-toolkit's own
+// active_conditions_test.go ActiveConditionsSuite.loadEncounterFromData: a
+// persist-then-reload cycle with no verb called in between, so the result
+// reflects exactly what a client asking for a snapshot immediately after a
+// fresh load would see. This is what actually populates ActiveConditions —
+// see the file-level doc comment for why.
+func (s *ConditionsProjectionIntegrationSuite) roundTripThroughLoadFromData(enc *tkenc.Encounter) *tkenc.Encounter {
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data tkenc.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := tkenc.LoadFromData(context.Background(), &data, s.broker)
+	s.Require().NoError(err)
+	return loaded
+}
+
+// drainReplayThenAssertNoMore drains the snapshot's normal replay set
+// (EntityAppeared/GeometryRevealed — count varies, so drain by a short
+// per-event timeout rather than a fixed count) then asserts nothing further
+// arrives within a longer settle window.
+func (s *ConditionsProjectionIntegrationSuite) drainReplayThenAssertNoMore(stream *capturingStream) {
+	for {
+		select {
+		case <-stream.sent:
+			continue // replay event — keep draining
+		case <-time.After(200 * time.Millisecond):
+			goto settled
+		}
+	}
+settled:
+	select {
+	case extra := <-stream.sent:
+		s.Failf("unexpected extra live envelope after snapshot+replay settled",
+			"got %T", extra.GetEvent())
+	case <-time.After(300 * time.Millisecond):
+		// Expected: nothing more arrives.
+	}
+}
+
+// ragingConditionBlob builds a RagingCondition JSON blob matching exactly
+// what Encounter.ActivateFeature would have produced and persisted, for a
+// character fixture that starts already-raging (no verb called).
+func (s *ConditionsProjectionIntegrationSuite) ragingConditionBlob(characterID string) json.RawMessage {
+	blob, err := json.Marshal(conditions.RagingData{
+		Ref:         refs.Conditions.Raging(),
+		CharacterID: characterID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	})
+	s.Require().NoError(err, "marshal RagingData fixture")
+	return blob
+}
+
+// buildRurikBarbarianData mirrors integration_barbarian_rage_test.go's
+// buildBobBarbarianData (same class, stats, and deterministic combat math) —
+// a distinct fixture name/entity avoids any cross-suite ID confusion in test
+// output, not because the fixtures differ. alreadyRaging attaches a
+// RagingCondition blob directly (see the file-level doc comment for why this
+// is the correct way to build a "hydrated, verb-free" raging fixture).
+func (s *ConditionsProjectionIntegrationSuite) buildRurikBarbarianData(alreadyRaging bool) *character.Data {
+	rageFeatureJSON := json.RawMessage(fmt.Sprintf(`{"ref":%q,"id":"rage","name":"Rage","level":1}`,
+		refs.Features.Rage()))
+
+	data := &character.Data{
+		ID:               condProjEntityRurik,
+		Name:             "Rurik the Barbarian",
+		Level:            1,
+		ClassID:          "barbarian",
+		ProficiencyBonus: 2,
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       14,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, // +3 — barbarian primary
+			abilities.DEX: 13, // +1
+			abilities.CON: 16, // +3
+			abilities.INT: 8,
+			abilities.WIS: 12,
+			abilities.CHA: 10,
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotMainHand: "greataxe",
+		},
+		Inventory: []character.InventoryItemData{
+			{Type: "weapon", ID: "greataxe", Quantity: 1},
+		},
+		Features: []json.RawMessage{rageFeatureJSON},
+		Resources: map[coreResources.ResourceKey]character.RecoverableResourceData{
+			dnd5eResources.RageCharges: {
+				Current:   2,
+				Maximum:   2,
+				ResetType: coreResources.ResetLongRest,
+			},
+		},
+	}
+	if alreadyRaging {
+		data.Conditions = []json.RawMessage{s.ragingConditionBlob(condProjEntityRurik)}
+	}
+	return data
+}
+
+// buildCharliMonkDataWithMartialArts builds a Monk whose Conditions already
+// carry a serialized MartialArtsCondition blob — exactly what a properly
+// character-creation-granted Monk carries (classes.GetMonkGrants attaches it
+// at level 1), built directly via the exported MartialArtsData shape rather
+// than the full draft/finalize creation flow: the toolkit's rpg-toolkit#778
+// filter matches on the literal Ref string regardless of how a condition
+// blob was attached, so this is a faithful, minimal fixture for what it's
+// testing (the filter), not a shortcut around it.
+func (s *ConditionsProjectionIntegrationSuite) buildCharliMonkDataWithMartialArts() *character.Data {
+	martialArtsBlob, err := json.Marshal(conditions.MartialArtsData{
+		Ref:         refs.Conditions.MartialArts(),
+		CharacterID: condProjMonkEntity,
+		MonkLevel:   1,
+	})
+	s.Require().NoError(err, "marshal MartialArtsData fixture")
+
+	return &character.Data{
+		ID:               condProjMonkEntity,
+		Name:             "Charli the Monk",
+		Level:            1,
+		ClassID:          "monk",
+		ProficiencyBonus: 2,
+		HitPoints:        10,
+		MaxHitPoints:     10,
+		ArmorClass:       15,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 10,
+			abilities.DEX: 16, // +3
+			abilities.CON: 13,
+			abilities.INT: 10,
+			abilities.WIS: 14, // +2 — unarmored defense
+			abilities.CHA: 8,
+		},
+		Conditions: []json.RawMessage{martialArtsBlob},
+	}
+}
+
+// setupCharRepoMock registers mock expectations for rurik, backed by
+// inMemoryCharStore.
+func (s *ConditionsProjectionIntegrationSuite) setupCharRepoMock(rurikData *character.Data) {
+	s.charStore.set(rurikData)
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: condProjEntityRurik}).
+		DoAndReturn(func(_ context.Context, _ characterrepo.GetInput) (*characterrepo.GetOutput, error) {
+			d := s.charStore.get(condProjEntityRurik)
+			if d == nil {
+				return nil, fmt.Errorf("rurik not found in charStore")
+			}
+			return &characterrepo.GetOutput{Character: &entities.Character{Data: d}}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			if input.Character != nil && input.Character.Data != nil {
+				s.charStore.update(input.Character.Data)
+			}
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), gomock.Not(characterrepo.GetInput{ID: condProjEntityRurik})).
+		Return(nil, fmt.Errorf("character not configured in conditions-projection integration test mock")).
+		AnyTimes()
+}
+
+// setupCharliCharRepoMock mirrors setupCharRepoMock for the Monk fixture (a
+// separate test, no rurik in play — a dedicated mock keeps the two tests'
+// character-store state fully isolated).
+func (s *ConditionsProjectionIntegrationSuite) setupCharliCharRepoMock(charliData *character.Data) {
+	s.charStore.set(charliData)
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: condProjMonkEntity}).
+		DoAndReturn(func(_ context.Context, _ characterrepo.GetInput) (*characterrepo.GetOutput, error) {
+			d := s.charStore.get(condProjMonkEntity)
+			if d == nil {
+				return nil, fmt.Errorf("charli not found in charStore")
+			}
+			return &characterrepo.GetOutput{Character: &entities.Character{Data: d}}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			if input.Character != nil && input.Character.Data != nil {
+				s.charStore.update(input.Character.Data)
+			}
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		}).AnyTimes()
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), gomock.Not(characterrepo.GetInput{ID: condProjMonkEntity})).
+		Return(nil, fmt.Errorf("character not configured in conditions-projection integration test mock")).
+		AnyTimes()
+}
+
+// seedSoloRurikEncounter is test 1's fixture: rurik alone (no monster — the
+// reconnect proof needs no combat, just a correctly-hydrated snapshot).
+// rurikData's DataJSON is attached at AddPlayer time and round-tripped
+// through LoadFromData before the first save, so ActiveConditions is
+// correctly computed from the start (see the file-level doc comment).
+func (s *ConditionsProjectionIntegrationSuite) seedSoloRurikEncounter(rurikData *character.Data) {
+	rurikJSON, err := json.Marshal(rurikData)
+	s.Require().NoError(err, "marshal rurik fixture")
+
+	enc := tkenc.New(context.Background(), condProjEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    encountercore.PlayerID(condProjPlayerRurik),
+		EntityID:    encountercore.EntityID(condProjEntityRurik),
+		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  "slashing",
+		DataJSON:    rurikJSON,
+	}))
+	loaded := s.roundTripThroughLoadFromData(enc)
+	s.Require().NoError(s.repo.Save(context.Background(), loaded.ToData()))
+}
+
+// seedKillableGoblinEncounter is the sweep test's fixture: rurik
+// (already-raging, DataJSON-attached + round-tripped) plus a goblin with HP
+// under raging rurik's deterministic one-hit damage (see
+// condProjGoblinKillableHP's doc).
+func (s *ConditionsProjectionIntegrationSuite) seedKillableGoblinEncounter(rurikData *character.Data) {
+	rurikJSON, err := json.Marshal(rurikData)
+	s.Require().NoError(err, "marshal rurik fixture")
+
+	enc := tkenc.New(context.Background(), condProjEncID, s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:    encountercore.PlayerID(condProjPlayerRurik),
+		EntityID:    encountercore.EntityID(condProjEntityRurik),
+		Position:    encountercore.Hex{Q: 0, R: 0, S: 0},
+		SightRange:  10,
+		HP:          14,
+		MaxHP:       14,
+		AC:          14,
+		AttackBonus: 5,
+		DamageDice:  "1d12+3",
+		DamageType:  "slashing",
+		DataJSON:    rurikJSON,
+	}))
+	s.Require().NoError(enc.AddMonster(s.goblinMonsterInput(condProjGoblinID,
+		encountercore.Hex{Q: 1, R: 0, S: -1}, condProjGoblinKillableHP)))
+	// AddMonster inline-checks combat entry (rpg-toolkit#759): rurik (sight
+	// range 10, no room) already sees the goblin, so the encounter
+	// self-transitions to TURN_BASED here.
+	loaded := s.roundTripThroughLoadFromData(enc)
+	s.Require().NoError(s.repo.Save(context.Background(), loaded.ToData()))
+}
+
+// goblinMonsterInput mirrors integration_barbarian_rage_test.go's helper of
+// the same name.
+func (s *ConditionsProjectionIntegrationSuite) goblinMonsterInput(
+	id string, pos encountercore.Hex, hp int,
+) tkenc.MonsterInput {
+	g := monster.NewGoblin(id)
+	gData := g.ToData()
+	gDataJSON, err := json.Marshal(gData)
+	s.Require().NoError(err, "marshal goblin data")
+
+	return tkenc.MonsterInput{
+		ID:          encountercore.EntityID(id),
+		Position:    pos,
+		HP:          hp,
+		MaxHP:       hp,
+		AC:          gData.ArmorClass,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+		DataJSON:    gDataJSON,
+	}
+}
+
+// advanceToRurik cycles initiative until rurik is the active actor — a
+// 2-combatant (rurik + one goblin) simplification of
+// integration_barbarian_rage_test.go's advanceToActor (only ever needs to
+// skip past the goblin's own turn, never a third player's).
+func (s *ConditionsProjectionIntegrationSuite) advanceToRurik() {
+	for range 20 {
+		data, err := s.repo.Get(context.Background(), condProjEncID)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(data.Initiative, "initiative must be rolled")
+		s.Require().True(data.ActiveIdx >= 0 && data.ActiveIdx < len(data.Initiative), "ActiveIdx must be in range")
+
+		activeID := string(data.Initiative[data.ActiveIdx])
+		if activeID == condProjEntityRurik {
+			return
+		}
+
+		// Only the goblin can be active otherwise (2-combatant encounter) —
+		// end its turn directly via the toolkit (no handler RPC for NPC turns).
+		enc, loadErr := tkenc.LoadFromData(context.Background(), data, s.broker)
+		s.Require().NoError(loadErr)
+		_, _, err = enc.EndTurn(context.Background(), encountercore.EntityID(activeID))
+		s.Require().NoError(err)
+		s.Require().NoError(s.repo.Save(context.Background(), enc.ToData()))
+	}
+	s.Fail("advanceToRurik: rurik did not become active within 20 initiative steps")
+}

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -308,12 +308,49 @@ func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
 				PlayerId: string(pd.ID),
 			},
 		},
+		StatusEffects: statusEffectsFrom(pd.ActiveConditions),
 	}
 	if pd.AC > 0 {
 		ac := int32(pd.AC)
 		e.ArmorClass = &ac
 	}
 	return e
+}
+
+// statusEffectsFrom projects a toolkit ActiveConditions ref list
+// (PlayerData.ActiveConditions / MonsterData.ActiveConditions,
+// rpg-toolkit#754) onto the wire, matching the live
+// translateConditionAppliedEvent's StatusEffect shape (Source: the same
+// conditionRefFor parse translate.go's live path already uses) so a
+// reconnecting client's snapshot and a continuously-connected client's
+// stream agree on shape (rpg-api#651).
+//
+// ActiveConditions is already filtered toolkit-side (rpg-toolkit#778): it
+// excludes conditions attached permanently at character/monster construction
+// (class-grant passives, monster traits), since those never fire the live
+// ConditionApplied event either — a naive unfiltered projection would badge
+// every Monk with "MartialArts" and every goblin with "PackTactics" forever.
+// rpg-api does no filtering of its own here; the boundary rule places that
+// judgment in the toolkit, which has the rules knowledge to make it (see
+// rpg-toolkit#778's investigation trail for why a ref-namespace filter in
+// rpg-api specifically does NOT work).
+//
+// DurationRounds is left unset: ActiveConditions carries only ref strings,
+// no duration — the live path's DurationRounds comes from the
+// ConditionAppliedEvent's own payload, which snapshot projection has no
+// equivalent of. A future toolkit enrichment could add it; nothing here
+// depends on that happening.
+func statusEffectsFrom(activeConditions []string) []*encounterv2pb.StatusEffect {
+	if len(activeConditions) == 0 {
+		return nil
+	}
+	effects := make([]*encounterv2pb.StatusEffect, 0, len(activeConditions))
+	for _, ref := range activeConditions {
+		effects = append(effects, &encounterv2pb.StatusEffect{
+			Source: conditionRefFor(ref),
+		})
+	}
+	return effects
 }
 
 // monsterEntity builds the wire-shape proto Entity for a monster, mirroring
@@ -344,6 +381,7 @@ func monsterEntity(m *tkenc.MonsterData) *encounterv2pb.Entity {
 				MonsterRef: monsterRefFor(m.MonsterRef),
 			},
 		},
+		StatusEffects: statusEffectsFrom(m.ActiveConditions),
 	}
 	if m.AC > 0 {
 		ac := int32(m.AC)

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -406,6 +406,115 @@ func (s *ProjectSuite) TestProjectFor_PlayerEntityCarriesArmorClass() {
 	s.Require().Equal(int32(15), found.GetArmorClass(), "armor_class must equal PlayerData.AC")
 }
 
+func (s *ProjectSuite) TestProjectFor_PlayerEntityCarriesActiveConditionsAsStatusEffects() {
+	// Rurik is mid-rage. rpg-toolkit#754/#778 (encounter v0.29.1): a hydrated
+	// combatant's PlayerData.ActiveConditions carries the ref of every
+	// condition that survives the toolkit's structurally-permanent filter —
+	// i.e. exactly the set a continuously-connected client would have seen
+	// live via ConditionApplied. rpg-api#651: project that onto the wire the
+	// same shape the live path already uses (translateConditionAppliedEvent's
+	// StatusEffect{Source: conditionRefFor(...)}), so a reconnecting client
+	// sees the rage badge instead of nothing until the next live event.
+	data := tkenc.NewData("enc-conditions")
+	data.Mode = core.ModeTurnBased
+	data.Round = 1
+	data.ActiveIdx = 0
+	data.Initiative = []core.EntityID{"char-rurik"}
+
+	rurik := newPlayerData("player-rurik", "char-rurik", originHex, 3)
+	rurik.HP = 20
+	rurik.MaxHP = 20
+	rurik.ActiveConditions = []string{"dnd5e:conditions:raging"}
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-rurik": rurik}
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-rurik", s.broker, nil, s.now)
+	s.Require().NoError(err)
+
+	var found *encounterv2pb.Entity
+	for _, e := range pb.GetSpace().GetEntities() {
+		if e.GetId() == "char-rurik" {
+			found = e
+			break
+		}
+	}
+	s.Require().NotNil(found, "rurik must be in the snapshot")
+	s.Require().Len(found.GetStatusEffects(), 1, "one ActiveConditions ref must become one status_effects entry")
+	effect := found.GetStatusEffects()[0]
+	s.Require().NotNil(effect.GetSource(), "status effect must carry a Source ref")
+	s.Require().Equal("dnd5e", effect.GetSource().GetModule())
+	s.Require().Equal("conditions", effect.GetSource().GetType())
+	s.Require().Equal("raging", effect.GetSource().GetId())
+}
+
+func (s *ProjectSuite) TestProjectFor_PlayerEntityNoActiveConditions_NoStatusEffects() {
+	// Negative case: a player with no ActiveConditions must get an empty (not
+	// nil-panicking, not spuriously populated) status_effects list.
+	data := tkenc.NewData("enc-no-conditions")
+	data.Mode = core.ModeTurnBased
+	data.Round = 1
+	data.ActiveIdx = 0
+	data.Initiative = []core.EntityID{"char-plain"}
+
+	plain := newPlayerData("player-plain", "char-plain", originHex, 3)
+	plain.HP = 10
+	plain.MaxHP = 10
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-plain": plain}
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-plain", s.broker, nil, s.now)
+	s.Require().NoError(err)
+
+	var found *encounterv2pb.Entity
+	for _, e := range pb.GetSpace().GetEntities() {
+		if e.GetId() == "char-plain" {
+			found = e
+			break
+		}
+	}
+	s.Require().NotNil(found, "plain must be in the snapshot")
+	s.Require().Empty(found.GetStatusEffects(), "no ActiveConditions must mean no status_effects")
+}
+
+func (s *ProjectSuite) TestProjectFor_MonsterEntityCarriesActiveConditionsAsStatusEffects() {
+	// Same projection, monster side. A monster's own condition namespace
+	// (e.g. a spell-applied dnd5e:conditions:poisoned, not a permanent trait —
+	// those are filtered toolkit-side per rpg-toolkit#778) must project the
+	// same way as a player's.
+	data := tkenc.NewData("enc-monster-conditions")
+	data.Mode = core.ModeTurnBased
+	data.Round = 1
+	data.ActiveIdx = 0
+	data.Initiative = []core.EntityID{"goblin-1"}
+
+	alice := newPlayerData("player-alice", "char-alice", originHex, 10)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
+	data.Monsters = map[core.EntityID]*tkenc.MonsterData{
+		"goblin-1": {
+			ID:               "goblin-1",
+			Position:         originHex,
+			HP:               7,
+			MaxHP:            7,
+			ActiveConditions: []string{"dnd5e:conditions:poisoned"},
+		},
+	}
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+
+	var found *encounterv2pb.Entity
+	for _, e := range pb.GetSpace().GetEntities() {
+		if e.GetId() == "goblin-1" {
+			found = e
+			break
+		}
+	}
+	s.Require().NotNil(found, "goblin-1 must be in the snapshot")
+	s.Require().Len(found.GetStatusEffects(), 1)
+	effect := found.GetStatusEffects()[0]
+	s.Require().Equal("dnd5e", effect.GetSource().GetModule())
+	s.Require().Equal("conditions", effect.GetSource().GetType())
+	s.Require().Equal("poisoned", effect.GetSource().GetId())
+}
+
 func (s *ProjectSuite) TestProjectFor_MonsterRef_TooManyColonsTreatedAsMalformed() {
 	// splitRef requires exactly two colons. A four-part ref (three colons)
 	// must fall back to the default rather than misparse, since we share


### PR DESCRIPTION
## Summary

Consumer half of rpg-toolkit#754/#778: projects the toolkit's snapshot-carried `ActiveConditions` onto the wire, so a reconnecting client sees active battlefield statuses (e.g. mid-rage) instead of nothing until the next live event.

Closes #651

## Load-bearing

- **`playerEntity`/`monsterEntity` (the shared entity builders from PR #645/#650) now populate `Entity.status_effects`** via a new `statusEffectsFrom` helper in `project.go`, reusing `conditionRefFor` — the same ref-parsing helper the live `translateConditionAppliedEvent` path already uses. Concretely: identical on `Source`; `DisplayName`/`IconHint` are unset on both paths (neither populates them today); `DurationRounds` is omitted in snapshots (`ActiveConditions` carries no duration — it's live-stream-only decoration, sourced from the `ConditionAppliedEvent` payload snapshots have no equivalent of).
- **No filtering happens in rpg-api.** `ActiveConditions` is already narrowed toolkit-side (rpg-toolkit#778, encounter v0.29.1) to exclude conditions attached permanently at character/monster construction. This is deliberate: investigated during #651's design gate and found that a ref-namespace filter (`dnd5e:conditions:*` vs `dnd5e:monster_traits:*`) provably cannot make the needed distinction — a Monk's `MartialArts` and a Barbarian's `Raging` are both `dnd5e:conditions:*`, yet only one should ever badge. That finding is what got rpg-toolkit#778 filed and fixed at the source instead of worked around here.
- **Found and documented (not fixed — out of scope) a related toolkit gap: toolkit#691.** `Encounter.ActivateFeature` deliberately skips the #689 hydration cascade (documented in `activate_feature.go`, to avoid a double-subscribe collision), so a feature activated via `ActivateFeature` alone does NOT immediately show up in `ActiveConditions` — only a later combat-capable verb (`MoveEntity`, `TakeAction`) that DOES use the cascade backfills it as a side effect. This is real and forced a redesign of the integration tests (see Test section) — flagged in `docs/status.md`, not fixed here.

## Bumps (ride this PR)

- `rpg-toolkit/encounter` v0.29.0 → v0.29.1 (rpg-toolkit#778's filter)
- `rpg-toolkit/rulebooks/dnd5e` v0.65.2 → v0.65.3

## Test

TDD throughout: wrote the two `project_test.go` unit tests first (RED — confirmed they failed for the right reason: empty `status_effects` because nothing populated it yet), then the minimal `statusEffectsFrom` implementation (GREEN).

Integration coverage (`integration_conditions_projection_test.go`, new suite `ConditionsProjectionIntegrationSuite`) is the real story here — building it surfaced toolkit#691 via a systematic-debugging pass (three-layer evidence: character store had the condition correctly, the raw persisted encounter snapshot didn't, `GetEncounter`'s full `ProjectFor` path didn't either — traced to `syncCombatantsToData` only running for `e.combatants`-held entities, and `ActivateFeature` never holding the actor there). Redesigned the fixtures to attach each character's `DataJSON` at `AddPlayer` time and round-trip once through `LoadFromData` before the first save — mirroring rpg-toolkit's own `active_conditions_test.go` "NoVerbCalled" pattern exactly, which is also the more honest shape of "hydrated after a restart" the issue actually describes.

- `TestIntegration_RagingCharacter_ReconnectSnapshotCarriesStatusEffect_NoLiveEvent` — a raging character's connect snapshot carries the rage status effect; zero live events fire in the whole test.
- `TestIntegration_MonkCharacter_MartialArtsDoesNotBadge` — a Monk with a real, round-tripped `MartialArts` condition never badges. Verified this is a true positive (not an accidental pass from broken hydration) with a standalone script confirming the condition genuinely round-trips into `character.Data.Conditions` while `ActiveConditions` still excludes it.
- `TestIntegration_EncounterEnd_SweepsRageFromSnapshot` — killing the sole goblin (a real combat kill via `TakeAction`, not a synthetic monster-removal shortcut) triggers `checkEncounterEnd`'s sweep; the post-end snapshot carries no stale rage badge. Sanity-checked rage WAS visible pre-kill, so the test can't pass by vacuous absence.

Verification:
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `golangci-lint run` on the touched package — 0 issues
- [x] `go test ./... -race` — full suite green
- [x] New integration suite — 10x under `-race`, stable
- [x] Full `internal/handlers/dnd5e/v2/encounter/...` package — green

## Docs

`docs/status.md`: new dated entry documenting the projection, the toolkit-side filtering decision, and the toolkit#691 finding as a known rough edge (not fixed here, correctly scoped to #651's projection-layer work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9
