### PR TITLE
chore(deps): bump rpg-toolkit/encounter v0.34.0 -> v0.34.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260720043951-c3059bc89397
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.34.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.34.1
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.66.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.34.0 h1:0S7SZj/ZEcSOiFUFvuvhL2Ifx407173TrEUEDHV0R7U=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.34.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.34.1 h1:uNgUeue5KSiGANCredIU+vh1Rm1xna3eI/agv/6Ynok=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.34.1/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=


### PR DESCRIPTION
## Summary
- Bumps `github.com/KirkDiggler/rpg-toolkit/encounter` v0.34.0 -> v0.34.1
- Delivers KirkDiggler/rpg-toolkit#808: pocket-exit `ExitCombat` now tears down the stale combat move budget, so `FREE_ROAM` movement isn't blocked after combat ends
- Internal/behavior-only fix in the toolkit — no API signature change, drop-in bump. `go.mod`/`go.sum` diff touches only the `encounter` module (verified no sibling toolkit modules were pulled in)
- Unblocks the Slice 2 sign-off walk

## Verification
- `GOPRIVATE=github.com/KirkDiggler go build ./...` — clean
- `go test -race ./...` — all green (unit + integration), including `TestDungeonTwoChamberSuite`, `TestMoveEntitySuite`, `TestMoveEntityNPCFirstSuite`, `TestEncounterV2IntegrationSuite`, `TestLobbyStartThenMoveSuite`

## Scope-decisions
- `make pre-commit` / `make ci-check` lint step reports 29 pre-existing findings (goconst/govet/staticcheck/unconvert/unused) across files this PR does not touch (harness.go, dungeon/toolkit, character converters, dice orchestrator). Confirmed these are pre-existing on `origin/main` HEAD (this branch's tree is identical to main aside from the go.mod/go.sum diff) and unrelated to the encounter bump. Left out of scope here — fixing 29 unrelated lint issues doesn't belong in an isolated dependency bump. Actual GitHub Actions CI (`test.yml`) does not run golangci-lint, so this won't block PR CI. Filing a separate cleanup issue for the lint debt is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybty7BT4V1mzQgPXUfUs1U