### PR TITLE
chore: bump rpg-toolkit encounter/environments/spatial (toolkit#789)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260717223548-c887cd37224a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.3
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.29.4
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.4
-	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
+	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.1
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.3 h1:B8527eOsWeSA6D4MqGwwrdIC6UIJJrPlNeaPUcDO4kQ=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.29.3/go.mod h1:+5A9/1WTQcZ5O/JDM191z+GdAz/MKW093EUYGgdJFco=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.4 h1:5Z7twH0pOyG7ngBaPcFrEOI0mPDTB0grAetpU8xekbM=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.29.4/go.mod h1:po7qqUZF+qkk4YY6IxIb2FysTYFmwevcek+OPEJLKIw=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -22,12 +22,12 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Y
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.4 h1:A5SMVL3BfodlJi5vnuzlzE7tdDoS/2MKqcpZhGIMXew=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.4/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
-github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2 h1:kPc3FZSRAB/gIzTBvlOYxzqp9mdL0akkeRW/8EZcI9A=
-github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3 h1:WL+XYgEIq1pJqtU5bwoRboTIwmZe4l0moH8A1WiaX/k=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0 h1:weKsLlsRV9kgoD/y68VWy0lpsu5zhwCmbnr5MUkLpsA=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.1 h1:gmU+aZITaya2senZ+7LZo3iFP7kxONqa4kSWWs2CgiM=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.1/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0 h1:G3Fbc88oko5o0yM1jQ2wB7bAeaHRRWPAiZRpsub36uk=
 github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0/go.mod h1:vRkHHvBU1hXvlPyOySMfXov4S4Tj/bTWJ7lUGSwgVmI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

Dependency bump: pulls rpg-toolkit#789 (entropy-seeded room generation, toolkit#787 + symmetric hex line-of-sight, toolkit#788) and its follow-up toolkit#793 (fixes #789's empty-room-rate regression, closes toolkit#792) into rpg-api. Zero api runtime code changes — the only non-dependency change is a test-assertion fix in `internal/integration/lobby_start_then_move_test.go` (see Scope decisions).

Bumped:
- `rpg-toolkit/encounter` v0.29.3 -> v0.29.4
- `rpg-toolkit/tools/environments` v0.4.2 -> **v0.4.4** (v0.4.3 landed toolkit#789's seeding fix; v0.4.4 adds toolkit#793's retry fix on top)
- `rpg-toolkit/tools/spatial` v0.5.0 -> v0.5.1

Closes #668
Refs #648
Refs KirkDiggler/rpg-toolkit#789, #792, #793

## Load-bearing digest

Rooms entropy-seed by default now — any api test or fixture needing deterministic walls must pass an explicit seed via `InitRoom`'s new variadic seed param (`InitRoom(width, height, pattern, seed...)`); seed `0` means "unset" (still entropy-seeded), not "seed with zero."

## Playtest evidence: wall layout varies per encounter, and now reliably has walls

`devseed` bypasses `CreateEncounter`/room creation entirely (writes Redis directly), so it can't prove this — the only path that calls `InitRoom` is the lobby flow's `StartEncounter` (`internal/orchestrators/lobby/start_encounter.go`). Evidence below is from running the server on this branch (`AUTH_DEV_MODE=true`, isolated Redis) and driving `CreateLobby` -> `SetReady` -> `StartEncounter` -> `GetEncounter` via grpcurl for fresh encounters, each with a devseed-seeded character (alice/bob/wendy) as the sole member. Two rounds, same harness, run before and after the v0.4.4 (#793) bump:

**Round 1 — v0.4.3 only (toolkit#789, before #793's retry fix):**

| Encounter | Player | Wall count |
|---|---|---|
| A | alice | **34** |
| B | bob | 0 |
| C | wendy | 0 |
| D | alice | 0 |
| E | alice | 0 |
| F | alice | 0 |

5 of 6 landed empty. A vs B still clearly **differ** (34 vs 0), proving toolkit#787's entropy seed reaches the game — but the empty-room rate itself was high enough to flag as a real concern (see the round-1 observation this PR's history carried, now resolved below).

**Round 2 — v0.4.4 (toolkit#793's retry-before-empty-fallback fix):**

| Encounter | Player | Wall count |
|---|---|---|
| A2 | alice | 26 |
| B2 | bob | 33 |
| C2 | wendy | 43 |
| D2 | alice | 41 |
| E2 | alice | 40 |
| F2 | alice | 19 |

**6 of 6 walled this round**, layouts all differing (19-43 walls, no two identical) — matches toolkit#793's own fix target (30%→96% non-empty at 20x20) and directly resolves the round-1 observation. toolkit#792/#793 are the closed loop on that finding.

## Scope decisions

- **No api runtime code changes.** `go build ./...` / `go vet ./...` clean; the only non-`go.mod`/`go.sum` diff is a test-assertion fix (below) — matches the toolkit-as-product boundary.
- **Test fix: `TestMoveEntity_AfterStartEncounter_ActuallyMoves` (rpg-api#656's regression gate) retired its "every direction succeeds" assumption.** That assumption was a fixture-era artifact, not a product invariant: it held only because pre-#793 walls were rare enough that this test's spawn point was almost never wall-adjacent. Root cause of the resulting flake, confirmed by reading rpg-toolkit's `truncateAtWall`: it checks the ENTIRE requested path, including the STARTING hex — and `StartEncounter`'s `roomCenterHex()` places the party at a fixed formula position with no check that the cell itself is clear. Under #793's now-common walls, the spawn cell itself can land ON a wall, which silently truncates movement in *every* direction from that spawn (not just toward one walled neighbor). That's still correct dungeon behavior given a wall really is on the path (not the #656 silent-no-op-with-nothing-to-blame regression) — but it's the class of gap Slice 2's entrance-anchored spawn (`rpg-project/ideas/the-dungeon/wave2-design.md`) fixes by replacing `roomCenterHex()` with a toolkit-provided, necessarily-clear spawn cell. Until then, the test asserts honesty — each direction either arrives, or a real wall on `[start, dest]` explains why it didn't — plus a parent-level guard that at least one of the six independent fresh rooms must allow movement (toolkit#793's path-safety validation guarantees walkable connectivity, so total lockout across all six would itself be a real bug). Verified stable: 60 consecutive runs (`-count=20` and `-count=40`), zero failures. Per director instruction, did **not** add wall-aware spawn logic to rpg-api — that's explicitly Slice 2's job and would be thrown away.
- **`go generate ./...` mock diff not included.** Running it locally regenerates import ordering in 7 mocks totally unrelated to this bump's modules (auth/character/dice/sandboxroom) — local mockgen/goimports tool-version drift, reverted, not committed.
- **Lint: 29 pre-existing violations, unchanged.** Matches the baseline documented in `docs/status.md` ("Lint — 29 pre-existing violations") exactly in count and category; none in files this bump touches.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `make test` — exit 0, all 23 packages `ok`, no FAIL/panic
- `make ci-check` — 2 flagged items, both pre-existing/unrelated (lint baseline above; mock-regen drift above)
- `TestLobbyStartThenMoveSuite` specifically: 60 consecutive runs (`-count=20`, `-count=40`), zero failures
- Playtest evidence — see tables above (round 1 and round 2)
