### PR TITLE
docs: equipment on the wire (#680) — routes, real-AC win, single equip path

### DIFF
--- a/docs/architecture/components/character-orchestrator.md
+++ b/docs/architecture/components/character-orchestrator.md
@@ -1,8 +1,8 @@
 ---
 name: character orchestrator
 description: Character creation, management, equipment, and data-loading orchestrator
-updated: 2026-05-02
-confidence: medium-high — verified by reading service.go and orchestrator.go
+updated: 2026-07-21
+confidence: medium-high — verified by reading service.go and orchestrator.go; rpg-api#680 equipment section verified against passing unit tests + an adversarial-gate-driven fix
 ---
 
 # character orchestrator
@@ -19,7 +19,7 @@ The character orchestrator handles character creation (draft lifecycle), charact
 ## Purpose
 
 - **Draft lifecycle:** create → update (name, race, class, background, ability scores, appearance) → validate → finalize → `character.Data` in Redis.
-- **Character management:** equip/unequip items in toolkit equipment slots; get/list/delete characters.
+- **Character management:** equip/unequip through the toolkit's rules engine (rpg-api#680 — see "Equipment" below, this used to be a bare data write); get/list/delete characters.
 - **Data loading:** list races, classes, backgrounds, equipment by type, spells, ability scores — delegates to rpg-toolkit for actual data.
 
 ## Public interface
@@ -70,6 +70,75 @@ The orchestrator works with:
 - `*character.Data` (toolkit type) — stored and loaded from Redis directly
 - `*entities.CharacterDraft` — in-progress creation state in Redis
 - `*entities.Appearance` — cosmetic character data, stored alongside `character.Data`
+
+## Equipment (rpg-api#680)
+
+`EquipItem`/`UnequipItem` are the ONE rules-correct equip path — the v1alpha1
+`CharacterService` and the new v1alpha2 `CharacterService`
+(`internal/handlers/dnd5e/v2/character/`) both call these same two methods. Previously
+they were a bare `charData.EquipmentSlots.Set/Clear(...)` — no rules, no occupancy, no
+validation, no recompute. That's gone.
+
+The method shape:
+
+1. `characterRepo.Get` — load the persisted `*character.Data`.
+2. `character.LoadFromData(ctx, data, events.NewEventBus())` — build the runtime
+   `*character.Character` so the toolkit's rules run for real.
+3. `char.EquipItem(slot, itemID)` / `char.UnequipItem(slot)` — the toolkit enforces
+   occupancy here (rpg-toolkit#812, v0.67.0): a two-handed weapon claims `main_hand` and
+   clears `off_hand`; equipping an occupied slot swaps the previous occupant back to
+   inventory (never dropped); an incompatible slot now returns an `rpgerr` (mapped to
+   `apierr.InvalidArgument` by `mapEquipError`) instead of silently succeeding.
+4. `mergedEquipmentData(ctx, original, char)` — persist. See below for why this is a
+   merge, not `Data: char.ToData()`.
+
+### Why persistence merges instead of overwriting (a real footgun)
+
+`mergedEquipmentData` copies the `*character.Data` loaded in step 1 and refreshes only
+two fields from the post-mutation runtime character:
+
+- **`EquipmentSlots`** — read via `char.ToData().EquipmentSlots`. Safe: it's a plain
+  `map[InventorySlot]string`, no registry resolution involved, round-trips correctly.
+- **`ArmorClass`** — set to `char.EffectiveAC(ctx).Total`, so the STORED int stays
+  truthful. This matters because the encounter seat's combat AC (`lobby`'s
+  `AddPlayer` seeding, `internal/orchestrators/lobby/character.go`) is seeded from this
+  same stored int — leaving it stale after an equip would desync combat AC from the
+  real display AC the wire now serves (see `docs/architecture/components/encounter.md`'s
+  CharacterData projection). Baking `EffectiveAC` into the stored int here is safe
+  specifically because this orchestrator method only ever runs on the out-of-encounter
+  character sheet, where `Conditions`/`ActionEconomy` carry no live combat buffs
+  (Shield, Mage Armor) to accidentally bake in — only permanent sources (armor, DEX,
+  features like Unarmored Defense) are ever on the breakdown at that point. Deferred:
+  rpg-api#684 (replace the cache with a direct `EffectiveAC` read everywhere, removing
+  the desync risk this manages rather than eliminates) and rpg-api#681 (push a live
+  update to an already-connected `StreamEncounter` client on an out-of-combat equip —
+  no toolkit broker event supports this today).
+
+Every OTHER field is deliberately left exactly as loaded, NOT persisted via a full
+`char.ToData()` overwrite. `ToData()`/`LoadFromData()` is lossy for data the toolkit
+runtime doesn't model on a round trip:
+
+- `BackgroundID` and `CreatedAt` are never populated by `ToData()` — confirmed by
+  reading `character.go`'s `ToData()`: no assignment exists for either. A full
+  overwrite silently zeros them.
+- Any inventory item whose ID isn't in the toolkit's built-in weapon/armor/tool/pack/
+  ammunition registry — a loot/quest item like `"potion-of-healing"` — is silently
+  skipped by `LoadFromData`'s `equipment.GetByID` resolution loop
+  (`if err != nil { continue }`). A full overwrite permanently deletes it from
+  `Data.Inventory`.
+
+An adversarial gate on rpg-api#680 caught this before merge: the original
+implementation persisted `char.ToData()` directly, and a regression test proved it
+destroyed a character's background, creation timestamp, and a non-registry inventory
+item on a single `EquipItem` call. `Character.EquipItem`/`UnequipItem` never touch
+`Inventory` at the toolkit level (only `EquipmentSlots`), so merging just those two
+fields onto the originally-loaded `Data` is a complete fix, not a partial workaround.
+Regression coverage: `TestEquipItem_PreservesNonEquipmentFields` and
+`TestEquipItem_SyncsStoredArmorClass` (`internal/orchestrators/character/equip_item_test.go`).
+
+**If this ever gets "simplified" back to `Data: char.ToData()`, the data loss returns
+silently** — there's no compiler error, just a character quietly missing fields the
+next time someone equips something.
 
 ## Known issues
 

--- a/docs/architecture/components/character-v2-handler.md
+++ b/docs/architecture/components/character-v2-handler.md
@@ -1,0 +1,85 @@
+---
+name: character v2 handler
+description: gRPC handler for the v1alpha2 CharacterService — out-of-encounter equip/unequip
+updated: 2026-07-21
+confidence: high — verified by reading handler.go, handler_test.go, and the shared orchestrator/projection code it calls
+---
+
+# character v2 handler (rpg-api#680)
+
+The v1alpha2 `dnd5e.api.v1alpha2.character.CharacterService` is the out-of-encounter
+character-sheet surface: `EquipItem`/`UnequipItem` for sheet editing between
+encounters. It is deliberately narrow — two RPCs, no draft lifecycle, no data-loading
+endpoints. The full character creation/management surface stays on the v1alpha1
+`CharacterService` (`docs/architecture/components/character-handler.md`); this handler
+exists only because equip/unequip needed a v1alpha2 wire shape (`Ref` + `slot_key`,
+keys-not-enums) and a response carrying the new `CharacterData` equipment fields
+(`docs/architecture/components/encounter.md`'s CharacterData projection section).
+
+The in-encounter equivalent — equipping mid-combat, with an action-economy cost — does
+not exist yet. When it lands, it rides the encounter stream, not this service
+(rpg-project#94).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `internal/handlers/dnd5e/v2/character/handler.go` | `Handler` struct + constructor + `EquipItem`/`UnequipItem` |
+| `internal/handlers/dnd5e/v2/character/handler_test.go` | Unit suite (gomock) — validation, delegation, error→gRPC-status mapping, response shape |
+
+No `converters.go` — proto↔domain translation here is small enough to live inline in
+`handler.go` (item Ref → toolkit item ID, slot key string → `character.InventorySlot`),
+unlike the v1alpha1 handler's 3,132-line converter file.
+
+## gRPC methods handled
+
+- `EquipItem(EquipItemRequest{character_id, item: Ref, slot_key}) → EquipItemResponse{character: CharacterData}`
+- `UnequipItem(UnequipItemRequest{character_id, slot_key}) → UnequipItemResponse{character: CharacterData}`
+
+`item` is a `Ref` (module/type/id), not a bare item id string — the handler resolves
+`ref.Id` as the toolkit item ID. Module/type on the Ref are NOT validated here;
+validating "what makes a Ref a valid item ref" would require rules knowledge this
+handler deliberately doesn't have.
+
+## Layering
+
+This handler is a thin wrapper — proto conversion only, no business logic:
+
+1. Validate the envelope (`character_id`, `item`/`item.id`, `slot_key` non-empty) →
+   `apierr.InvalidArgument`.
+2. Delegate to `character.Service.EquipItem`/`UnequipItem`
+   (`internal/orchestrators/character` — the SAME orchestrator the v1alpha1 handler
+   uses; see `character-orchestrator.md`'s Equipment section for what that method
+   actually does). Orchestrator errors are wrapped with `apierr.ToGRPCError`.
+3. Re-fetch via `characterService.GetCharacter`, load the runtime character
+   (`character.LoadFromData`), and compose the response via
+   `encounterhandler.BuildEquipmentCharacterData` — the SAME composition function the
+   v1alpha2 encounter snapshot path uses (`internal/handlers/dnd5e/v2/encounter/
+   character_data.go`). One composition, two callers: the character sheet and the
+   encounter HUD never independently drift.
+
+`armor_class_detail.total` is the ONLY AC total on this response — there is no
+surrounding `Entity.armor_class` to keep in sync with, unlike the encounter snapshot
+(see `CharacterData.armor_class_detail`'s doc comment in the proto for the full
+rationale on why the field is duplicated there but not here).
+
+## Wiring
+
+Registered in both `cmd/server/server.go` and `internal/integration/harness/harness.go`,
+sharing the SAME `character.Service` instance the v1alpha1 `CharacterService` uses — no
+separate orchestrator construction.
+
+## Test coverage
+
+`handler_test.go` — gomock suite: validation errors (missing `character_id`/`item`/
+`slot_key`), success path (asserts `armor_class_detail` is real and non-zero, `equipped`
+contains the newly-equipped slot, `inventory` includes the equipped item per the wire
+contract), orchestrator error → gRPC status mapping (`apierr.NotFound` → `codes.NotFound`,
+a generic error → `codes.Internal`).
+
+The end-to-end equip→snapshot proof (real AC against a hand-computed expected total,
+two-handed occupancy visible across both surfaces, non-equipment-field preservation) is
+an integration suite in the encounter package —
+`internal/handlers/dnd5e/v2/encounter/integration_equipment_test.go` — since it needs
+both this service and the v1alpha2 encounter service wired against the same character
+store.

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter (v1alpha2)
 description: v1alpha2 encounter service — thin handlers over a clean load→verb→persist orchestrator
-updated: 2026-05-31
-confidence: high — verified by reading handler.go, end_turn.go, orchestrators/encounter/v2/{orchestrator,load,end_turn,take_action,move_entity,submit_check_reaction}.go, reaction_resume.go, .golangci.yml, combat_handlers_test.go
+updated: 2026-07-21
+confidence: high — verified by reading handler.go, end_turn.go, orchestrators/encounter/v2/{orchestrator,load,end_turn,take_action,move_entity,submit_check_reaction}.go, reaction_resume.go, .golangci.yml, combat_handlers_test.go; rpg-api#680 CharacterData equipment projection section verified against passing integration tests
 ---
 
 # encounter (v1alpha2)
@@ -23,6 +23,7 @@ The orchestrator stays **rulebook-free**. All game complexity lives in the rpg-t
 | `internal/handlers/dnd5e/v2/encounter/reaction_resume.go` | Rulebook-touching adapter seam (excluded from depguard): marshal/decode the opaque `*combat.AttackContext`, build reaction modifiers (Shield +5 AC), one-shot-reaction predicate — injected into the orchestrator's `ReactionResume` |
 | `internal/handlers/dnd5e/v2/encounter/{dnd5e_combat_resolver,dnd5e_combat_resolver_phased,dnd5e_movement_resolver,combatant,hydrate_players}.go` | Resolver / cascade adapters (excluded from depguard) — translate held entities through the rulebook |
 | `internal/handlers/dnd5e/v2/encounter/project.go` | ProjectFor helper — toolkit Data → proto Encounter |
+| `internal/handlers/dnd5e/v2/encounter/character_data.go` | `BuildEquipmentCharacterData` — toolkit EquipmentView → proto CharacterData equipment fields (rpg-api#680), shared with the v1alpha2 character handler |
 | `internal/handlers/dnd5e/v2/encounter/translate.go` | Event translator — toolkit events → proto EncounterEvent |
 | `internal/orchestrators/encounter/v2/orchestrator.go` | Orchestrator struct + `Config` (Broker, repo, resolver builders, `CharacterDataCascade`, `ReactionResume`) + `New` |
 | `internal/orchestrators/encounter/v2/load.go` | The single load core: Get → auth (membership + optional entity-ownership) → #689 character-data attach → `LoadFromData` with resolvers wired uniformly. Defines `ErrEncounterNotFound` / `ErrPlayerNotInEncounter` / `ErrEntityOwnershipMismatch` |
@@ -128,6 +129,52 @@ As of #500, `ProjectFor` includes all entities currently visible to the viewer �
 ### Wall + door projection (The Dungeon wave 2 Slice 2, rpg-api#676)
 
 `Space.Walls` carries TWO shapes now, both whole-room/unconditional (not LoS-gated like `Hexes`/`Entities` — wave 1's "no per-viewer wall reveal yet" still holds): `wallsToProto(data.Space)` projects persisted solid/window segments (`Start == End` degenerate hexes), and `doorWallsToProto(data)` separately projects every entry in `data.Doors` as a `WALL_KIND_DOOR_CLOSED`/`WALL_KIND_DOOR_OPEN` `Wall` carrying its entity id (`rpg-api-protos#186`'s additive `Wall.id` — the web's click→`Interact(id)` bridge). A door's `From` is its own cell; `To` is its passage-edge neighbor (`doorPassageNeighbor`, found via `perception.HexNeighbors` + `SpaceData.RegionAt` — never `Start == End` for a door, which is the 6-door-pair render-multiplicity bug the design doc's §Q2 calls out). `DoorData` stays the single source of door truth (position, open/locked state); the wall is purely its projected geometry.
+
+### CharacterData equipment projection (rpg-api#680)
+
+`playerEntity`'s `CharacterData` carries `equipped`/`inventory`/`slots`/
+`armor_class_detail`/`main_hand_damage`, populated from the toolkit's `EquipmentView`
+display projection (rpg-toolkit#812) — this is the fix for board #11's other named
+equipment sin: AC on the wire used to be `converters.go`'s `int32(data.ArmorClass)`
+(v1alpha1), a straight copy of a stored int, never `EffectiveAC`.
+
+`characterDataFor` (`project.go`, née `characterIdentityFor` — merged with the #664
+identity lookup so this slice doesn't add a second per-player `charRepo.Get`) does ONE
+character-store lookup per projected player: `charRepo.Get` → `character.LoadFromData`
+→ `char.EquipmentView(ctx)` → `BuildEquipmentCharacterData` (`character_data.go`), a
+pure field-for-field map (`Items[].Name/Kind/SlotKeys/StatLine` → `Item`, `Slots` →
+`SlotDef`, `ACTotal`/`ACNote` → `ArmorClassDisplay`, `MainHandDamage` → the sibling
+field) — no rules computed in rpg-api, everything is toolkit-composed pass-through.
+`BuildEquipmentCharacterData` is exported and shared with the out-of-encounter
+`v1alpha2 character` handler (`character-v2-handler.md`), so the character sheet and the
+encounter HUD never independently drift from two compositions of the same data.
+
+**AC-sync invariant.** `Entity.armor_class` (the flat cross-entity-type field every
+`Entity`, including monsters, carries) is kept equal to
+`CharacterData.armor_class_detail.total` in `playerEntity`: the real,
+toolkit-computed `EquipmentView.ACTotal` wins over the encounter snapshot's own cached
+`pd.AC` whenever equipment data is available; `pd.AC` is only a fallback for when the
+character store wasn't reachable (nil `charRepo`, a lookup/load failure — degrades the
+snapshot the same way identity resolution already did pre-#680, never fails it). The
+underlying `character.Data.ArmorClass` stored int is separately kept truthful by the
+orchestrator on every equip/unequip call (`character-orchestrator.md`'s
+`mergedEquipmentData`), so the SAME total is what a fresh encounter seat gets seeded
+with (`lobby`'s `AddPlayer`) too — two independent sync points converging on one real
+number rather than one authoritative source, tracked as a simplification opportunity
+under rpg-api#684.
+
+**`icon_key` is deliberately empty.** No toolkit/asset-manifest source exists yet for a
+bare sprite key — composing one in rpg-api would be exactly the kind of display-field
+invention this slice exists to stop. Asset-manifest mapping is a follow-up, not started.
+
+**Live-push deferred (rpg-api#681).** An out-of-combat equip (via the v1alpha2
+character service) does NOT push an update to an already-connected `StreamEncounter`
+client — there is no existing toolkit broker event for "entity data changed," and the
+character orchestrator has no dependency on the encounter broker today. A NEW snapshot
+build (a fresh `StreamEncounter` connect, or `GetEncounter`) picks up the change for
+free, since `characterDataFor` re-reads the character store on every call — but a
+client that stays connected through someone else's out-of-band equip won't see it
+update live. True live-push rides with encounter-scoped equip (rpg-project#94).
 
 ## StreamEncounter flow (#497)
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api quality scorecard
 description: Per-component grade with rationale — a graded scorecard to update as the codebase evolves
-updated: 2026-07-13
-confidence: medium — Wave 2.11e encounter v2 graded from shipped-code + integration test verification; older entries reflect 2026-05-02 snapshot pending refresh; rpg-api#636 note verified against passing tests; rpg-api#642 deletions verified against passing build/vet/test/lint
+updated: 2026-07-21
+confidence: medium — Wave 2.11e encounter v2 graded from shipped-code + integration test verification; older entries reflect 2026-05-02 snapshot pending refresh; rpg-api#636 note verified against passing tests; rpg-api#642 deletions verified against passing build/vet/test/lint; rpg-api#680 entries verified against passing unit + integration suite
 ---
 
 # Quality Scorecard
@@ -162,7 +162,24 @@ character API silently returns stub data for real fields. One TODO in
 interact with toolkit, this belongs in the orchestrator." That smell is present
 but not yet addressed. Test coverage exists via `list_equipment_test.go` and
 `list_spells_test.go` but the converter surface is sparsely tested relative to
-its size.
+its size. Its `EquipItem`/`UnequipItem` RPCs now delegate to the rules-correct
+orchestrator method (rpg-api#680, see "Character orchestrator" below) — that
+specific gap is closed even though the surrounding stub/TODO debt isn't.
+
+### Character v2 handler — B (new, 2026-07-21)
+
+`internal/handlers/dnd5e/v2/character/` (rpg-api#680) — the v1alpha2
+`CharacterService`, out-of-encounter `EquipItem`/`UnequipItem` only. Deliberately
+narrow: no `converters.go`, proto↔domain translation is small enough to stay
+inline in `handler.go`. Delegates to the SAME orchestrator method the v1alpha1
+handler uses and shares `BuildEquipmentCharacterData`
+(`internal/handlers/dnd5e/v2/encounter/character_data.go`) with the encounter
+snapshot path for its response composition — no independent logic to drift.
+Gomock unit suite covers validation, delegation, and error→status mapping; the
+end-to-end proof (real AC, occupancy visible across both surfaces) is the
+integration suite in the encounter package (`encounter.md`). Held at B rather
+than A pending production traffic and a genuine in-encounter equip path
+(rpg-project#94) to prove the boundary holds under a second consumer.
 
 ## Orchestrators
 
@@ -187,6 +204,15 @@ The `service.go` / `orchestrator.go` split within the package follows the
 defined pattern. Grade would be higher with better alive-state handling and
 completing the TODO at line 3352 (monster turns for entities acting before
 current entity).
+
+**Update (rpg-api#680, 2026-07-21):** `EquipItem`/`UnequipItem` are rules-correct
+now — load the runtime character, call the toolkit's `EquipItem`/`UnequipItem`
+(occupancy, slot-compatibility), persist via a merge that deliberately avoids a
+full `char.ToData()` overwrite (which is lossy for `BackgroundID`/`CreatedAt`/
+non-registry inventory — see `character-orchestrator.md`'s Equipment section).
+Grade held at B- rather than raised: the fix is real and well-tested, but the
+alive-check and monster-turns TODOs that capped this grade are unrelated and
+still open.
 
 ### Lobby orchestrator — B+ (new, 2026-07-07)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-20
-confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite; #656 movement-truncation fix verified against an isolated toolkit-level repro, a new RPC-level regression test (10x -race), and the full suite; #663 AbandonEncounter + combat pockets + rage-at-seating verified against passing unit/integration/-race full suite plus a live playtest against the real game route; #676 The Dungeon wave 2 Slice 2 (api leg) verified against passing unit tests + a new 3-test integration gate suite (8x stress-run, entropy-seeded layouts)
+updated: 2026-07-21
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite; #656 movement-truncation fix verified against an isolated toolkit-level repro, a new RPC-level regression test (10x -race), and the full suite; #663 AbandonEncounter + combat pockets + rage-at-seating verified against passing unit/integration/-race full suite plus a live playtest against the real game route; #676 The Dungeon wave 2 Slice 2 (api leg) verified against passing unit tests + a new 3-test integration gate suite (8x stress-run, entropy-seeded layouts); #680 equipment on the wire verified against passing unit + integration suite (real AC, occupancy, non-equipment-field preservation) + adversarial-gate fixes + full CI green against published deps
 ---
 
 # rpg-api: Where We Are
@@ -10,6 +10,85 @@ confidence: high — Wave 2 Monk entries verified against passing integration te
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**Equipment on the wire — real AC, one rules-correct equip path (rpg-api#680, 2026-07-21)** —
+board #11's two named equipment sins are both fixed. AC on the wire used to be
+`converters.go`'s `int32(data.ArmorClass)` — a straight copy of a stored int, never
+computed. Equip used to be `internal/orchestrators/character/orchestrator.go`'s bare
+`EquipmentSlots.Set/Clear` — no rules, no occupancy, no recompute. Both are gone.
+
+**The single equip path.** `Orchestrator.EquipItem`/`UnequipItem` now load the runtime
+`*character.Character` via `character.LoadFromData`, call the toolkit's rules-aware
+`Character.EquipItem`/`UnequipItem` (rpg-toolkit#812, v0.67.0 — two-handed weapons
+claim/clear `off_hand`, equipping an occupied slot swaps the previous occupant back to
+inventory, an incompatible slot is a real error now instead of a silent no-op), and
+persist the result. Both the existing v1alpha1 `CharacterService.EquipItem`/`UnequipItem`
+and the new v1alpha2 `CharacterService` (below) call this ONE orchestrator method — no
+dual logic, occupancy enforced exactly once, in the toolkit.
+
+**New v1alpha2 `dnd5e.api.v1alpha2.character.CharacterService`**
+(`internal/handlers/dnd5e/v2/character/`, rpg-api-protos#188) — `EquipItem`/`UnequipItem`,
+the out-of-encounter character-sheet surface (equip/unequip between encounters; the
+in-encounter equivalent, when it exists, rides the encounter stream instead —
+rpg-api#681 below). Both RPCs return the recomputed `CharacterData`: real AC, composed
+`stat_line`/`main_hand_damage`, current `equipped`/`inventory`/`slots` — that response IS
+this slice's delivery mechanism, not a follow-up read.
+
+**Real AC.** `CharacterData.armor_class_detail`/`Entity.armor_class` (the v1alpha2
+encounter snapshot, `internal/handlers/dnd5e/v2/encounter/project.go`'s `playerEntity`)
+now come from the toolkit's `EquipmentView` (`EffectiveAC(ctx).Total`), not a stored int.
+See `docs/architecture/components/encounter.md`'s "CharacterData equipment projection"
+section for the AC-sync invariant this introduces.
+
+**Why persistence merges instead of overwriting — a real footgun, worth remembering.**
+`Orchestrator`'s `mergedEquipmentData` copies the ORIGINALLY loaded `character.Data` and
+refreshes only `EquipmentSlots` + `ArmorClass` from the post-mutation runtime character —
+it does NOT persist a full `char.ToData()` round-trip. The toolkit's `ToData()`/
+`LoadFromData()` pair is lossy: `BackgroundID` and `CreatedAt` are never populated by
+`ToData()` at all, and any inventory item whose ID isn't in the toolkit's built-in
+weapon/armor/tool/pack/ammo registry (a loot/quest item) is silently dropped by
+`LoadFromData`'s `equipment.GetByID` resolution loop. An adversarial gate caught this
+before merge — the naive full-overwrite version destroyed a test character's background,
+creation timestamp, and a non-registry inventory item on a single equip call. If this
+ever gets "simplified" back to `Data: char.ToData()`, that data loss returns silently.
+See `docs/architecture/components/character-orchestrator.md`'s Equipment section.
+
+**Boundary discipline.** rpg-api composes no display strings, computes no AC, enforces
+no occupancy anywhere in this slice — `BuildEquipmentCharacterData`
+(`internal/handlers/dnd5e/v2/encounter/character_data.go`) is a pure field-for-field map
+from the toolkit's `EquipmentView` (`Items[].Name/Kind/SlotKeys/StatLine`, `Slots`,
+`ACTotal`/`ACNote`, `MainHandDamage`) onto the wire `CharacterData`, Ref-translation only.
+One composition, shared by the character-sheet RPC response and the encounter snapshot
+path, so the two surfaces never independently drift.
+
+**Known deferrals, all filed:**
+- **rpg-api#681** — live-push of a recomputed snapshot to an already-open
+  `StreamEncounter` connection when an out-of-combat equip happens. No existing toolkit
+  broker event supports "entity data changed," and the character orchestrator has no
+  dependency on the encounter broker today; building one is new cross-orchestrator
+  wiring, out of scope for this slice. A NEW snapshot build (`GetEncounter`, or a fresh
+  `StreamEncounter` connect) already reflects a persisted equip change for free.
+- **rpg-api#683** — `make ci-check` (`scripts/ci-checks.sh`)'s mock-regeneration check
+  runs `go generate ./...` then unconditionally `git checkout -- .` on ANY diff,
+  including tool-version-drift cosmetic diffs unrelated to real interface changes. It
+  fired a false positive mid-implementation and wiped every uncommitted tracked-file
+  edit in the working tree back to `HEAD` (new untracked files survived). Commit before
+  running `make ci-check` until this is fixed.
+- **rpg-api#684** — replace the stored `ArmorClass` int with a direct `EffectiveAC` read
+  everywhere (eliminating the cache/desync risk `mergedEquipmentData` currently manages
+  by keeping the int refreshed on every equip) — a larger, separately-scoped change.
+
+Verified: orchestrator unit suite (occupancy, slot-swap, non-registry-field preservation,
+stored-AC sync, error mapping) + a table-driven integration suite wiring both the
+v1alpha2 character service and the v1alpha2 encounter service against the same character
+store (`internal/handlers/dnd5e/v2/encounter/integration_equipment_test.go`) — fighter
+equips chain mail for a hand-computed AC of 16 (heavy armor, no DEX bonus), rogue equips
+leather for a hand-computed AC of 14 (11 base + DEX 16's +3 mod), barbarian's two-handed
+greataxe equip clears `off_hand` on both the RPC response and the encounter snapshot, and
+unequip returns an item to inventory without dropping it. Full `go test ./...` and
+`golangci-lint` (0 new issues) green against the published `rpg-toolkit/rulebooks/dnd5e
+v0.67.0` + `rpg-api-protos/gen/go` (post rpg-api-protos#188) — no replace directives in
+the merged commit. CI green on rpg-api#682.
 
 **The Dungeon wave 2 Slice 2 (api leg) — two-chamber dungeon, door projection,
 per-chamber goblin seeding (rpg-api#676, 2026-07-20)** — `StartEncounter`


### PR DESCRIPTION
## Summary

Living-docs pass for what rpg-api#680 shipped (merged as #682) — our convention is docs land with the work; filed as a follow-up here to close that gap.

- **`docs/status.md`** — new Active work entry: equipment routes live, the architecture-honesty win (AC on the wire now comes from the toolkit's `EffectiveAC`, not `converters.go`'s stale stored int), the single rules-correct equip path (`LoadFromData` → toolkit `Character.EquipItem` → `mergedEquipmentData`), and the three deferrals (rpg-api#681 live-push, rpg-api#683 the `ci-check` footgun, rpg-api#684 combat-AC single-source).
- **`docs/architecture/components/character-orchestrator.md`** — new "Equipment" section: the `LoadFromData` → toolkit `EquipItem` → `mergedEquipmentData` flow, and exactly why persistence merges instead of overwriting (the `BackgroundID`/`CreatedAt`/non-registry-inventory data loss an adversarial gate caught before merge).
- **`docs/architecture/components/character-v2-handler.md`** (new) — the out-of-encounter v1alpha2 `CharacterService`: narrow surface, shares the same orchestrator method and `BuildEquipmentCharacterData` composition the v1alpha1 handler and the encounter snapshot path use.
- **`docs/architecture/components/encounter.md`** — new "CharacterData equipment projection" section: `characterDataFor`/`BuildEquipmentCharacterData`, the AC-sync invariant (`Entity.armor_class` == `armor_class_detail.total`, and the stored int stays truthful too), `icon_key`'s Scope-decision, and the live-push deferral.
- **`docs/quality.md`** — new v1alpha2 character handler entry (B); character orchestrator entry updated with the equipment fix (grade held — the gaps that capped it at B- are unrelated and still open).

## Verification

Every claim in these docs was checked against the merged code at `443387d` (function names, error message strings, issue titles, toolkit version) rather than carried over from memory or the PR description — no invented details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
