### PR TITLE
fix(deploy): fail loud on dispatch, fix docker-stage death-save flake

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,11 @@
-name: Build and Push Docker Image
+name: Build Docker Image
 
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -63,7 +64,7 @@ jobs:
           type=sha
           type=raw,value=latest,enable={{is_default_branch}}
           
-    - name: Build and push Docker image
+    - name: Build Docker image (push on main)
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,8 +74,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Trigger deployment
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      continue-on-error: true
+      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
       uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
       with:
         workflow: deploy.yml

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.2
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.3
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.4
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.2 h1:SJMAPPBXX8EgxS8CSBznDU2kNYjpu7Yi5pbfWwfTic8=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.2/go.mod h1:tKTfCSHoKFXKD4vAfKRb13C3BnHeL2NN4d516B3E7fs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.3 h1:B8527eOsWeSA6D4MqGwwrdIC6UIJJrPlNeaPUcDO4kQ=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.3/go.mod h1:+5A9/1WTQcZ5O/JDM191z+GdAz/MKW093EUYGgdJFco=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3 h1:wn7yHxmyKI3u1W1rRgcSjRkszaHLXhYg5PfWyw5ZGkM=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.3/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.4 h1:A5SMVL3BfodlJi5vnuzlzE7tdDoS/2MKqcpZhGIMXew=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.4/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2 h1:kPc3FZSRAB/gIzTBvlOYxzqp9mdL0akkeRW/8EZcI9A=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/KirkDiggler/rpg-api/internal/auth"
 	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
 	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkdice "github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	tkevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
@@ -28,6 +29,19 @@ type HandlerConfig struct {
 	CombatResolverConfig   *Dnd5eCombatResolverConfig   // optional; used to build Dnd5eCombatResolver per-request
 	MovementResolverConfig *Dnd5eMovementResolverConfig // optional; used to build Dnd5eMovementResolver per-request (Wave 2.11e #539)
 	Now                    func() time.Time             // optional; defaults to time.Now
+
+	// Roller overrides the dice.Roller every orchestrator LoadFromData wires
+	// via tkenc.WithRoller (rpg-api#659's Config.Roller seam, threaded here).
+	// Optional — nil leaves the toolkit's own default (dice.NewRoller(), a real
+	// crypto/rand-backed roller) in place, so production behavior is unchanged.
+	//
+	// CombatResolverConfig.Roller only reaches the combat resolver (attack/
+	// damage rolls); it does NOT reach the encounter's own roller field, which
+	// separately drives non-combat-resolver dice consumers like the Unconscious
+	// condition's automatic death saves (rpg-toolkit's conditions.NewUnconsciousCondition,
+	// wired from tkenc's e.roller). A test that wants full determinism on a path
+	// that can knock a player to 0 HP must set both fields to the same roller.
+	Roller tkdice.Roller
 }
 
 // Handler implements dnd5e.api.v1alpha2.encounter.EncounterServiceServer.
@@ -145,7 +159,8 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 			BuildReactionModifiers: buildReactionModifiers,
 			IsOneShotReaction:      isOneShotReaction,
 		},
-		Now: now,
+		Now:    now,
+		Roller: cfg.Roller,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build encounter orchestrator: %w", err)

--- a/internal/handlers/dnd5e/v2/encounter/integration_player_shield_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_player_shield_test.go
@@ -120,6 +120,15 @@ func (s *PlayerShieldIntegrationSuite) SetupTest() {
 			CharacterRepo: s.mockCharRepo,
 			Roller:        fixedRoller{val: shieldRollVal},
 		},
+		// The encounter's own roller (distinct from CombatResolverConfig.Roller
+		// above) drives non-combat-resolver dice consumers — notably the
+		// Unconscious condition's automatic death save, which fires the instant
+		// wendy's HP hits 0 and her next turn starts (immediate in this 2-combatant
+		// encounter, same RPC). Left unwired, that death save rolled a real
+		// crypto/rand d20; ~1-in-20 runs rolled a natural 20, regaining 1 HP and
+		// flipping wendy's persisted HP from 0 to 1 out from under this test's
+		// exact-damage assertion. See rpg-deployment#50.
+		Roller: fixedRoller{val: shieldRollVal},
 	})
 	s.Require().NoError(err)
 	s.handler = h


### PR DESCRIPTION
## Summary

Three changes, all required before an rpg-api image can deploy again with current dependencies:

1. **Fail-loud deploy dispatch.** `docker.yml`'s "Trigger deployment" step had `continue-on-error: true` on the `benc-uk/workflow-dispatch` call to `rpg-deployment`'s `deploy.yml`. Since ~February, `DEPLOYMENT_TOKEN` has been invalid (`Bad credentials`) and this step has failed on every push to main — silently, because `continue-on-error` swallowed it. Five months of merges looked deployed and weren't. Removed `continue-on-error`; a dead token now fails the workflow instead of rotting silently. Also widened the trigger gate to `workflow_dispatch` so a manual rerun exercises the full chain — the first post-merge run after Kirk rotates the token *is* that token's live test.

2. **Docker-stage test flake.** The docker workflow's own `Run tests` step failed on `TestPlayerShieldIntegrationSuite/TestPlayerShield_NotReady_NoPrompt` at merge commit 7d089fc, while the separate `Test and Coverage` workflow passed the same commit. Bisected by running the test as repeated fresh processes (not `-count=N`, which shares one process/hash-seed and hid it) — reproduced locally at roughly a 1-in-20 rate.

3. **Dependency bump.** `rpg-toolkit/encounter` v0.29.2 → v0.29.3 (drags `rulebooks/dnd5e` v0.65.3 → v0.65.4). Delivers toolkit#785 (dead characters un-brick on entering a new encounter) with zero api code changes — the `AddPlayer` path picks it up automatically.

## Root cause (test flake)

Not the combat math. Instrumented the full chain: `combat.ApplyAttackOutcome` always computed the correct 8 damage; the toolkit's in-memory `PlayerData.HP` always correctly dropped 8→0. The flip happened *after* that, between the in-memory mutation and the final `repo.Save`.

The culprit is `rpg-toolkit`'s `Unconscious` condition: the instant a player's HP hits exactly 0, the condition subscribes and auto-rolls a death save at that player's *next* turn start. In this 2-combatant fixture, the victim's next turn starts immediately, in the same RPC. That death-save roll uses the toolkit encounter's own `e.roller` field — a separate seam from `CombatResolverConfig.Roller`, which only reaches the *combat resolver's* attack/damage rolls. `HandlerConfig` never threaded anything into that seam, so it silently fell back to the toolkit's real `dice.NewRoller()` (crypto/rand). About 1-in-20 runs rolled a natural 20, which regains 1 HP per D&D 5e rules — flipping the persisted HP from 0 to 1 and breaking the test's exact-damage assertion.

## Fix

Added `HandlerConfig.Roller`, threaded to the orchestrator's existing `Config.Roller` seam (`internal/orchestrators/encounter/v2/orchestrator.go`, originally added for rpg-api#659's deterministic-initiative test) which conditionally appends `tkenc.WithRoller(...)` on every `LoadFromData`. The test now sets both `CombatResolverConfig.Roller` (attack/damage) and the new top-level `Roller` (everything else the encounter itself rolls, including death saves) to the same `fixedRoller`, so every dice consumer on the path is deterministic. Deliberately not a skip or a retry wrapper — this is the same `fixedMaxRoller`-style determinism pattern already used elsewhere in this test file, just wired to the seam that was missing it.

## Load-bearing

- `internal/handlers/dnd5e/v2/encounter/handler.go`: `HandlerConfig.Roller` → `encounterorch.Config.Roller`. Nil-safe; production behavior unchanged (orchestrator only appends `WithRoller` when non-nil).
- `internal/orchestrators/encounter/v2/orchestrator.go` (untouched, pre-existing): the `Config.Roller` / `o.roller` seam this PR reuses.
- `rpg-toolkit/encounter`'s `conditions.NewUnconsciousCondition` / `death.go:applyUnconsciousOnZeroHP`: where the death-save roll actually fires, for anyone chasing a similar flake in another 0-HP-adjacent test.
- `go.mod`/`go.sum`: `rpg-toolkit/encounter` v0.29.3 bump delivers toolkit#785 arcade recovery (dead characters un-brick on entering a new encounter) — no api code changes needed, picked up automatically on the `AddPlayer` path.

## Scope decisions

- **Did not fix repo-wide `make ci-check` debt.** Both `make pre-commit`'s lint step (29 pre-existing `golangci-lint` issues) and mock regeneration drift (7 files, cosmetic import-grouping from a newer `mockgen`) fail on a clean `origin/main` checkout, in files this PR never touches (`internal/integration/harness.go`, `internal/components/dungeon/**`, `internal/handlers/dnd5e/v1alpha1/character/converters.go`, `internal/auth/mock/*`, etc.). Confirmed by running `go generate ./...` and `golangci-lint run` and diffing against this branch's actual changes — zero overlap. Neither is CI-gating today (no lint step exists in any GitHub Actions workflow). Left both untouched to keep this PR scoped to the deploy-hardening task; regenerating mocks or fixing lint repo-wide is a separate cleanup.
- **Did not touch the two direct `tkenc.New`/`tkenc.LoadFromData` calls inside the test's own `seedShieldEncounter`/`advanceToWendyActiveTurn` helpers.** Those only affect initiative order (already tolerated as either-order by the test's polling loop) and force-ending an already-active NPC turn without triggering `NPCAct` — neither path can reach the death-save code, so wiring a roller there wouldn't change anything and would just be noise.

## Verification

- `TestPlayerShieldIntegrationSuite` run as 50 independent fresh processes with `-race` (pre-bump) and again as 40 fresh processes (post-bump, against v0.29.3): 0 failures in either batch (previously ~1-in-20 to 1-in-25 across several 25-40 run batches).
- `go test ./... -race`: green, both before and after the toolkit bump.
- `go build ./...`, `go vet ./...`: clean.
- Confirmed via GH Actions run history (`gh run view 29661368364 -R KirkDiggler/rpg-api --log-failed`) that this exact test/failure signature is what broke the docker workflow at 7d089fc.

Part of the multi-repo fix for rpg-deployment#50 — https://github.com/KirkDiggler/rpg-deployment/issues/50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9
