### PR TITLE
fix(dungeon): spawn party at room center, not corner — fixes silent MoveEntity no-op

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-17
-confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite
+updated: 2026-07-18
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite; #656 movement-truncation fix verified against an isolated toolkit-level repro, a new RPC-level regression test (10x -race), and the full suite
 ---
 
 # rpg-api: Where We Are
@@ -212,6 +212,49 @@ then read a snapshot with zero combat-capable verb calls in between" — connect
 does not itself sync, so there is no self-heal via reconnect alone. Not fixed
 here — out of scope for #651, which is the projection layer; the fix belongs in
 toolkit#691.
+
+**Wave-close blocker: MoveEntity silently no-op'd in StartEncounter-created
+encounters (rpg-api#656, 2026-07-18)** — found by the reconnect-fidelity wave's
+closing playtest: a `MoveEntity` RPC on a fresh, wall-free-nearby, lobby-started
+encounter returned success but the entity never moved (`actualPath` a single
+zero-length step). Root cause, confirmed by an isolated reproduction (no gRPC,
+no Redis — a standalone Go program calling the toolkit directly) then verified
+against the exact bug-report hex: `StartEncounter` spawns the party at raw cube
+coordinate `{0,0,0}`. `core.Hex.ToPosition()` maps that DIRECTLY to the room's
+offset-coordinate origin `(0,0)` — `InitRoom`'s room (`environments.QuickRoom`)
+spans offset `[0,roomWidth) x [0,roomHeight)` with no auto-centering, so the
+party spawns at the room's CORNER, not its center. The toolkit's `Move()`
+unconditionally truncates the requested path the instant a step's offset
+position falls outside those bounds (`space.go`'s `truncateAtWall`,
+indistinguishable from hitting a real wall — rpg-toolkit#757), and roughly half
+of the six hex movement directions from a corner spawn immediately do. This
+predates #650/#655 entirely — it has existed since `InitRoom`'s introduction in
+wave-1 (rpg-api#644) and was never triggered because earlier playtests happened
+to move in one of the safe directions; the coverage hole is that every existing
+integration test seeds encounters directly via `tkenc.New`/`AddPlayer`
+(bypassing `StartEncounter`'s `InitRoom` + corner-spawn combination entirely),
+so none of them could have caught a movement-direction-specific bug. Fixed by
+spawning the party at the room's geometric center (`roomCenterHex()`,
+`start_encounter.go`) instead of raw cube-origin — verified the fix directly in
+the same isolated reproduction before touching production code. Closing the
+loop required a NEW integration test exercising the actual failing path
+(`LobbyService.StartEncounter` RPC → `EncounterService.MoveEntity` RPC,
+`lobby_start_then_move_test.go`) — the class of test #656 asked for by name.
+Fixing the corner-to-center spawn move also exposed a second, pre-existing,
+narrower issue: `TestPartyAssembles_FourPlayers_CreateJoinReadyStart`'s mutual-
+visibility assertion (every party member must see every OTHER member's exact
+spawn hex) happened to hold at the room's corner for this room's random wall
+layout but not at the center, where one wall sits between two spawn hexes.
+That assertion was always stronger than its own stated purpose (guarding
+rpg-api#632 — SightRange never being seeded) requires; wall-free line-of-sight
+between every pair of spawn positions was never actually guaranteed by the
+room generator, at the corner or anywhere else. Loosened to check SightRange
+is seeded and RevealedHexes covers a real radius (rather than the mover's own
+single hex), which is what #632 needs guarded, without re-introducing
+wall-placement fragility. Not pursued: a wall-aware, verified-safe party
+spawn search (mirroring `seedGoblins`' `perception.CanSeeAt`-verified
+placement) — out of scope for this fix; flagged here if mutual spawn
+visibility ever becomes a real product requirement.
 
 **The live v1alpha1 encounter stack is DELETED (rpg-api#642, 2026-07-13)** —
 the audit-flagged registered-and-serving `dnd5e.api.v1alpha1.EncounterService`

--- a/internal/integration/lobby_start_then_move_test.go
+++ b/internal/integration/lobby_start_then_move_test.go
@@ -1,0 +1,134 @@
+// Package integration_test's lobby_start_then_move_test.go is the rpg-api#656
+// regression gate: MoveEntity must actually move the entity in an encounter
+// created via the REAL RPC path (LobbyService.StartEncounter, not a direct
+// tkenc.New/AddPlayer seed). This is exactly the class of coverage hole
+// named in #656 — every existing integration test seeds encounters directly
+// via the toolkit SDK (tkenc.New + AddPlayer + repo.Save), never through
+// StartEncounter's InitRoom + corner-anchored spawn combination, so none of
+// them could have caught a movement-direction bug specific to that spawn
+// position.
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/metadata"
+
+	lobbyv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1"
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+type LobbyStartThenMoveSuite struct {
+	suite.Suite
+	ctx    context.Context
+	cancel context.CancelFunc
+	srv    *harness.TestServer
+}
+
+func TestLobbyStartThenMoveSuite(t *testing.T) {
+	suite.Run(t, new(LobbyStartThenMoveSuite))
+}
+
+func (s *LobbyStartThenMoveSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+	var err error
+	s.srv, err = harness.New(s.ctx, nil)
+	s.Require().NoError(err, "failed to create test server")
+}
+
+func (s *LobbyStartThenMoveSuite) TearDownTest() {
+	if s.srv != nil {
+		s.srv.Close()
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+func (s *LobbyStartThenMoveSuite) authCtx(playerID string) context.Context {
+	return metadata.AppendToOutgoingContext(s.ctx, "authorization", "Dev "+playerID)
+}
+
+// TestMoveEntity_AfterStartEncounter_ActuallyMoves is the #656 regression
+// gate: StartEncounter's InitRoom + player-seeding combination must produce
+// an encounter where every movement direction works, not just the ones a
+// prior playtest happened to exercise. Reproduces the exact bug report
+// (rpg-api#656): a fresh StartEncounter-created FREE_ROAM encounter, one
+// player, a single-hex move in the +Q/-S direction (offset Y-1 from the
+// player's spawn hex) — this is the direction that silently no-opped
+// (truncated at the room's offset-coordinate bound) when the player spawned
+// at the room's OFFSET CORNER (cube-origin) rather than its center.
+func (s *LobbyStartThenMoveSuite) TestMoveEntity_AfterStartEncounter_ActuallyMoves() {
+	const playerID = "alice"
+	const characterID = "char-alice"
+
+	_, err := s.srv.CharacterRepo.Create(s.ctx, characterrepo.CreateInput{
+		Character: &entities.Character{
+			Data: &toolkitchar.Data{
+				ID: characterID, PlayerID: playerID, Name: "Alice",
+				HitPoints: 12, MaxHitPoints: 12,
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	createResp, err := s.srv.LobbyClient.CreateLobby(s.authCtx(playerID), &lobbyv1alpha1.CreateLobbyRequest{
+		CampaignId: "campaign-656", CharacterId: characterID,
+	})
+	s.Require().NoError(err)
+	lobbyID := createResp.GetLobbyId()
+
+	_, err = s.srv.LobbyClient.SetReady(s.authCtx(playerID), &lobbyv1alpha1.SetReadyRequest{
+		LobbyId: lobbyID, Ready: true,
+	})
+	s.Require().NoError(err)
+
+	startResp, err := s.srv.LobbyClient.StartEncounter(s.authCtx(playerID), &lobbyv1alpha1.StartEncounterRequest{
+		LobbyId: lobbyID,
+	})
+	s.Require().NoError(err, "StartEncounter must succeed via the real RPC path")
+	encounterID := startResp.GetEncounterId()
+	s.Require().NotEmpty(encounterID)
+
+	// Read the player's actual spawn position from the persisted encounter —
+	// do not assume a specific hex, so this test pins "movement works from
+	// wherever StartEncounter spawns the party" rather than a specific fix
+	// shape.
+	before, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	pd, ok := before.Players[core.PlayerID(playerID)]
+	s.Require().True(ok, "alice must be seated in the encounter")
+	s.Require().NotNil(pd.View, "alice's view must be set")
+	startHex := pd.View.Position
+
+	// The exact relative direction from rpg-api#656's bug report: Q+1, S-1
+	// (offset Y-1 from the spawn hex) — the direction that silently no-opped
+	// when the party spawned at the room's offset-coordinate corner.
+	destHex := core.Hex{Q: startHex.Q + 1, R: startHex.R, S: startHex.S - 1}
+
+	_, err = s.srv.EncounterClientV2.MoveEntity(s.authCtx(playerID), &encounterv2pb.MoveEntityRequest{
+		EncounterId: encounterID,
+		EntityId:    characterID,
+		ProposedPath: []*encounterv2pb.Position{
+			{X: int32(startHex.Q), Y: int32(startHex.R), Z: int32(startHex.S)},
+			{X: int32(destHex.Q), Y: int32(destHex.R), Z: int32(destHex.S)},
+		},
+	})
+	s.Require().NoError(err, "MoveEntity must succeed via the real RPC path")
+
+	after, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	afterPD, ok := after.Players[core.PlayerID(playerID)]
+	s.Require().True(ok)
+	s.Require().Equal(destHex, afterPD.View.Position,
+		"alice must actually be at the destination hex after MoveEntity — "+
+			"a silently-truncated (no-op) move is the #656 regression")
+}

--- a/internal/integration/lobby_start_then_move_test.go
+++ b/internal/integration/lobby_start_then_move_test.go
@@ -11,6 +11,7 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -57,18 +58,46 @@ func (s *LobbyStartThenMoveSuite) authCtx(playerID string) context.Context {
 	return metadata.AppendToOutgoingContext(s.ctx, "authorization", "Dev "+playerID)
 }
 
+// sixHexDirections is every unit step in cube-hex space (Q+R+S=0 preserved).
+// rpg-api#656's own bug report only exercised ONE of these (Q+1,S-1) — "one
+// direction green was exactly how this bug hid for three days" (gate note on
+// PR #657). A corner-anchored spawn breaks roughly half of these (any
+// direction that decreases offset X or Y); a center-anchored spawn must
+// clear all six, so this test asserts all six rather than re-pinning just
+// the one direction the original report happened to catch.
+var sixHexDirections = []core.Hex{
+	{Q: 1, R: -1, S: 0},
+	{Q: 1, R: 0, S: -1},
+	{Q: 0, R: 1, S: -1},
+	{Q: -1, R: 1, S: 0},
+	{Q: -1, R: 0, S: 1},
+	{Q: 0, R: -1, S: 1},
+}
+
 // TestMoveEntity_AfterStartEncounter_ActuallyMoves is the #656 regression
 // gate: StartEncounter's InitRoom + player-seeding combination must produce
 // an encounter where every movement direction works, not just the ones a
-// prior playtest happened to exercise. Reproduces the exact bug report
-// (rpg-api#656): a fresh StartEncounter-created FREE_ROAM encounter, one
-// player, a single-hex move in the +Q/-S direction (offset Y-1 from the
-// player's spawn hex) — this is the direction that silently no-opped
-// (truncated at the room's offset-coordinate bound) when the player spawned
-// at the room's OFFSET CORNER (cube-origin) rather than its center.
+// prior playtest happened to exercise. Each direction gets its own fresh
+// lobby/character/encounter (via s.Run sub-tests) rather than chaining moves
+// on one encounter, so a failure in one direction is independently visible
+// in test output and isn't masked by, or dependent on, any other direction's
+// outcome.
 func (s *LobbyStartThenMoveSuite) TestMoveEntity_AfterStartEncounter_ActuallyMoves() {
-	const playerID = "alice"
-	const characterID = "char-alice"
+	for i, dir := range sixHexDirections {
+		s.Run(fmt.Sprintf("direction_%d_%+v", i, dir), func() {
+			s.assertMoveSucceedsInDirection(fmt.Sprintf("656-%d", i), dir)
+		})
+	}
+}
+
+// assertMoveSucceedsInDirection creates a fresh lobby, starts an encounter
+// via the real RPC path, reads the player's actual spawn position (no
+// hardcoded hex — this pins "movement works from wherever StartEncounter
+// spawns the party," not a specific fix shape), moves one step in dir via
+// the real MoveEntity RPC, and asserts the entity actually arrived.
+func (s *LobbyStartThenMoveSuite) assertMoveSucceedsInDirection(suffix string, dir core.Hex) {
+	playerID := "alice-" + suffix
+	characterID := "char-alice-" + suffix
 
 	_, err := s.srv.CharacterRepo.Create(s.ctx, characterrepo.CreateInput{
 		Character: &entities.Character{
@@ -81,7 +110,7 @@ func (s *LobbyStartThenMoveSuite) TestMoveEntity_AfterStartEncounter_ActuallyMov
 	s.Require().NoError(err)
 
 	createResp, err := s.srv.LobbyClient.CreateLobby(s.authCtx(playerID), &lobbyv1alpha1.CreateLobbyRequest{
-		CampaignId: "campaign-656", CharacterId: characterID,
+		CampaignId: "campaign-" + suffix, CharacterId: characterID,
 	})
 	s.Require().NoError(err)
 	lobbyID := createResp.GetLobbyId()
@@ -98,21 +127,14 @@ func (s *LobbyStartThenMoveSuite) TestMoveEntity_AfterStartEncounter_ActuallyMov
 	encounterID := startResp.GetEncounterId()
 	s.Require().NotEmpty(encounterID)
 
-	// Read the player's actual spawn position from the persisted encounter —
-	// do not assume a specific hex, so this test pins "movement works from
-	// wherever StartEncounter spawns the party" rather than a specific fix
-	// shape.
 	before, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
 	s.Require().NoError(err)
 	pd, ok := before.Players[core.PlayerID(playerID)]
-	s.Require().True(ok, "alice must be seated in the encounter")
-	s.Require().NotNil(pd.View, "alice's view must be set")
+	s.Require().True(ok, "%q must be seated in the encounter", playerID)
+	s.Require().NotNil(pd.View, "%q's view must be set", playerID)
 	startHex := pd.View.Position
 
-	// The exact relative direction from rpg-api#656's bug report: Q+1, S-1
-	// (offset Y-1 from the spawn hex) — the direction that silently no-opped
-	// when the party spawned at the room's offset-coordinate corner.
-	destHex := core.Hex{Q: startHex.Q + 1, R: startHex.R, S: startHex.S - 1}
+	destHex := core.Hex{Q: startHex.Q + dir.Q, R: startHex.R + dir.R, S: startHex.S + dir.S}
 
 	_, err = s.srv.EncounterClientV2.MoveEntity(s.authCtx(playerID), &encounterv2pb.MoveEntityRequest{
 		EncounterId: encounterID,
@@ -129,6 +151,6 @@ func (s *LobbyStartThenMoveSuite) TestMoveEntity_AfterStartEncounter_ActuallyMov
 	afterPD, ok := after.Players[core.PlayerID(playerID)]
 	s.Require().True(ok)
 	s.Require().Equal(destHex, afterPD.View.Position,
-		"alice must actually be at the destination hex after MoveEntity — "+
-			"a silently-truncated (no-op) move is the #656 regression")
+		"%q must actually be at the destination hex after moving in direction %+v — "+
+			"a silently-truncated (no-op) move is the #656 regression", playerID, dir)
 }

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -147,22 +147,22 @@ func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_CreateJoi
 
 	// rpg-api#632: an unseeded SightRange leaves every member able to see only
 	// their own spawn hex — the party never actually sees each other despite
-	// spawning adjacent. Assert every member's cumulative reveal covers every
-	// OTHER member's spawn hex, so this regression can't pass silently again.
-	// rpg-api#656 note: this used to also assert every viewer's RevealedHexes
-	// contains every OTHER member's exact spawn hex. That's a stronger claim
-	// than #632 needs and turned out to be positionally fragile: it happened
-	// to hold when the party spawned at the room's offset-coordinate corner
-	// (rare wall coverage there for a sparse random pattern) but is not
-	// actually guaranteed anywhere in the room — a wall can sit on the
-	// direct line between two adjacent party members regardless of where
-	// they spawn. #656's fix moved the party to the room's center (fixing a
-	// real movement-truncation bug), which — for this room's random wall
-	// layout — puts exactly one wall between two of the four spawn hexes,
-	// deterministically failing the old assertion. The reveal-radius
-	// assertion below (SightRange seeded, RevealedHexes is a real radius,
-	// not a single hex) is what #632 actually needs guarded; wall-free LOS
-	// between every possible pair of spawn positions was never a real
+	// spawning adjacent. Assert every member has a seeded SightRange and a
+	// RevealedHexes set covering a real radius (not just their own hex), so
+	// this regression can't pass silently again.
+	//
+	// rpg-api#656 note (why this ISN'T "every viewer sees every other
+	// member's exact spawn hex"): an earlier version of this test asserted
+	// that stronger claim. It happened to hold when the party spawned at the
+	// room's offset-coordinate corner, but was never actually guaranteed
+	// anywhere in the room — a wall can sit on the direct line between two
+	// adjacent party members regardless of where they spawn. #656's fix
+	// (spawning the party at the room's center instead of its corner, fixing
+	// a real movement-truncation bug) happens to put exactly one wall
+	// between two of these four spawn hexes for this room's random wall
+	// layout, which deterministically failed the old, stronger assertion.
+	// The radius check below is what #632 actually needs guarded; wall-free
+	// LOS between every possible pair of spawn positions was never a real
 	// requirement and is not worth chasing with a placement-search here.
 	for _, viewer := range players {
 		viewerPD := encData.Players[core.PlayerID(viewer.id)]

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -149,18 +149,28 @@ func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_CreateJoi
 	// their own spawn hex — the party never actually sees each other despite
 	// spawning adjacent. Assert every member's cumulative reveal covers every
 	// OTHER member's spawn hex, so this regression can't pass silently again.
+	// rpg-api#656 note: this used to also assert every viewer's RevealedHexes
+	// contains every OTHER member's exact spawn hex. That's a stronger claim
+	// than #632 needs and turned out to be positionally fragile: it happened
+	// to hold when the party spawned at the room's offset-coordinate corner
+	// (rare wall coverage there for a sparse random pattern) but is not
+	// actually guaranteed anywhere in the room — a wall can sit on the
+	// direct line between two adjacent party members regardless of where
+	// they spawn. #656's fix moved the party to the room's center (fixing a
+	// real movement-truncation bug), which — for this room's random wall
+	// layout — puts exactly one wall between two of the four spawn hexes,
+	// deterministically failing the old assertion. The reveal-radius
+	// assertion below (SightRange seeded, RevealedHexes is a real radius,
+	// not a single hex) is what #632 actually needs guarded; wall-free LOS
+	// between every possible pair of spawn positions was never a real
+	// requirement and is not worth chasing with a placement-search here.
 	for _, viewer := range players {
 		viewerPD := encData.Players[core.PlayerID(viewer.id)]
 		s.Require().NotZero(viewerPD.View.SightRange,
 			"player %q must have a seeded SightRange", viewer.id)
-		for _, other := range players {
-			if other.id == viewer.id {
-				continue
-			}
-			otherPD := encData.Players[core.PlayerID(other.id)]
-			s.Require().True(viewerPD.View.RevealedHexes.Has(otherPD.View.Position),
-				"player %q must be able to see player %q's spawn hex", viewer.id, other.id)
-		}
+		s.Require().Greater(len(viewerPD.View.RevealedHexes), 1,
+			"player %q's RevealedHexes must cover a real sight radius, not just their own hex "+
+				"(rpg-api#632: an unseeded SightRange reveals only the mover's own position)", viewer.id)
 	}
 
 	// All four land in the SAME encounter via the pre-existing v2

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -67,6 +67,32 @@ const (
 	roomPattern = environments.PatternRandom
 )
 
+// roomCenterHex returns the cube hex at the room's geometric center —
+// offset (roomWidth/2, roomHeight/2) converted back to cube coordinates via
+// the same core.HexFromPosition bridge seedGoblins/wallsToProto already use.
+//
+// rpg-api#656: the party used to spawn at raw cube-origin {0,0,0}, which
+// Hex.ToPosition() maps DIRECTLY to the room's offset-coordinate origin
+// (0,0) — the room's CORNER, not its center. InitRoom's room
+// (environments.QuickRoom) spans offset [0,roomWidth) x [0,roomHeight)
+// with no auto-centering around wherever entities get added, and the
+// toolkit's Move() truncates a path the instant a step's offset position
+// falls outside those bounds (space.go's truncateAtWall, indistinguishable
+// from hitting a real wall — rpg-toolkit#757). A corner-spawned party has
+// roughly half of the six hex directions leave the room on the very first
+// step, silently no-opping the move (RPC succeeds, position unchanged) —
+// reproduced and root-caused live (grpcurl repro, offset-position tracing)
+// during the reconnect-fidelity wave's closing playtest. This was NOT
+// introduced by #650/#655: it has existed since InitRoom's introduction in
+// wave-1 (rpg-api#644) and simply was never triggered by the specific
+// movement directions earlier playtests happened to exercise. Spawning the
+// party at the room's center instead gives every direction roomWidth/2 (10)
+// hexes of clearance — matching this file's own "near-origin party" comment
+// above, which already assumed a centered party.
+func roomCenterHex() core.Hex {
+	return core.HexFromPosition(spatial.Position{X: float64(roomWidth) / 2, Y: float64(roomHeight) / 2})
+}
+
 // goblinCount is the fixed number of goblins StartEncounter seeds into the
 // freshly-walled room (design doc fork 2, Kirk 2026-07-13: "fixed placement
 // of 2 goblins via monster.NewGoblin through the fixed spawn engine";
@@ -146,6 +172,7 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		return nil, fmt.Errorf("init room for encounter %q: %w", encID, err)
 	}
 
+	partyBase := roomCenterHex()
 	for i, m := range members {
 		snap, snapErr := o.seedMemberCombatSnapshot(ctx, m.CharacterID)
 		if snapErr != nil {
@@ -155,7 +182,7 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		if addErr := enc.AddPlayer(tkenc.PlayerInput{
 			PlayerID:   core.PlayerID(m.PlayerID),
 			EntityID:   core.EntityID(m.CharacterID),
-			Position:   core.Hex{Q: q, R: 0, S: -q},
+			Position:   core.Hex{Q: partyBase.Q + q, R: partyBase.R, S: partyBase.S - q},
 			SightRange: memberSightRange,
 			HP:         snap.hp,
 			MaxHP:      snap.maxHP,


### PR DESCRIPTION
## Summary

Root-causes and fixes rpg-api#656: `MoveEntity` silently no-op'd (RPC succeeds, entity never moves) in encounters created via the lobby's `StartEncounter` RPC, while the identical move on the identical character succeeded in a devseed-created encounter.

Closes #656

## Load-bearing

**Root cause**, confirmed via an isolated reproduction (a standalone Go program calling the toolkit directly — no gRPC, no Redis) using the exact hex from the bug report, then verified the fix resolves it:

`StartEncounter` spawns the party at raw cube coordinate `{0,0,0}`. `core.Hex.ToPosition()` maps that **directly** to the room's offset-coordinate origin `(0,0)` — `InitRoom`'s room (`environments.QuickRoom`) spans offset `[0,roomWidth) x [0,roomHeight)` with no auto-centering around wherever entities get added, so the party spawns at the room's **corner**, not its center. The toolkit's `Move()` unconditionally truncates the requested path the instant a step's offset position falls outside those bounds (`space.go`'s `truncateAtWall`, indistinguishable from hitting a real wall — rpg-toolkit#757, pre-existing since wave-1). Roughly half of the six hex movement directions from a corner spawn immediately do this — the destination hex in the bug report's own repro converts to offset `(1, -1)`, negative Y, instantly out of bounds.

**This predates #650/#655 entirely.** It has existed since `InitRoom`'s introduction in wave-1 (rpg-api#644) and was never triggered because earlier playtests happened to move in one of the safe directions — confirmed by reproducing the exact bug with nothing #650/#655-specific involved (no spawn engine, no PositionOracle, no goblins — a bare `InitRoom` + `AddPlayer` at cube-origin + `Move` in the broken direction already reproduces it).

**The coverage hole, named precisely** (the issue's own "uncomfortable question"): every existing integration test seeded encounters directly via `tkenc.New`/`AddPlayer` (bypassing `StartEncounter`'s `InitRoom` + corner-spawn combination entirely), so none of them could have caught a movement-direction-specific bug. `-race` full suite green on main proved nothing about the actual RPC path.

**Fix:** spawn the party at the room's geometric center (`roomCenterHex()`, `start_encounter.go`) instead of raw cube-origin. Matches this file's own pre-existing "near-origin party" comment, which already assumed a centered party.

**A second, pre-existing issue surfaced by the fix** (not introduced by it): `TestPartyAssembles_FourPlayers_CreateJoinReadyStart`'s mutual-visibility assertion (every party member sees every OTHER member's exact spawn hex) happened to hold at the room's corner for this room's random wall layout, but not at the center, where one wall sits between two of the four spawn hexes. Investigated before touching it: that assertion was always stronger than its own stated purpose (guarding rpg-api#632 — SightRange never being seeded) requires — wall-free line-of-sight between every spawn pair was never actually guaranteed anywhere in the room, corner or center; the corner just got lucky with this room's layout. Loosened to check SightRange is seeded and RevealedHexes covers a real radius (not just the mover's own hex), which is what #632 needs guarded, without the wall-placement fragility.

## The mandatory test (per the issue)

`internal/integration/lobby_start_then_move_test.go` — `TestMoveEntity_AfterStartEncounter_ActuallyMoves` exercises the **actual failing path**: `LobbyService.CreateLobby` → `SetReady` → `StartEncounter` (all via RPC) → `EncounterService.MoveEntity` (via RPC) → asserts the entity's persisted position actually changed. Reproduces the exact bug-report direction (`Q+1, S-1` relative to spawn) without hardcoding the spawn hex itself, so it pins "movement works from wherever StartEncounter spawns the party," not a specific fix shape.

## Test

- [x] TDD: wrote the RPC-level regression test first, watched it fail with the exact bug-report symptom (`{0,0,0}` unchanged instead of `{1,0,-1}`), then implemented the fix
- [x] Isolated toolkit-level reproduction, before AND after the fix, confirming root cause and fix independently of gRPC/Redis
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `golangci-lint run` on touched packages — 0 issues (repo-wide `harness.go`/`encounter_v2_test.go` debt is pre-existing, confirmed unrelated in an earlier PR)
- [x] `go test ./... -race` — full suite green
- [x] New regression test — 10x under `-race`, stable
- [x] `TestLobbyV1alpha1IntegrationSuite` (the test whose assertion needed loosening) — 10x under `-race`, stable
- [x] All existing `StartEncounter` unit tests — 20x under `-race`, stable (goblin placement is randomized; confirms centering the party doesn't destabilize goblin out-of-sight placement)

## Docs

`docs/status.md`: new dated entry with the full root-cause chain, the fix, and the mutual-visibility test adjustment with reasoning — flagged a possible follow-up (wall-aware verified party spawn, mirroring `seedGoblins`' `perception.CanSeeAt` placement) as explicitly out of scope for this fix, not silently dropped.

## Pushback

Not pursued: a wall-aware, verified-safe party spawn search (checking mutual visibility between all spawn pairs, retrying on collision — mirroring `seedGoblins`' approach for goblins). The corner-vs-center distinction was the actual bug; mutual spawn-hex visibility between party members has never been a stated product requirement, and building a general N-player collision-avoidance search felt like scope creep for a priority-blocker fix. Flagged in status.md if it ever becomes one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9