### PR TITLE
fix(encounter): populate Entity.display_name and CharacterData.class_ref for players

### DIFF
--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -451,7 +451,7 @@ func (h *Handler) translateForStream(
 		if err != nil {
 			return nil, fmt.Errorf("load encounter for entity-appeared enrichment: %w", err)
 		}
-		return translateEntityAppearedEventWithData(appearEvt, viewer, h.now(), data)
+		return translateEntityAppearedEventWithData(ctx, h.combatResolverConfig.CharacterRepo, appearEvt, viewer, h.now(), data)
 	}
 
 	return TranslateEvent(evt, viewer, h.now())

--- a/internal/handlers/dnd5e/v2/encounter/hydrate_players_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/hydrate_players_test.go
@@ -18,16 +18,19 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"go.uber.org/mock/gomock"
 
+	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	tkenccore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	tkencevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	tkcharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
@@ -206,4 +209,78 @@ func (s *HydratePlayersReconcileSuite) TestAttachActorCharacterData_ReconcilesFr
 	var loaded tkcharacter.Data
 	s.Require().NoError(json.Unmarshal(data.Players["player-A"].DataJSON, &loaded))
 	s.Equal(3, loaded.HitPoints, "the actor-menu hydration path must reconcile HP too")
+}
+
+// ---------------------------------------------------------------------------
+// translateEntityAppearedEventWithData / entityForID — live-path identity
+// enrichment (rpg-api#664)
+// ---------------------------------------------------------------------------
+
+// TestTranslateEntityAppearedEventWithData_PopulatesIdentity proves the live
+// EntityAppeared path (a party member who was out of the viewer's sight at
+// connect time and later moves into view) gets the same
+// display_name/class_ref enrichment ProjectFor's connect-time snapshot gets
+// (see project_test.go's TestProjectFor_PlayerEntityCarriesDisplayNameAndClassRef)
+// — otherwise this second entity-building path would relocate rpg-api#664's
+// bug into a rarer trigger instead of fixing it.
+func (s *HydratePlayersReconcileSuite) TestTranslateEntityAppearedEventWithData_PopulatesIdentity() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-A"}).
+		Return(&characterrepo.GetOutput{
+			Character: &entities.Character{
+				Data: &tkcharacter.Data{ID: "char-A", Name: "Alice", ClassID: "rogue"},
+			},
+		}, nil)
+
+	data := tkenc.NewData("enc-1")
+	data.Players[tkenccore.PlayerID("player-A")] = &tkenc.PlayerData{
+		ID:       tkenccore.PlayerID("player-A"),
+		EntityID: tkenccore.EntityID("char-A"),
+		HP:       10,
+		MaxHP:    10,
+	}
+
+	evt := tkencevents.NewEntityAppearedEvent(
+		"enc-1", uint64(1), tkenccore.EntityID("char-A"),
+		tkenccore.Hex{Q: 1, R: -1, S: 0},
+		map[tkenccore.PlayerID]struct{}{"player-B": {}},
+	)
+
+	out, err := translateEntityAppearedEventWithData(s.ctx, s.mockCharRepo, evt, "player-B", time.Now(), data)
+	s.Require().NoError(err)
+
+	app := out.GetEvent().(*encounterv2pb.EncounterEvent_EntityAppeared).EntityAppeared
+	s.Require().Equal("Alice", app.GetEntity().GetDisplayName())
+	classRef := app.GetEntity().GetCharacter().GetClassRef()
+	s.Require().NotNil(classRef)
+	s.Require().Equal("dnd5e", classRef.GetModule())
+	s.Require().Equal("class", classRef.GetType())
+	s.Require().Equal("rogue", classRef.GetId())
+}
+
+// TestTranslateEntityAppearedEventWithData_NilCharRepo_LeavesIdentityBlank
+// proves the live path degrades gracefully (same contract as ProjectFor's
+// absent-data fallback) rather than panicking or failing the event when no
+// character store is wired.
+func (s *HydratePlayersReconcileSuite) TestTranslateEntityAppearedEventWithData_NilCharRepo_LeavesIdentityBlank() {
+	data := tkenc.NewData("enc-1")
+	data.Players[tkenccore.PlayerID("player-A")] = &tkenc.PlayerData{
+		ID:       tkenccore.PlayerID("player-A"),
+		EntityID: tkenccore.EntityID("char-A"),
+		HP:       10,
+		MaxHP:    10,
+	}
+
+	evt := tkencevents.NewEntityAppearedEvent(
+		"enc-1", uint64(1), tkenccore.EntityID("char-A"),
+		tkenccore.Hex{Q: 1, R: -1, S: 0},
+		map[tkenccore.PlayerID]struct{}{"player-B": {}},
+	)
+
+	out, err := translateEntityAppearedEventWithData(s.ctx, nil, evt, "player-B", time.Now(), data)
+	s.Require().NoError(err)
+
+	app := out.GetEvent().(*encounterv2pb.EncounterEvent_EntityAppeared).EntityAppeared
+	s.Require().Empty(app.GetEntity().GetDisplayName())
+	s.Require().Nil(app.GetEntity().GetCharacter().GetClassRef())
 }

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -24,12 +24,19 @@ import (
 // The broker is required to rehydrate a live Encounter via LoadFromData
 // (needed for SnapshotFor).
 //
-// charRepo is used ONLY to hydrate the turn's ACTIVE actor so the snapshot's
-// TurnState can carry that actor's economy + available_actions menu at turn
-// start (#601: the client needs the menu to take its FIRST action, before any
-// TurnStateChanged push fires). nil disables menu hydration (tests / non-combat
-// callers): the snapshot then carries initiative/active/round only, as before.
-// The toolkit computes the menu (ActorTurnState); rpg-api projects it.
+// charRepo serves two purposes, both by-key lookups against the character
+// store rather than anything rules-touching:
+//  1. Hydrates the turn's ACTIVE actor so the snapshot's TurnState can carry
+//     that actor's economy + available_actions menu at turn start (#601: the
+//     client needs the menu to take its FIRST action, before any
+//     TurnStateChanged push fires). The toolkit computes the menu
+//     (ActorTurnState); rpg-api projects it.
+//  2. Resolves EVERY projected player entity's display_name/class_ref
+//     (rpg-api#664) via characterIdentityFor — not just the active actor.
+//
+// nil disables both (tests / non-combat callers): the snapshot then carries
+// initiative/active/round only and player entities carry no
+// display_name/class_ref, as before #664.
 //
 // now is passed explicitly so callers in tests can inject a fixed clock.
 func ProjectFor(
@@ -356,6 +363,9 @@ const characterClassRefType = "class"
 // back to the raw entity id with no crash), so a missing/erroring character
 // record should degrade the label, not the snapshot or the live event
 // carrying it.
+//
+// One charRepo.Get per projected player per call, no batching — batch seam:
+// see rpg-api#666.
 func characterIdentityFor(ctx context.Context, charRepo characterrepo.Repository, characterID string) (string, *encounterv2pb.Ref) {
 	if charRepo == nil {
 		return "", nil

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -139,14 +139,16 @@ func ProjectFor(
 		pd := data.Players[pid]
 		if pid == viewer {
 			// Viewer always sees their own entity.
-			entities = append(entities, playerEntity(pd, snap.Position))
+			name, classRef := characterIdentityFor(ctx, charRepo, string(pd.EntityID))
+			entities = append(entities, playerEntity(pd, snap.Position, name, classRef))
 			continue
 		}
 		if pd.View == nil {
 			continue
 		}
 		if visibleNow != nil && visibleNow.Has(pd.View.Position) {
-			entities = append(entities, playerEntity(pd, pd.View.Position))
+			name, classRef := characterIdentityFor(ctx, charRepo, string(pd.EntityID))
+			entities = append(entities, playerEntity(pd, pd.View.Position, name, classRef))
 		}
 	}
 
@@ -290,15 +292,24 @@ func buildTurnState(data *tkenc.Data, actorTurnState *tkenc.ActorTurnState) *enc
 // the caller supplies (snap.Position vs pd.View.Position), so the rest of the
 // emit lives here to keep them symmetric and to mirror the monster emit shape.
 //
-// CharacterData currently sets only PlayerId. ClassRef/RaceRef are deferred
-// until toolkit PlayerData carries class/race info; see issue #511 for the
-// rationale (we don't want to couple ProjectFor to the character orchestrator
-// for a thin enrichment).
-func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
+// displayName/classRef are resolved by the caller (characterIdentityFor) and
+// passed in rather than looked up here — playerEntity stays a pure builder,
+// matching monsterEntity's shape, and both call sites (ProjectFor's snapshot
+// loop, entityForID's live-event enrichment) share the exact same resolution
+// path (rpg-api#664).
+//
+// CharacterData.RaceRef remains unset: issue #664 only asked for
+// display_name/class_ref (the identity dock's actual read, rpg-dnd5e-web#491)
+// — race has no client reader yet, so resolving it now would be speculative
+// enrichment with nothing to verify it against. Add it the same way
+// (characterIdentityFor already holds the full character record) once a
+// caller needs it.
+func playerEntity(pd *tkenc.PlayerData, pos core.Hex, displayName string, classRef *encounterv2pb.Ref) *encounterv2pb.Entity {
 	e := &encounterv2pb.Entity{
-		Id:       string(pd.EntityID),
-		Position: HexToPosition(pos),
-		Type:     encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER,
+		Id:          string(pd.EntityID),
+		Position:    HexToPosition(pos),
+		Type:        encounterv2pb.EntityType_ENTITY_TYPE_CHARACTER,
+		DisplayName: displayName,
 		Hp: &encounterv2pb.HitPoints{
 			Current: int32(pd.HP),
 			Max:     int32(pd.MaxHP),
@@ -306,6 +317,7 @@ func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
 		Data: &encounterv2pb.Entity_Character{
 			Character: &encounterv2pb.CharacterData{
 				PlayerId: string(pd.ID),
+				ClassRef: classRef,
 			},
 		},
 		StatusEffects: statusEffectsFrom(pd.ActiveConditions),
@@ -315,6 +327,49 @@ func playerEntity(pd *tkenc.PlayerData, pos core.Hex) *encounterv2pb.Entity {
 		e.ArmorClass = &ac
 	}
 	return e
+}
+
+// characterClassRefType is the proto Ref.Type value for a class identity ref
+// (mirrors monsterEntity's "monster" / conditionRefFor's "condition" —
+// established Ref-tagging convention in this file, see monsterRefFor).
+const characterClassRefType = "class"
+
+// characterIdentityFor resolves a player seat's display name and class ref
+// for wire projection (rpg-api#664: real StartEncounter players showed the
+// raw entity id instead of "Alice"/"Rogue" because playerEntity never
+// populated these fields — issue #511 deferred it "until toolkit PlayerData
+// carries class/race info"). That toolkit change never happened and isn't
+// needed: a player seat's EntityID IS the character ID
+// (start_encounter.go's AddPlayer sets EntityID: core.EntityID(m.CharacterID)),
+// so this is a plain by-key lookup against the character store already
+// wired into ProjectFor for turn-menu hydration — no rules math, pure
+// projection of data rpg-api already owns.
+//
+// characterID intentionally comes in as a plain string, not core.EntityID —
+// the character store's key space is characterrepo's, independent of the
+// toolkit's entity-ID type.
+//
+// Any resolution failure (nil charRepo — tests and any caller that hasn't
+// wired one, a NotFound character, or a genuine store error) returns zero
+// values rather than propagating an error: display_name/class_ref are
+// optional-by-design on the wire (rpg-dnd5e-web#491's dock already falls
+// back to the raw entity id with no crash), so a missing/erroring character
+// record should degrade the label, not the snapshot or the live event
+// carrying it.
+func characterIdentityFor(ctx context.Context, charRepo characterrepo.Repository, characterID string) (string, *encounterv2pb.Ref) {
+	if charRepo == nil {
+		return "", nil
+	}
+	out, err := charRepo.Get(ctx, characterrepo.GetInput{ID: characterID})
+	if err != nil || out == nil || out.Character == nil || out.Character.Data == nil {
+		return "", nil
+	}
+	data := out.Character.Data
+	var classRef *encounterv2pb.Ref
+	if data.ClassID != "" {
+		classRef = &encounterv2pb.Ref{Module: refModuleDnd5e, Type: characterClassRefType, Id: data.ClassID}
+	}
+	return data.Name, classRef
 }
 
 // statusEffectsFrom projects a toolkit ActiveConditions ref list
@@ -367,6 +422,15 @@ func statusEffectsFrom(activeConditions []string) []*encounterv2pb.StatusEffect 
 // this fix (the live path used to hand-build a bare {id, position} Entity
 // with no type, HP, or monster ref — see translateEntityAppearedEventWithData's
 // doc for the full story).
+//
+// Entity.DisplayName is deliberately left unset here (rpg-api#664
+// scope-decision): unlike a character's Name, "goblin" -> "Goblin" is
+// content knowledge, not stored data — resolving it would mean rpg-api
+// owning a monster-ref-to-label table, the same content the client already
+// resolves for condition refs (see translateConditionAppliedEvent's doc:
+// "the web resolves display_name/icon_hint from its own lookup table").
+// MonsterData.MonsterRef already carries the structured {module,type,id} the
+// client needs to do that lookup itself.
 func monsterEntity(m *tkenc.MonsterData) *encounterv2pb.Entity {
 	me := &encounterv2pb.Entity{
 		Id:       string(m.ID),

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -6,14 +6,20 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	tkcharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
 	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
 )
 
 // ProjectSuite covers ProjectFor's per-viewer projection of toolkit
@@ -22,13 +28,21 @@ import (
 // FREE_ROAM and only emitted player entities.
 type ProjectSuite struct {
 	suite.Suite
-	now    time.Time
-	broker *tkenc.Broker
+	now          time.Time
+	broker       *tkenc.Broker
+	ctrl         *gomock.Controller
+	mockCharRepo *charactermock.MockRepository
 }
 
 func (s *ProjectSuite) SetupTest() {
 	s.now = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
+}
+
+func (s *ProjectSuite) TearDownTest() {
+	s.ctrl.Finish()
 }
 
 // originHex is the cube origin (0,0,0); used everywhere viewers stand at
@@ -357,9 +371,14 @@ func (s *ProjectSuite) TestProjectFor_PlayerEntitiesCarryTypeHpAndCharacterData(
 	s.Require().NotNil(ac, "viewer's own entity must carry CharacterData oneof")
 	s.Require().Equal("player-alice", ac.GetPlayerId(),
 		"CharacterData.PlayerId must equal the toolkit PlayerData.ID")
-	// ClassRef / RaceRef intentionally deferred — see issue #511 deferred section.
-	s.Require().Nil(ac.GetClassRef(), "ClassRef deferred until PlayerData carries it")
-	s.Require().Nil(ac.GetRaceRef(), "RaceRef deferred until PlayerData carries it")
+	// This test passes a nil charRepo (see the ProjectFor call below), so
+	// characterIdentityFor has nothing to resolve display_name/class_ref
+	// from — see TestProjectFor_PlayerEntityCarriesDisplayNameAndClassRef for
+	// the populated case (rpg-api#664). RaceRef stays nil regardless — see
+	// playerEntity's doc: unlike class, nothing reads it yet.
+	s.Require().Empty(a.GetDisplayName(), "no charRepo wired in this test")
+	s.Require().Nil(ac.GetClassRef(), "no charRepo wired in this test")
+	s.Require().Nil(ac.GetRaceRef(), "RaceRef has no reader yet — see playerEntity's doc")
 
 	// Visible other-player (bob, in alice's sight).
 	b := byID["char-bob"]
@@ -612,6 +631,93 @@ func (s *ProjectSuite) TestProjectFor_NilSpace_EmptyWalls() {
 	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	s.Require().Empty(pb.GetSpace().GetWalls())
+}
+
+// TestProjectFor_PlayerEntityCarriesDisplayNameAndClassRef proves rpg-api#664:
+// once a charRepo is wired, both the viewer's own entity and a visible
+// other-player entity carry display_name (from the character record's Name)
+// and CharacterData.class_ref (from ClassID) — the real StartEncounter path
+// (which does wire a charRepo, unlike this suite's other nil-charRepo tests)
+// no longer falls back to the raw entity id on the web's identity dock.
+func (s *ProjectSuite) TestProjectFor_PlayerEntityCarriesDisplayNameAndClassRef() {
+	// FreeRoam (no active actor) deliberately: turn-based mode would also
+	// exercise ProjectFor's #601 active-actor menu hydration (a SEPARATE
+	// charRepo.Get/Update pair for whichever seat is active), which is
+	// orthogonal to what this test verifies and would need its own mock
+	// expectations to avoid an unrelated gomock failure.
+	data := tkenc.NewData("enc-identity")
+	data.Mode = core.ModeFreeRoam
+
+	alice := newPlayerData("player-alice", "char-alice", originHex, 3)
+	bob := newPlayerData("player-bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0}, 3)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{
+		"player-alice": alice,
+		"player-bob":   bob,
+	}
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{
+			Character: &entities.Character{Data: &tkcharacter.Data{ID: "char-alice", Name: "Alice", ClassID: "rogue"}},
+		}, nil)
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-bob"}).
+		Return(&characterrepo.GetOutput{
+			Character: &entities.Character{Data: &tkcharacter.Data{ID: "char-bob", Name: "Bob", ClassID: "fighter"}},
+		}, nil)
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.mockCharRepo, s.now)
+	s.Require().NoError(err)
+
+	byID := make(map[string]*encounterv2pb.Entity)
+	for _, e := range pb.GetSpace().GetEntities() {
+		byID[e.GetId()] = e
+	}
+
+	a := byID["char-alice"]
+	s.Require().NotNil(a, "viewer's own entity must be emitted")
+	s.Require().Equal("Alice", a.GetDisplayName())
+	aClassRef := a.GetCharacter().GetClassRef()
+	s.Require().NotNil(aClassRef)
+	s.Require().Equal("dnd5e", aClassRef.GetModule())
+	s.Require().Equal("class", aClassRef.GetType())
+	s.Require().Equal("rogue", aClassRef.GetId())
+
+	b := byID["char-bob"]
+	s.Require().NotNil(b, "visible other-player must be emitted")
+	s.Require().Equal("Bob", b.GetDisplayName())
+	bClassRef := b.GetCharacter().GetClassRef()
+	s.Require().NotNil(bClassRef)
+	s.Require().Equal("fighter", bClassRef.GetId())
+}
+
+// TestProjectFor_PlayerEntity_CharacterNotFound_LeavesIdentityBlank proves
+// the absent-data fallback (rpg-api#664): a character store miss (or any
+// other lookup error) must not fail the whole snapshot — it degrades to the
+// pre-fix blank display_name/class_ref, exactly like the nil-charRepo case,
+// so a data-consistency gap elsewhere never blocks viewing the encounter.
+func (s *ProjectSuite) TestProjectFor_PlayerEntity_CharacterNotFound_LeavesIdentityBlank() {
+	data := tkenc.NewData("enc-missing-char")
+	data.Mode = core.ModeFreeRoam
+	alice := newPlayerData("player-alice", "char-alice", originHex, 3)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
+
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(nil, apierr.NotFoundf("character with ID %s not found", "char-alice"))
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, s.mockCharRepo, s.now)
+	s.Require().NoError(err, "a missing character record must not fail the snapshot")
+
+	var a *encounterv2pb.Entity
+	for _, e := range pb.GetSpace().GetEntities() {
+		if e.GetId() == "char-alice" {
+			a = e
+		}
+	}
+	s.Require().NotNil(a)
+	s.Require().Empty(a.GetDisplayName())
+	s.Require().Nil(a.GetCharacter().GetClassRef())
 }
 
 func TestProjectSuite(t *testing.T) {

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -4,6 +4,7 @@
 package encounter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	encounterv2pb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
@@ -326,14 +328,25 @@ func translateEntityAppearedEvent(e *events.EntityAppearedEvent, viewer core.Pla
 // ever produce this event is enc.Move(), which always runs against an
 // encounter MoveEntity's orchestrator already loaded from the repo. No
 // retry needed.
+//
+// ctx/charRepo (rpg-api#664) thread through to entityForID -> playerEntity's
+// characterIdentityFor so a player appearing mid-encounter (e.g. stepping
+// into another party member's sight) gets the same display_name/class_ref
+// enrichment ProjectFor's connect-time snapshot gets — otherwise this live
+// path would relocate the #664 bug rather than fix it: correct identity on
+// first connect, blank again the moment a not-yet-visible party member
+// walks into view. charRepo may be nil (tests, or a caller with no char
+// store wired) — characterIdentityFor already degrades to empty/nil rather
+// than erroring.
 func translateEntityAppearedEventWithData(
+	ctx context.Context, charRepo characterrepo.Repository,
 	e *events.EntityAppearedEvent, viewer core.PlayerID, now time.Time, data *encounter.Data,
 ) (*encounterv2pb.EncounterEvent, error) {
 	if _, ok := e.PerPlayer[viewer]; !ok {
 		return nil, ErrViewerSawNothing
 	}
 
-	entity := entityForID(data, e.Entity)
+	entity := entityForID(ctx, charRepo, data, e.Entity)
 	if entity == nil {
 		// Defensive: the entity is gone from data between publish and this
 		// read (e.g. killed the same tick) — fall back to the bare shape
@@ -381,7 +394,10 @@ func translateEntityAppearedEventWithData(
 // the event's own reported position afterward (see its doc for why), so
 // this does not need pd.View to be populated to enrich the rest of the
 // entity's fields.
-func entityForID(data *encounter.Data, id core.EntityID) *encounterv2pb.Entity {
+//
+// ctx/charRepo (rpg-api#664) are forwarded to characterIdentityFor for the
+// player branch only — monsterEntity never needed a character lookup.
+func entityForID(ctx context.Context, charRepo characterrepo.Repository, data *encounter.Data, id core.EntityID) *encounterv2pb.Entity {
 	if data == nil {
 		return nil
 	}
@@ -390,7 +406,8 @@ func entityForID(data *encounter.Data, id core.EntityID) *encounterv2pb.Entity {
 	}
 	if pid := playerSeatForEntity(data, id); pid != "" {
 		if pd := data.Players[pid]; pd != nil {
-			return playerEntity(pd, core.Hex{})
+			name, classRef := characterIdentityFor(ctx, charRepo, string(pd.EntityID))
+			return playerEntity(pd, core.Hex{}, name, classRef)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

StartEncounter's real path left `Entity.display_name` and `CharacterData.class_ref` at zero value, so the web's new identity dock (rpg-dnd5e-web#491) fell back to raw entity ids like "char-alice" instead of "Alice"/"Rogue". A player seat's `EntityID` **is** the character ID (`start_encounter.go`'s `AddPlayer`: `EntityID: core.EntityID(m.CharacterID)`), so both entity-building paths now resolve name/class by key against the character store already wired into the handler — no toolkit change, no rules math.

Closes #664

## Load-bearing

- New `characterIdentityFor(ctx, charRepo, characterID)` (`project.go`) does a plain `characterrepo.Get` by key and returns `(name, classRef)`, degrading to `("", nil)` on any failure (nil charRepo, NotFound, store error) rather than failing the caller — display identity is optional-by-design on the wire (the web already falls back gracefully).
- `playerEntity()` now takes `displayName`/`classRef` params instead of resolving nothing. **Both** entity-building paths use the same resolution: `ProjectFor`'s connect-time snapshot loop *and* `entityForID` (the live `EntityAppeared` translation path, `translate.go`) — kept in sync deliberately, so a party member who becomes visible mid-encounter doesn't relocate this bug into a rarer trigger instead of fixing it.
- `ClassRef` shape: `{module:"dnd5e", type:"class", id:<classes.Class>}`, matching the existing `monsterRefFor`/`conditionRefFor` Ref-tagging convention already in this file.

## Scope decisions

- **Monster `Entity.DisplayName` stays unset** (e.g. `goblin-1` does not become "Goblin"). Matches this codebase's existing precedent for condition refs (`translateConditionAppliedEvent`'s doc: "the web resolves display_name/icon_hint from its own lookup table") — rpg-api shouldn't own monster-ref-to-label content knowledge. `MonsterData.MonsterRef` already carries the structured ref the client needs to do that lookup itself.
- **`CharacterData.RaceRef` stays unset.** Issue #664 only asked for `display_name`/`class_ref` (the identity dock's actual read, rpg-dnd5e-web#491) — race has no client reader yet, so resolving it now would be speculative enrichment with nothing to verify it against. `characterIdentityFor` already holds the full character record; adding race is a one-line follow-up whenever a caller needs it.
- **No rpg-toolkit bump.** `rpg-toolkit/encounter` is already pinned at v0.29.3 — the latest tag on the remote — so there's nothing trivially-green to ride along.

## Test plan

- [x] New unit tests: `project_test.go`'s `TestProjectFor_PlayerEntityCarriesDisplayNameAndClassRef` (happy path, both viewer's-own and visible-other-player) and `TestProjectFor_PlayerEntity_CharacterNotFound_LeavesIdentityBlank` (absent-data fallback).
- [x] `hydrate_players_test.go`'s `TestTranslateEntityAppearedEventWithData_PopulatesIdentity` and `_NilCharRepo_LeavesIdentityBlank` covering the live-event enrichment path.
- [x] `go test ./... -race`: full suite green.
- [x] `make pre-commit`: fmt/tidy/eof/test all pass; lint fails at the documented pre-existing 29-violation baseline (`docs/status.md`'s "Lint — 29 pre-existing violations" section) — verified zero new issues introduced (fixed one `unconvert` my own new line triggered, confirmed exact 29/29 match against the doc after).
- [x] `make ci-check`: same lint baseline, plus a local `mockgen`-version import-ordering drift across 7 unrelated mock files (not touched by this PR's interfaces) — reverted, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9