### PR TITLE
fix(encounter): drive the first NPC turn on Move-triggered combat entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.1
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.1 h1:TYXlu4BentfCyIbGTC6sRGE/FfSPYsv8h0coQxTjmPA=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.1/go.mod h1:tKTfCSHoKFXKD4vAfKRb13C3BnHeL2NN4d516B3E7fs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.2 h1:SJMAPPBXX8EgxS8CSBznDU2kNYjpu7Yi5pbfWwfTic8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.2/go.mod h1:tKTfCSHoKFXKD4vAfKRb13C3BnHeL2NN4d516B3E7fs=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/orchestrators/encounter/v2/drive_npc_test.go
+++ b/internal/orchestrators/encounter/v2/drive_npc_test.go
@@ -87,12 +87,21 @@ func (s *DriveStalledNPCTurnSuite) SetupTest() {
 func (s *DriveStalledNPCTurnSuite) seedTurnBased(encID string, monsterIDs []core.EntityID, initiative []core.EntityID, activeIdx int) {
 	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
-		PlayerID:    dnPlayerBob,
-		EntityID:    dnEntityBob,
-		Position:    core.Hex{Q: 0, R: 0, S: 0},
-		SightRange:  10,
-		HP:          14,
-		MaxHP:       14,
+		PlayerID:   dnPlayerBob,
+		EntityID:   dnEntityBob,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		// HP=50: comfortably above any realistic damage a chained goblin
+		// NPCAct dispatch can deal here (rpg-api#659 toolkit bump to
+		// v0.29.2 added TPK detection to checkEncounterEnd, which clears
+		// Initiative on transition to ModeEnded — a real crit-max 1d6+2
+		// goblin hit is 2d6+2=14, exactly lethal at the old HP=14 and
+		// occasionally flaked this suite's real-dice StandInCombatResolver
+		// into a TPK mid-chain). This margin makes every test below
+		// structurally immune to that outcome regardless of roll luck, for
+		// up to several chained goblins.
+		HP:          50,
+		MaxHP:       50,
 		AC:          14,
 		AttackBonus: 5,
 		DamageDice:  "1d12+3",

--- a/internal/orchestrators/encounter/v2/end_turn_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_test.go
@@ -96,12 +96,18 @@ func (s *EndTurnSuite) SetupTest() {
 func (s *EndTurnSuite) seedTurnBased(encID string, initiative []core.EntityID, activeIdx int) {
 	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
-		PlayerID:    etPlayerBob,
-		EntityID:    etEntityBob,
-		Position:    core.Hex{Q: 0, R: 0, S: 0},
-		SightRange:  10,
-		HP:          14,
-		MaxHP:       14,
+		PlayerID:   etPlayerBob,
+		EntityID:   etEntityBob,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		// HP=50: comfortably above a goblin crit-max hit (1d6+2 -> 2d6+2=14 on
+		// a nat 20), so the NPC dispatch loop below can never TPK bob mid-chain
+		// (rpg-api#659: the v0.29.2 toolkit bump added TPK detection to
+		// checkEncounterEnd, which clears Initiative on ModeEnded — this
+		// suite's real-dice StandInCombatResolver occasionally hit that at the
+		// old HP=14, flaking the NPC-dispatch assertions below).
+		HP:          50,
+		MaxHP:       50,
 		AC:          14,
 		AttackBonus: 5,
 		DamageDice:  "1d12+3",
@@ -235,7 +241,10 @@ func (s *EndTurnSuite) TestEndTurn_NPCDispatchLoop_CyclesPastConsecutiveNPCs() {
 	enc := tkenc.New(s.ctx, "enc-npc-chain", s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: etPlayerBob, EntityID: etEntityBob, Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
-		HP: 14, MaxHP: 14, AC: 14, AttackBonus: 5, DamageDice: "1d12+3", DamageType: "slashing",
+		// HP=50, not 14: TWO goblins chain their scripted attacks below; see
+		// seedTurnBased's doc comment above for why (rpg-api#659, v0.29.2 TPK
+		// detection).
+		HP: 50, MaxHP: 50, AC: 14, AttackBonus: 5, DamageDice: "1d12+3", DamageType: "slashing",
 	}))
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
 		ID: etGoblinID, Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7, AC: 15, Speed: 6,

--- a/internal/orchestrators/encounter/v2/load.go
+++ b/internal/orchestrators/encounter/v2/load.go
@@ -108,18 +108,20 @@ func (o *Orchestrator) load(ctx context.Context, in loadInput) (*tkenc.Encounter
 	}
 
 	// Resolvers are wired uniformly on every load, mirroring the handler today.
-	// The dice roller is carried inside the resolver configs (the builders), not
-	// passed as a separate WithRoller option — keeping a single roller source per
-	// the "one representation" rule rather than a parallel encounter-level roller.
+	// The dice roller LoadFromData uses is the toolkit's own default
+	// (dice.NewRoller()) in production — Config.Roller is unset, so o.roller is
+	// nil and the WithRoller option below is never appended, meaning combat
+	// rolls (attack, damage, initiative) are carried inside the resolver
+	// configs (the builders) exactly as before, with a single production
+	// roller source. rpg-api#659 added the one exception: a test that needs a
+	// deterministic initiative roll on the real Move -> checkCombatEntry ->
+	// SetMode -> rollInitiative path sets Config.Roller, which conditionally
+	// appends WithRoller here to override just that call's roller.
 	opts := []tkenc.Option{
 		tkenc.WithCharacterResolver(o.resolver),
 		tkenc.WithCombatResolver(o.buildCombatResolver(data)),
 		tkenc.WithMovementResolver(o.buildMovementResolver(data)),
 	}
-	// rpg-api#659: o.roller is nil in production (Config.Roller unset), so this
-	// is a no-op there — LoadFromData keeps its own default dice.Roller. Tests
-	// that need a deterministic initiative roll on the real Move ->
-	// checkCombatEntry -> SetMode -> rollInitiative path set Config.Roller.
 	if o.roller != nil {
 		opts = append(opts, tkenc.WithRoller(o.roller))
 	}

--- a/internal/orchestrators/encounter/v2/load.go
+++ b/internal/orchestrators/encounter/v2/load.go
@@ -111,10 +111,19 @@ func (o *Orchestrator) load(ctx context.Context, in loadInput) (*tkenc.Encounter
 	// The dice roller is carried inside the resolver configs (the builders), not
 	// passed as a separate WithRoller option — keeping a single roller source per
 	// the "one representation" rule rather than a parallel encounter-level roller.
-	enc, err := tkenc.LoadFromData(ctx, data, o.broker,
+	opts := []tkenc.Option{
 		tkenc.WithCharacterResolver(o.resolver),
 		tkenc.WithCombatResolver(o.buildCombatResolver(data)),
-		tkenc.WithMovementResolver(o.buildMovementResolver(data)))
+		tkenc.WithMovementResolver(o.buildMovementResolver(data)),
+	}
+	// rpg-api#659: o.roller is nil in production (Config.Roller unset), so this
+	// is a no-op there — LoadFromData keeps its own default dice.Roller. Tests
+	// that need a deterministic initiative roll on the real Move ->
+	// checkCombatEntry -> SetMode -> rollInitiative path set Config.Roller.
+	if o.roller != nil {
+		opts = append(opts, tkenc.WithRoller(o.roller))
+	}
+	enc, err := tkenc.LoadFromData(ctx, data, o.broker, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("load encounter from data %q: %w", in.EncounterID, err)
 	}

--- a/internal/orchestrators/encounter/v2/move_entity.go
+++ b/internal/orchestrators/encounter/v2/move_entity.go
@@ -107,11 +107,36 @@ func (o *Orchestrator) MoveEntity(ctx context.Context, in *MoveEntityInput) (*Mo
 		return nil, fmt.Errorf("%w: %w", ErrMoveRefused, moveErr)
 	}
 
-	// persistWithCharacterData flushes the cascaded player DataJSON back to the
-	// character store (so the next RPC re-attaches fresh state and the snapshot
-	// does not carry a soon-stale char blob) after the SyncErr check, then saves —
-	// mirroring the inline handler's persistPlayerCharacterData + Save.
-	if err := o.persistWithCharacterData(ctx, enc, in.EncounterID); err != nil {
+	// rpg-api#659: enc.Move can trigger the toolkit's own FREE_ROAM->TURN_BASED
+	// combat entry (checkCombatEntry, called inline at the end of Move) when the
+	// mover's updated view newly sights a monster. SetMode rolls initiative and
+	// announces the first turn (TurnStartedEvent) but never dispatches it — only
+	// the orchestrator drives NPC turns (driveNPCChain, the same cycle EndTurn
+	// uses below its own toolkit verb call). Without this, a monster winning
+	// initiative on a sighted Move stalls forever: EndTurn requires the CURRENT
+	// active actor's owning player to call it, and there is no such player.
+	// Before this fix, the only thing that ever drove that first NPC turn was
+	// the #636 connect-time self-heal (DriveStalledNPCTurn, called from
+	// StreamEncounter/GetEncounter) — i.e. the encounter only advanced once some
+	// client (re)connected. Mirroring EndTurn's call exactly makes the kick
+	// deterministic on the mode transition itself, matching driveNPCChain's own
+	// doc comment ("a future in-process combat-entry trigger can (and should)
+	// call this... right after its own SetMode").
+	//
+	// active/isNPC are read AFTER Move so they reflect whatever Move actually
+	// did: a non-combat-entry move (still FREE_ROAM, or TURN_BASED with a player
+	// active) yields ActiveActor()=="" or a player id, so IsNPC is false and
+	// driveNPCChain zero-iterates — behavior-preserving for every case except
+	// the one this fixes. This also covers the encounter ending mid-Move (a
+	// synchronous instant-death via an opportunity attack): ActiveActor()
+	// returns "" whenever Mode != ModeTurnBased, which includes ModeEnded, so
+	// driveNPCChain still zero-iterates and simply persists.
+	//
+	// driveNPCChain persists on every exit path (including zero-iteration), so
+	// it replaces the direct persistWithCharacterData call below rather than
+	// running alongside it — the same structure EndTurn uses.
+	active := enc.ActiveActor()
+	if err := o.driveNPCChain(ctx, enc, in.EncounterID, active, enc.IsNPC(active)); err != nil {
 		return nil, err
 	}
 

--- a/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
@@ -1,0 +1,191 @@
+package encounter_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// MoveEntity NPC-first combat-entry regression (rpg-api#659): a sighted Move
+// that flips FREE_ROAM -> TURN_BASED with a monster winning initiative must
+// drive that monster's turn ITSELF — it must not depend on a later
+// StreamEncounter/GetEncounter connect providing the #636 self-heal kick
+// (DriveStalledNPCTurn) to un-stall it. Before the fix, MoveEntity persisted
+// right after enc.Move() without checking whether the mode transition it just
+// triggered left an NPC active, so the encounter would sit there until some
+// client (re)connected — exactly the issue's repro ("goblin wins initiative,
+// don't refresh, watch it hang").
+//
+// This exercises the REAL trigger path the toolkit uses for combat entry
+// (Move -> checkCombatEntry -> SetMode -> rollInitiative), not a hand-seeded
+// post-roll Initiative/ActiveIdx (which would bypass the very code path this
+// bug lives in). A forced-constant dice.Roller (Config.Roller, rpg-api#659)
+// makes every rollInitiative d20 call tie, so the sort's ascending-id
+// tiebreak deterministically puts the goblin first on every run — no retries,
+// no flake.
+
+const (
+	mfEncID     = "enc-move-npc-first"
+	mfPlayerZoe = "zoe"
+	mfEntityZoe = "zed-char-zoe"  // sorts AFTER mfGoblinID on an initiative tie
+	mfGoblinID  = "ann-goblin-mf" // sorts BEFORE mfEntityZoe on an initiative tie
+)
+
+// constantRoller always returns the same value (capped to the die size), so
+// rollInitiative's per-combatant d20 calls tie every time, making the
+// ascending-id tiebreak in the toolkit's rollInitiative (combat.go) the sole,
+// deterministic decider of turn order — see this file's doc comment.
+type constantRoller struct{ value int }
+
+func (c constantRoller) Roll(_ context.Context, size int) (int, error) {
+	if size <= 0 {
+		return 0, fmt.Errorf("constantRoller: invalid die size %d", size)
+	}
+	if c.value > size {
+		return size, nil
+	}
+	return c.value, nil
+}
+
+func (c constantRoller) RollN(ctx context.Context, count, size int) ([]int, error) {
+	out := make([]int, count)
+	for i := range out {
+		v, err := c.Roll(ctx, size)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+type MoveEntityNPCFirstSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	broker *tkenc.Broker
+	repo   encountersv2.Repository
+	orch   *encounterorch.Orchestrator
+}
+
+func (s *MoveEntityNPCFirstSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.repo = encountersv2.NewInMemory()
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:        s.broker,
+		EncounterRepo: s.repo,
+		Resolver:      stubCharacterResolver{},
+		// Stand-in combat resolver, same choice as DriveStalledNPCTurnSuite: no
+		// DataJSON is seeded on the goblin, so NPCAct takes the scripted
+		// single-phase path — this test asserts WHETHER/WHEN the goblin's turn
+		// was driven, not its combat outcome.
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return v2encounter.NewStandInCombatResolver(nil)
+		},
+		// nil movement resolver: the toolkit Move takes the legacy single-jump
+		// branch (no per-step chain, no OAs) — isolates the combat-entry kick
+		// from movement-resolver mechanics, matching MoveEntitySuite's own choice.
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		ReactionResume: encounterorch.ReactionResume{
+			MarshalAttackContext: func(_ *tkenc.PhasedAttackContext) ([]byte, error) {
+				return []byte(`{}`), nil
+			},
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+		// Forces every rollInitiative d20 to tie so the goblin (lower id) wins
+		// the ascending-id tiebreak deterministically — see constantRoller.
+		Roller: constantRoller{value: 10},
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedFreeRoamOutOfSight persists a FREE_ROAM encounter with zoe far enough
+// from the goblin (hex distance 20 > sight range 10) that combat has NOT yet
+// started at seed time — the encounter only flips to TURN_BASED once zoe's
+// own Move closes the distance below her sight range, exercising
+// checkCombatEntry for real rather than asserting against hand-seeded state.
+func (s *MoveEntityNPCFirstSuite) seedFreeRoamOutOfSight() {
+	enc := tkenc.New(s.ctx, core.EncounterID(mfEncID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   mfPlayerZoe,
+		EntityID:   mfEntityZoe,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 10,
+		// HP=50, not a lower value: the goblin's scripted turn runs as part of
+		// this test's own driveNPCChain dispatch. A goblin crit-max hit
+		// (1d6+2 -> 2d6+2=14 on a nat 20) must never be able to reduce zoe to
+		// 0 HP and trigger the toolkit's TPK-end path (checkEncounterEnd,
+		// v0.29.2), which would clear Initiative and break this test's
+		// core assertion on an unrelated roll of the dice.
+		HP:    50,
+		MaxHP: 50,
+		AC:    14,
+	}))
+	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
+		ID:          mfGoblinID,
+		Position:    core.Hex{Q: 20, R: 0, S: -20},
+		HP:          7,
+		MaxHP:       7,
+		AC:          15,
+		Speed:       6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4,
+		DamageDice:  "1d6+2",
+		DamageType:  "slashing",
+	}))
+	s.Require().NoError(s.repo.Save(s.ctx, enc.ToData()))
+}
+
+// --- the headline fix ---
+
+func (s *MoveEntityNPCFirstSuite) TestMoveEntity_NPCFirstCombatEntry_DrivesGoblinTurnWithoutReconnect() {
+	s.seedFreeRoamOutOfSight()
+
+	// Move zoe to within sight range (hex distance 9 <= sightRange 10) of the
+	// goblin. This is the exact repro shape from rpg-api#659: a sighted Move
+	// that itself triggers combat entry, with the monster winning initiative.
+	out, err := s.orch.MoveEntity(s.ctx, &encounterorch.MoveEntityInput{
+		EncounterID: mfEncID,
+		PlayerID:    mfPlayerZoe,
+		EntityID:    mfEntityZoe,
+		Path: []core.Hex{
+			{Q: 0, R: 0, S: 0},
+			{Q: 11, R: 0, S: -11},
+		},
+	})
+	s.Require().NoError(err, "the sighted move that triggers combat entry must succeed")
+	s.Require().NotNil(out)
+
+	loaded, getErr := s.repo.Get(s.ctx, mfEncID)
+	s.Require().NoError(getErr)
+	s.Require().Equal(core.ModeTurnBased, loaded.Mode, "the move must have triggered combat entry")
+	s.Require().NotEmpty(loaded.Initiative, "initiative must have rolled")
+	s.Require().Equal(core.EntityID(mfGoblinID), loaded.Initiative[0],
+		"sanity check on the test setup: the constant roller's tiebreak must have put the goblin first")
+
+	// The headline assertion: MoveEntity alone — no DriveStalledNPCTurn call,
+	// no StreamEncounter/GetEncounter connect anywhere in this test — must have
+	// already driven the goblin's turn to completion and advanced the active
+	// actor to zoe. Before the #659 fix, the active actor would still be the
+	// goblin here, stalled forever until some client reconnected.
+	s.Equal(core.EntityID(mfEntityZoe), loaded.Initiative[loaded.ActiveIdx],
+		"MoveEntity itself must drive the goblin's turn — the active actor must already be the player, with zero reconnects")
+}
+
+func TestMoveEntityNPCFirstSuite(t *testing.T) {
+	suite.Run(t, new(MoveEntityNPCFirstSuite))
+}

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 )
 
@@ -159,6 +160,15 @@ type Config struct {
 	// Not used by the door verbs (Interact); reserved for the projection /
 	// snapshot read path carved in later steps of #582.
 	Now func() time.Time
+
+	// Roller overrides the dice.Roller every LoadFromData wires via
+	// tkenc.WithRoller (rpg-api#659). Optional — nil leaves the toolkit's own
+	// default (dice.NewRoller(), a real crypto/rand-backed roller) in place, so
+	// production behavior is unchanged. Exists solely so tests can force a
+	// deterministic initiative roll on the REAL combat-entry path (Move ->
+	// checkCombatEntry -> SetMode -> rollInitiative) instead of hand-seeding
+	// post-roll Initiative/ActiveIdx, which cannot exercise Move's own roll.
+	Roller dice.Roller
 }
 
 // Orchestrator is the v2 encounter load → verb → persist core. Construct via
@@ -180,6 +190,9 @@ type Orchestrator struct {
 	characterData  CharacterDataCascade
 	reactionResume ReactionResume
 	now            func() time.Time
+	// roller overrides LoadFromData's dice.Roller when non-nil (rpg-api#659,
+	// test-only determinism seam — see Config.Roller).
+	roller dice.Roller
 	// npcDriveLocks single-flights DriveStalledNPCTurn per encounter ID
 	// (rpg-api#636) so concurrent connect-time kicks for the same encounter
 	// don't each load the same NPC-active snapshot and double-dispatch.
@@ -220,6 +233,7 @@ func New(cfg *Config) (*Orchestrator, error) {
 		characterData:         cfg.CharacterData,
 		reactionResume:        cfg.ReactionResume,
 		now:                   now,
+		roller:                cfg.Roller,
 		npcDriveLocks:         newKeyedMutex(),
 	}, nil
 }


### PR DESCRIPTION
## Summary

The first NPC turn after combat entry could stall indefinitely until a client reconnected. Root cause: `MoveEntity` calls the toolkit's `enc.Move()`, which can trigger FREE_ROAM->TURN_BASED combat entry inline (`checkCombatEntry` at the end of `Move`, rpg-toolkit `combat.go`). `SetMode` rolls initiative and announces the first turn (`TurnStartedEvent`) but never dispatches it — only the orchestrator drives NPC turns, via `driveNPCChain`. `EndTurn` already does this correctly after its own toolkit verb call; `MoveEntity` never did. So when a monster won initiative on a sighted Move, nothing ever drove its turn until the `#636` connect-time self-heal (`DriveStalledNPCTurn`, wired into `StreamEncounter`/`GetEncounter`) fired on the next client connect — matching the issue's exact repro (reconnect reliably un-stalls it).

## Fix

`internal/orchestrators/encounter/v2/move_entity.go`: after `enc.Move()` succeeds, mirror `EndTurn`'s existing pattern — read the post-Move active actor and call `driveNPCChain` instead of persisting directly. `driveNPCChain` persists unconditionally on every exit path (including zero-iteration when the active actor is a player or the encounter stayed FREE_ROAM), so this is behavior-preserving for every non-combat-entry move and only adds the missing drive when combat entry lands on an NPC. It also gracefully zero-iterates if the encounter ends mid-Move (a synchronous death), since `ActiveActor()` returns `""` whenever `Mode != ModeTurnBased`, which includes `ModeEnded`.

Test infrastructure: added an optional `Config.Roller` to the encounter orchestrator (nil by default, zero production behavior change) so the regression test can force a deterministic initiative roll through the *real* `Move -> checkCombatEntry -> SetMode -> rollInitiative` path, instead of faking pre-seeded post-roll state.

Regression test (`move_entity_npc_first_test.go`): seeds a FREE_ROAM encounter with a player out of a monster's sight range, moves the player into sight (triggering combat entry for real), and asserts the goblin's turn was already driven by `MoveEntity` alone — zero calls to `DriveStalledNPCTurn`/`StreamEncounter`/`GetEncounter` anywhere in the test. Verified the test fails without the fix (confirmed by temporarily reverting the fix and re-running) and passes with it.

## Toolkit bump (rides this PR)

`rpg-toolkit/encounter` v0.29.1 -> v0.29.2 (the death-handling wave). `go mod tidy` needed no companion `rulebooks/dnd5e` bump — the already-present v0.65.3 release outranks encounter v0.29.2's transitive pseudo-version requirement under Go's MVS/semver precedence, so it stays pinned there; `go build ./...` confirms this resolves cleanly.

v0.29.2 adds TPK detection to `checkEncounterEnd` (confirmed absent in v0.29.1 by reading both versions' `death.go` — a doc comment in v0.29.1 explicitly says the end predicate "never fires on a TPK... until a TPK-end predicate exists"). This newly reachable mid-chain "encounter ended, Initiative cleared" state occasionally (rare crit-max damage) flaked three pre-existing tests that chain `NPCAct` dispatch against a 14-HP player with real (`crypto/rand`-backed) dice via `StandInCombatResolver`: `DriveStalledNPCTurnSuite`'s `TestDriveStalledNPCTurn_ChainedNPCFirst_CascadesToFirstPlayer` / `_NPCFirst_DrivesToPlayer` / `_ConcurrentKicks_SingleFlight`, and `EndTurnSuite`'s `TestEndTurn_NPCDispatchLoop_CyclesPastConsecutiveNPCs`. Confirmed via diagnostic logging (`mode=ENDED bobHP=0`) and by reverting to v0.29.1 for 20 runs with zero failures. Fixed by raising the fixed player's HP to 50 in each affected fixture — comfortably above any realistic chained-goblin damage, so TPK is structurally impossible in these tests regardless of roll luck. My own new `move_entity_npc_first_test.go` was proactively given the same margin.

## Testing

- `go test ./... -race`: green.
- `go test ./internal/orchestrators/encounter/v2/... -race -count=80`: green (stress-verifying the TPK-flake fix).
- `go build ./...`, `go vet ./...`: clean.
- `gofmt -l` / `golangci-lint run` scoped to every file this PR touches: clean.

## Load-bearing

- `internal/orchestrators/encounter/v2/move_entity.go`: `MoveEntity` now calls `o.driveNPCChain` (not `persistWithCharacterData` directly) after `enc.Move()`, using `enc.ActiveActor()` / `enc.IsNPC(active)` read post-Move — this is the actual fix; any future combat-entry-capable verb needs the same pattern.
- `internal/orchestrators/encounter/v2/orchestrator.go` + `load.go`: new optional `Config.Roller` (test-only determinism seam, threaded into `tkenc.WithRoller` only when non-nil) — production behavior is unchanged (`o.roller` stays nil, toolkit keeps its own `dice.NewRoller()`).
- `go.mod`/`go.sum`: `rpg-toolkit/encounter` v0.29.1 -> v0.29.2 adds TPK detection (`checkEncounterEnd` can now end an encounter — and clear `Initiative` — on the last conscious player going down, not just on the last monster dying). Any code that assumes `Initiative` is always non-empty after a successful NPC dispatch needs to account for this new terminal state.

## Scope decisions

- Did **not** touch `AddMonster`'s own inline `checkCombatEntry` call site: its only production caller (`lobby/start_encounter.go`'s `seedGoblins`) pre-verifies spawn placement is outside every player's sight specifically so combat can't start at spawn, so that path is a legitimate no-op today and out of the issue's scope.
- Did **not** touch `internal/pkg/devcombat/inject.go` (the `--inject-combat` dev tool): it writes to Redis out-of-process with no RPC to hook the fix into, which is precisely why the `#636` connect-time self-heal (`DriveStalledNPCTurn`) exists and remains its intended reliance — unchanged by this PR.
- Did **not** fix the 29 pre-existing `golangci-lint` findings `make pre-commit` surfaces repo-wide (dungeon toolkit direction-string constants, character-converter constants, integration harness errcheck/shadow, an unused test helper, etc.) — none are in files this PR touches (`git status` before staging confirms), none are new (20 consecutive runs under `-count` reproduce the same set), and this repo's actual GitHub Actions CI (`test.yml`/`docker.yml`) does not run `golangci-lint` at all, only `go test -race`. Flagging in case a dedicated lint-debt cleanup issue is wanted.

Closes #659
