### PR TITLE
fix(lobby): restore dead characters to full HP on new encounter seating

### DIFF
--- a/internal/orchestrators/lobby/character.go
+++ b/internal/orchestrators/lobby/character.go
@@ -80,12 +80,47 @@ func (o *Orchestrator) seedMemberCombatSnapshot(ctx context.Context, characterID
 	if err := o.clearStaleActionEconomy(ctx, out.Character); err != nil {
 		return memberCombatSnapshot{}, err
 	}
+	if err := o.restoreForNewEncounter(ctx, out.Character); err != nil {
+		return memberCombatSnapshot{}, err
+	}
 
 	return memberCombatSnapshot{
 		hp:    out.Character.Data.HitPoints,
 		maxHP: out.Character.Data.MaxHitPoints,
 		ac:    out.Character.Data.ArmorClass,
 	}, nil
+}
+
+// restoreForNewEncounter applies rpg-toolkit's arcade recovery
+// (tkcharacter.RestoreForNewEncounter, rpg-toolkit#785/#786) to char's
+// persisted data before it is seated in a BRAND NEW encounter: death is an
+// encounter-scoped outcome, not a persistent character state. A character
+// carrying 0 HP or less is restored to full HP with death-save state cleared
+// and the Unconscious condition stripped; a character already above 0 HP is
+// untouched (see RestoreForNewEncounter's own doc for the full contract).
+//
+// rpg-api#670: StartEncounter's AddPlayer call deliberately does not carry
+// DataJSON (hydration is the v2 orchestrator's characterData.Attach
+// cascade's job — see TestStartEncounter_SeedsHonestCombatSnapshot), so the
+// toolkit's own restoreForNewSeat (encounter.go, DataJSON-gated) never fires
+// for a real StartEncounter-seeded seat. Calling RestoreForNewEncounter
+// directly here — on the same character.Data this function already loads —
+// gets the identical toolkit-owned restore rule applied without requiring
+// StartEncounter to plumb a full character blob through AddPlayer's
+// PlayerInput just to trigger it.
+//
+// This must run BEFORE the memberCombatSnapshot is built below, and its
+// result (when it fires) must be persisted back to the character store:
+// otherwise the very next StartEncounter for this character would read the
+// same pre-restore hp=0 record straight out of the store again.
+func (o *Orchestrator) restoreForNewEncounter(ctx context.Context, char *entities.Character) error {
+	if char.Data == nil || !tkcharacter.RestoreForNewEncounter(char.Data) {
+		return nil
+	}
+	if _, err := o.characterRepo.Update(ctx, characterrepo.UpdateInput{Character: char}); err != nil {
+		return fmt.Errorf("persist arcade-recovery restore for character %q: %w", char.Data.ID, err)
+	}
+	return nil
 }
 
 // clearStaleActionEconomy resets char's toolkit action economy back to nil

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -1,6 +1,8 @@
 package lobby_test
 
 import (
+	"encoding/json"
+
 	"go.uber.org/mock/gomock"
 
 	"github.com/KirkDiggler/rpg-api/internal/apierr"
@@ -8,9 +10,12 @@ import (
 	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
+	rpgcore "github.com/KirkDiggler/rpg-toolkit/core"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
 )
 
 func (s *LobbySuite) seedReadyLobby(id, host string, others ...string) {
@@ -141,6 +146,90 @@ func (s *LobbySuite) TestStartEncounter_ClearsStaleActionEconomy() {
 	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
 	s.Require().NoError(err)
 	s.Require().Equal(12, encData.Players[core.PlayerID("alice")].HP)
+}
+
+// TestStartEncounter_DeadCharacter_ArcadeRecoveryRestoresAndPersists is the
+// rpg-api#670 regression: a character carrying 0 HP from a PRIOR encounter
+// (a confirmed death or an unresolved TPK snapshot) must be seated ALIVE at
+// full HP in a BRAND NEW encounter — rpg-toolkit's arcade recovery
+// (character.RestoreForNewEncounter, toolkit#785/#786) exists for exactly
+// this, but only fires where a caller actually invokes it. StartEncounter's
+// AddPlayer call deliberately carries no DataJSON (hydration is the v2
+// orchestrator's job — see TestStartEncounter_SeedsHonestCombatSnapshot
+// above), so the toolkit's OWN DataJSON-gated restoreForNewSeat path inside
+// AddPlayer never fires for a real lobby-started encounter. character.go's
+// restoreForNewEncounter step is what actually triggers the toolkit's
+// restore rule here, and must persist the result back to the character
+// store — otherwise the NEXT StartEncounter for this character would read
+// the same pre-restore hp=0 record right back out of the store.
+func (s *LobbySuite) TestStartEncounter_DeadCharacter_ArcadeRecoveryRestoresAndPersists() {
+	s.seedReadyLobby("lobby-dead-alice", "alice")
+
+	unconsciousBlob, err := json.Marshal(struct {
+		Ref *rpgcore.Ref `json:"ref"`
+	}{Ref: refs.Conditions.Unconscious()})
+	s.Require().NoError(err)
+
+	s.charRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{
+			Character: &entities.Character{
+				Data: &toolkitchar.Data{
+					ID: "char-alice", PlayerID: "alice", Name: "Alice",
+					HitPoints: 0, MaxHitPoints: 20,
+					DeathSaveState: &saves.DeathSaveState{Failures: 3},
+					Conditions:     []json.RawMessage{unconsciousBlob},
+				},
+			},
+		}, nil)
+
+	var persisted *toolkitchar.Data
+	s.charRepo.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			persisted = input.Character.Data
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		})
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-dead-alice",
+	})
+	s.Require().NoError(err)
+
+	// Alive on the encounter wire: full HP, not the dead hp=0 the store had.
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	s.Require().Equal(20, encData.Players[core.PlayerID("alice")].HP,
+		"a dead character must be seated at full HP in a NEW encounter (arcade recovery)")
+	s.Require().Equal(20, encData.Players[core.PlayerID("alice")].MaxHP)
+
+	// Persisted back to the character store: the NEXT StartEncounter must not
+	// read the same pre-restore hp=0 record again.
+	s.Require().NotNil(persisted, "the restored character must be persisted back to the character store")
+	s.Require().Equal(20, persisted.HitPoints, "persisted record must carry the restored HP")
+	s.Require().Nil(persisted.DeathSaveState, "death-save state must be cleared")
+	s.Require().Empty(persisted.Conditions, "the Unconscious condition must be stripped")
+}
+
+// TestStartEncounter_LivingCharacter_ArcadeRecoveryDoesNotFire proves the
+// restore is death-scoped, not a free heal: a character already above 0 HP
+// must be seated unchanged, with no extra Update call to the character
+// store beyond StartEncounter's other necessary writes.
+func (s *LobbySuite) TestStartEncounter_LivingCharacter_ArcadeRecoveryDoesNotFire() {
+	s.seedReadyLobby("lobby-alive-alice", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 7, 20)
+	// No Update EXPECT() is armed: gomock fails the test if StartEncounter
+	// calls charRepo.Update for a character that never needed restoring.
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-alive-alice",
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	s.Require().Equal(7, encData.Players[core.PlayerID("alice")].HP,
+		"a living character's HP must not be touched by arcade recovery")
 }
 
 func (s *LobbySuite) TestStartEncounter_CharacterNotFound_SeedsZeroHP_NotFatal() {


### PR DESCRIPTION
## Summary

- `StartEncounter`'s `AddPlayer` call never carried `DataJSON`, so the toolkit's DataJSON-gated arcade-recovery restore (`RestoreForNewEncounter`) never fired for a real lobby-started encounter — a previously-dead character was seated back into a brand-new encounter still at `hp=0`, dead conditions and all.
- `seedMemberCombatSnapshot` (`internal/orchestrators/lobby/character.go`) now calls the toolkit's `tkcharacter.RestoreForNewEncounter` directly on the character data it already loads, and persists the restored HP / cleared death-save state / stripped Unconscious condition back to the character store — so both this encounter's seat AND the next `StartEncounter`'s read of the store come back healthy.

Full discrimination evidence (ruling out hypotheses A/C/D as the primary cause): KirkDiggler/rpg-api#670 (comment) — https://github.com/KirkDiggler/rpg-api/issues/670#issuecomment-5017626830

Closes #670

## Fix

Small, boundary-respecting change: the toolkit owns the restore rule (`RestoreForNewEncounter`, unchanged), rpg-api's job is just routing a dead character's data through it and persisting what comes back — mirrors the existing `clearStaleActionEconomy` pattern in the same file (load → toolkit verb → persist if it fired).

## Scope decisions

- Did **not** plumb `DataJSON` through `AddPlayer`'s `PlayerInput` to trigger the toolkit's own `restoreForNewSeat` path. That would require StartEncounter to hydrate/marshal the full character blob at seat time, which `TestStartEncounter_SeedsHonestCombatSnapshot` already documents as deliberately deferred to the v2 orchestrator's `characterData.Attach` cascade (`hydrate_players.go`) on the first combat-capable RPC. Calling `RestoreForNewEncounter` directly on the already-loaded `character.Data` gets the identical toolkit-owned restore rule without disturbing that boundary.
- Did **not** touch hypothesis A (resume routing into a stale encounter) — that's rpg-api#663's abandon-path design, separate from this bug. Confirmed via static trace this fix is independent of it: a fresh `StartEncounter` call now seats a dead character alive regardless of how the client got to calling it.
- Did **not** fix the pre-existing, unrelated `make lint` findings encountered while validating (goconst/govet/staticcheck/unconvert/unused across `internal/integration/harness/harness.go`, `internal/integration/encounter_v2_test.go`, and files in a sibling worktree) — none are in the files this PR touches, and CI's `test.yml` has no lint gate, so they're pre-existing debt, not a regression from this change.

## Evidence

- Confirmed via static trace: `start_encounter.go`'s `AddPlayer` call is the only real (non-devseed) `AddPlayer` call site in rpg-api, and it never sets `PlayerInput.DataJSON`.
- Confirmed via toolkit source read (`rpg-toolkit/encounter@v0.29.4`, `rulebooks/dnd5e@v0.65.4` — both pinned in `go.mod`, both already contain the arcade-recovery code): `AddPlayer`'s `restoreForNewSeat` is a documented no-op when `DataJSON` is empty.
- Verified the new regression test is real: reverted just the `character.go` fix (keeping the new test), reran — test failed exactly as expected (HP stayed 0, no `Update` call happened). Restored the fix, reran — passes.
- Full `go test ./...` passes. One integration test (`TestLobbyStartThenMoveSuite`) failed once under the full suite; reproduced it in isolation both with and without this change (passed both times) and reran the full suite again (passed) — pre-existing flakiness unrelated to this diff, not a regression.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/orchestrators/lobby/...` — new tests pass, full suite green
- [x] `go test ./...` — full suite green (see flakiness note above)
- [x] New test fails without the fix (verified), passes with it
- [ ] Copilot review
