### PR TITLE
infra(integration)#699: share one Redis container per test process, preserve per-test isolation

### DIFF
--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -68,11 +68,38 @@
       ],
       "commit": "935cbb7",
       "notes": "Exactly one full run: exit 0, 37.4s wall clock (/usr/bin/time -v), exactly 3 redis:7-alpine containers created/terminated total (one per Go test process: internal/integration, internal/integration/character, internal/integration/harness — confirmed via TestMain STARTED/TERMINATED log lines and 3x 'Creating container for image redis:7-alpine'). docker ps confirmed zero leaked containers afterward. Goroutine-count spot check after 8 tests in internal/integration: 3 (stable, no broker/gRPC leak). Compares to the accepted ~283s/33-container baseline; this branch's own actual pre-#699 count would have measured 30 (character suite already amortized 7 tests onto 1 container via SetupSuite pre-#699 — noted honestly in docs/status.md rather than repeating the issue's 33 uncritically)."
+    },
+    {
+      "id": "2026-07-23-006",
+      "task": "PR #700 opened; addressed 4 Copilot review comments (fresh cleanup ctx, idempotency docstring, misleading 'Shared' log wording, success/failure Terminate logging); replied individually and resolved all 4 threads",
+      "status": "completed",
+      "artifacts": [
+        "internal/integration/harness/harness.go",
+        "internal/integration/harness/redis_container.go"
+      ],
+      "commit": "9daa277",
+      "notes": "CI (build, test) green; mergeStateStatus CLEAN. PR intentionally left open, not merged."
+    },
+    {
+      "id": "2026-07-23-007",
+      "task": "Close an independent-review gap: add durable regression coverage for (1) per-test application freshness across two NewWithRedis instances and (2) shared-Redis state isolation via the exact FlushRedis sequence SetupTest uses, with a fixed key immune to ID-collision false negatives",
+      "status": "completed",
+      "artifacts": [
+        "internal/integration/shared_fixture_regression_test.go",
+        "internal/integration/harness/harness.go",
+        "docs/how-to/run-integration-tests.md",
+        "docs/status.md",
+        "docs/architecture/components/integration-test-harness.md",
+        ".claude/tests.json"
+      ],
+      "commit": "PENDING",
+      "notes": "New TestSharedRedisFixture_PerTestFreshnessAndStateIsolation in internal/integration (primary package, so a targeted -run starts only that package's one container). per_test_application_freshness is a characterization test (passed immediately, pinning NewWithRedis's existing fresh-wiring behavior) — added TestServer.GRPCServer(), a minimal test-only seam on the harness package (test-support code, never imported by production), to make gRPC server identity assertable alongside the existing exported BrokerV2/LobbyBroker/EncRepoV2/LobbyRepo/CharacterRepo fields. shared_redis_state_isolation_via_flush is mutation-tested: temporarily skipping the second cycle's FlushRedis call reproduced 'Should be zero, but was 1' (RED), reverted to GREEN. Targeted run: 1 container, ~13-14s wall (mostly container start/teardown; test body 0.02-0.03s), race-clean. Also fixed docs/how-to/run-integration-tests.md's inaccurate '36 containers before #699' wording to the verified actual 30 (36 remains correct as the total TEST METHOD count, kept separately). Did NOT re-run go test ./internal/integration/... locally per instructions — full-package confirmation deferred to CI."
     }
   ],
   "next_steps": [
-    "Push branch, open PR linking #699 (ready, not draft)",
-    "Self-review diff, address any automated (Copilot) comments individually",
+    "Push branch, update PR #700 body with the new regression coverage + docs correction",
+    "Inspect CI's full-package run log/container count on the new push (do not re-run locally)",
+    "Address any new automated comments individually",
     "Do not merge — awaiting explicit approval per repo workflow"
   ]
 }

--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -3,17 +3,76 @@
   "issues": ["#699"],
   "goal": "Split Redis container lifecycle ownership from per-test TestServer/service wiring in internal/integration/harness. One shared Redis testcontainer per test process (internal/integration and internal/integration/character each own one), started once and terminated once, while every test still gets fresh gRPC/repos/brokers/clients and a FlushRedis before it runs. Preserve standalone harness.New owning behavior for callers outside the package fixture.",
   "dependencies": {},
-  "open_pr_coordination": {},
-  "sessions": [],
+  "open_pr_coordination": {
+    "pr-698": "feat/689-deterministic-crypt-monsters — already merged into main before this branch was cut from origin/main; no rebase/merge needed."
+  },
+  "sessions": [
+    {
+      "id": "2026-07-23-001",
+      "task": "RED then GREEN: split Redis container ownership from TestServer wiring in internal/integration/harness (RedisContainer/StartRedis/Terminate/Lease, NewWithRedis, idempotent Close)",
+      "status": "completed",
+      "artifacts": [
+        "internal/integration/harness/redis_container.go",
+        "internal/integration/harness/lifecycle_internal_test.go",
+        "internal/integration/harness/harness.go"
+      ],
+      "commit": "745578d",
+      "notes": "Docker-free whitebox tests using a fakeContainer (embeds nil testcontainers.Container, overrides only Terminate) and a redismocks.MockClient. Each of the 3 lifecycle invariants (closeOnce guard, leaseMu lock, termOnce guard) was mutated out individually and reproduced the exact failure its test exists to catch, then reverted."
+    },
+    {
+      "id": "2026-07-23-002",
+      "task": "Convert every suite in internal/integration (DungeonCryptSuite first, then EncounterV2IntegrationSuite, CryptMonsterSeedRedisSuite, LobbyStartThenMoveSuite, LobbyV1alpha1IntegrationSuite) to a shared package-level RedisContainer via a new TestMain",
+      "status": "completed",
+      "artifacts": [
+        "internal/integration/main_test.go",
+        "internal/integration/dungeon_crypt_test.go",
+        "internal/integration/encounter_v2_test.go",
+        "internal/integration/lobby_crypt_monster_seed_test.go",
+        "internal/integration/lobby_start_then_move_test.go",
+        "internal/integration/lobby_v1alpha1_test.go"
+      ],
+      "commit": "4c3b519",
+      "notes": "go test ./internal/integration/ -v starts/terminates exactly 1 redis:7-alpine container for all 28 test methods across 5 suites (previously 1 per test method). All pass."
+    },
+    {
+      "id": "2026-07-23-003",
+      "task": "Convert internal/integration/character (separate Go test process) to its own shared RedisContainer + TestMain; move CharacterCreationSuite off SetupSuite-shared-everything onto per-test-fresh NewWithRedis",
+      "status": "completed",
+      "artifacts": [
+        "internal/integration/character/main_test.go",
+        "internal/integration/character/creation_test.go"
+      ],
+      "commit": "8289f52",
+      "notes": "This package's suite previously shared one full TestServer (gRPC server/repos/brokers) across all 7 tests via SetupSuite, relying solely on FlushRedis for isolation. Now every test gets its own fresh TestServer via NewWithRedis against the process's one shared container, matching the discipline used in internal/integration."
+    },
+    {
+      "id": "2026-07-23-004",
+      "task": "fmt/lint clean-up + full non-Docker verification (build/vet/fmt/imports/tidy/lint vs origin/main baseline, non-integration unit tests -race)",
+      "status": "completed",
+      "artifacts": [
+        "internal/integration/main_test.go",
+        "internal/integration/character/main_test.go",
+        "internal/integration/harness/lifecycle_internal_test.go"
+      ],
+      "commit": "531c380",
+      "notes": "golangci-lint run: 29 issues, byte-for-byte identical categories/counts vs a clean origin/main worktree (verified side by side) — zero new lint debt. go generate ./... mock drift (7 files) reproduced identically on origin/main, reverted as out-of-scope (same precedent as #689/PR#698). go test -race on all non-internal/integration packages: green."
+    },
+    {
+      "id": "2026-07-23-005",
+      "task": "Single authorized full run: go test -v -race ./internal/integration/...; docs update with measured before/after",
+      "status": "completed",
+      "artifacts": [
+        "docs/status.md",
+        "docs/how-to/run-integration-tests.md",
+        "docs/architecture/components/integration-test-harness.md"
+      ],
+      "commit": "935cbb7",
+      "notes": "Exactly one full run: exit 0, 37.4s wall clock (/usr/bin/time -v), exactly 3 redis:7-alpine containers created/terminated total (one per Go test process: internal/integration, internal/integration/character, internal/integration/harness — confirmed via TestMain STARTED/TERMINATED log lines and 3x 'Creating container for image redis:7-alpine'). docker ps confirmed zero leaked containers afterward. Goroutine-count spot check after 8 tests in internal/integration: 3 (stable, no broker/gRPC leak). Compares to the accepted ~283s/33-container baseline; this branch's own actual pre-#699 count would have measured 30 (character suite already amortized 7 tests onto 1 container via SetupSuite pre-#699 — noted honestly in docs/status.md rather than repeating the issue's 33 uncritically)."
+    }
+  ],
   "next_steps": [
-    "Write failing lifecycle ownership tests in internal/integration/harness (docker-free, injectable terminator seam)",
-    "Implement RedisContainer/StartRedis + NewWithRedis in harness package, keep New's owning behavior",
-    "Add TestMain to internal/integration (integration_test package) owning one shared container + lease guard",
-    "Convert DungeonCryptSuite first, verify targeted green, then EncounterV2/LobbyV1alpha1/LobbyStartThenMove",
-    "Add TestMain to internal/integration/character (separate process) owning its own shared container, convert CharacterCreationSuite",
-    "Full verification: build/vet/fmt/imports/tidy/lint/pre-commit/ci-check",
-    "Exactly one timed full go test ./internal/integration/... run, capture wall time + container count, compare to ~283s/33 baseline",
-    "Update docs/how-to/run-integration-tests.md and docs/architecture/components/integration-test-harness.md with new pattern + serialized-integration-runner rule",
-    "Push branch, open PR linking #699, self-review, address automated comments individually"
+    "Push branch, open PR linking #699 (ready, not draft)",
+    "Self-review diff, address any automated (Copilot) comments individually",
+    "Do not merge — awaiting explicit approval per repo workflow"
   ]
 }

--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -1,60 +1,19 @@
 {
-  "branch": "feat/689-deterministic-crypt-monsters",
-  "issues": ["#689"],
-  "goal": "First crypt learning-slice monster composition: exactly 1 deterministic entrance skeleton, 0 corridor monsters, exactly 1 deterministic non-wight skeleton-captain boss (rpg-toolkit#816), placed via toolkit spawn.FixedPositions and the existing tested regionEntryAnchor door-neighbor helper. Removes out-of-sight PositionOracle/search from this path. No goblins, no obstacle projection, no #694/#697 compact-spec consumption.",
-  "dependencies": {
-    "rpg-toolkit/encounter": "v0.38.0 (bumped from v0.35.0) - CryptDungeonParams (#826), RegionData.Hexes/RegionAt, SpaceData.Entrance",
-    "rpg-toolkit/rulebooks/dnd5e": "v0.68.0 (bumped from v0.67.0) - monsters.NewSkeleton, monsters.NewSkeletonCaptain (#816, non-wight)",
-    "rpg-toolkit/tools/spawn": "v0.3.0 (unchanged, already has FixedPositions from PR #770)"
-  },
-  "open_pr_coordination": {
-    "pr-697": "feat/694-consume-crypt-dungeon-params — do NOT base on or consume; #689 does not depend on #694 per the 2026-07-23 dependency-cycle correction. Anchor-resolution helper is written generically over []tkenc.DungeonRegionParams/[]tkenc.DungeonConnectorParams so it also works directly against tkenc.CryptDungeonParams's output as a forward-compat fixture, without importing anything from PR #697's branch."
-  },
-  "sessions": [
-    {
-      "id": "2026-07-23-001",
-      "task": "Verify toolkit dependency publication (encounter v0.38.0, rulebooks/dnd5e v0.68.0, tools/spawn v0.3.0) and bump go.mod with no local replace",
-      "status": "completed",
-      "artifacts": ["go.mod", "go.sum"],
-      "commit": "6812532",
-      "notes": "Confirmed via git merge-base --is-ancestor that PR #770 (spawn FixedPositions), PR #820 (#816 skeleton-captain), PR #826 (#819 CryptDungeonParams) are all ancestors of their respective published tags."
-    },
-    {
-      "id": "2026-07-23-002",
-      "task": "RED then GREEN: regionMonsterAnchor/buildMonsterSeedGroups/seedRegionMonsters; retire seedGoblins/regionOutOfSight/regionSpawnSpec; harden regionEntryAnchor after the CryptDungeonParams fixture's 1000-seed sweep caught a real 40/1000 wall-collision gap",
-      "status": "completed",
-      "artifacts": [
-        "internal/orchestrators/lobby/crypt_monster_seed.go",
-        "internal/orchestrators/lobby/crypt_monster_seed_internal_test.go",
-        "internal/orchestrators/lobby/crypt_dungeon_params_fixture_internal_test.go",
-        "internal/orchestrators/lobby/start_encounter.go",
-        "internal/orchestrators/lobby/start_encounter_test.go",
-        "internal/orchestrators/lobby/region_entry_anchor_internal_test.go"
-      ],
-      "commit": "58270a6",
-      "notes": "Anchor-safety finding: regionEntryAnchor generalized to the entrance's own outgoing door landed on a real interior wall 40/1000 seeds against rpg-toolkit's own CryptDungeonParams dimensions (perception.HexNeighbors' fixed direction order doesn't prioritize the required-path row). Hardened with a room.CanPlaceEntity check per candidate (existing toolkit-exposed validity query, not new geometry) rather than filing a NEEDS_CONTEXT toolkit-seam issue — re-verified 0/1000 (CryptDungeonParams dims) and 0/4000 (dungeonSpec dims x party 1..4) after the fix. CAUTION for future sessions: scripts/ci-checks.sh runs `git checkout -- .` on ANY uncommitted diff when go generate reports drift (even unrelated mock drift) — commit work before running it."
-    },
-    {
-      "id": "2026-07-23-003",
-      "task": "Real-Redis integration coverage + update the existing dungeon_crypt_test.go gate for the new composition",
-      "status": "completed",
-      "artifacts": [
-        "internal/integration/lobby_crypt_monster_seed_test.go",
-        "internal/integration/dungeon_crypt_test.go"
-      ],
-      "commit": "fcb2bea",
-      "notes": "TestCryptMonsterSeedRedisSuite (3/3), TestDungeonCryptSuite (4/4), TestLobbyV1alpha1IntegrationSuite (4/4), TestLobbyStartThenMoveSuite (1/1) all pass against real Redis + Docker testcontainers. Full-repo `go test ./internal/integration/...` (every suite) times out in this sandbox purely from serial Docker container teardown latency (~10-20s/container, environmental, reproduces identically on unrelated pre-existing suites) — verified the #689-relevant suites individually instead."
-    },
-    {
-      "id": "2026-07-23-004",
-      "task": "Full verification (build/vet/race/lint-vs-main-baseline/fmt/tidy) + docs update",
-      "status": "completed",
-      "artifacts": ["docs/status.md", "docs/architecture/components/lobby-service.md"],
-      "commit": "0761399",
-      "notes": "golangci-lint: 29 issues, IDENTICAL categories/counts on this branch and on a fresh origin/main worktree — zero new issues. go generate ./... surfaces pre-existing mockgen-version import-ordering drift in 7 unrelated mock files, reproduced identically on origin/main — reverted (out of scope, not introduced here)."
-    }
-  ],
+  "branch": "infra/699-shared-integration-redis",
+  "issues": ["#699"],
+  "goal": "Split Redis container lifecycle ownership from per-test TestServer/service wiring in internal/integration/harness. One shared Redis testcontainer per test process (internal/integration and internal/integration/character each own one), started once and terminated once, while every test still gets fresh gRPC/repos/brokers/clients and a FlushRedis before it runs. Preserve standalone harness.New owning behavior for callers outside the package fixture.",
+  "dependencies": {},
+  "open_pr_coordination": {},
+  "sessions": [],
   "next_steps": [
-    "PR open, not merged — awaiting review per task instructions"
+    "Write failing lifecycle ownership tests in internal/integration/harness (docker-free, injectable terminator seam)",
+    "Implement RedisContainer/StartRedis + NewWithRedis in harness package, keep New's owning behavior",
+    "Add TestMain to internal/integration (integration_test package) owning one shared container + lease guard",
+    "Convert DungeonCryptSuite first, verify targeted green, then EncounterV2/LobbyV1alpha1/LobbyStartThenMove",
+    "Add TestMain to internal/integration/character (separate process) owning its own shared container, convert CharacterCreationSuite",
+    "Full verification: build/vet/fmt/imports/tidy/lint/pre-commit/ci-check",
+    "Exactly one timed full go test ./internal/integration/... run, capture wall time + container count, compare to ~283s/33 baseline",
+    "Update docs/how-to/run-integration-tests.md and docs/architecture/components/integration-test-harness.md with new pattern + serialized-integration-runner rule",
+    "Push branch, open PR linking #699, self-review, address automated comments individually"
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -4,71 +4,71 @@
       "id": "owned-close-terminates-once",
       "feature": "redis-container-lifecycle-ownership",
       "prompt": "Construct a TestServer via harness.New (or the underlying ownership seam) with a fake Redis container terminator. Call Close(). Verify Terminate was called exactly once.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "borrowed-close-never-terminates",
       "feature": "redis-container-lifecycle-ownership",
       "prompt": "Construct a TestServer via harness.NewWithRedis against an already-running Redis address (non-owning). Call Close(). Verify the shared container's Terminate is never called.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "shared-fixture-starts-terminates-once",
       "feature": "redis-container-lifecycle-ownership",
       "prompt": "Call harness.StartRedis once, then Terminate it twice. Verify the underlying container Terminate is invoked exactly once (idempotent double-terminate guard).",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "per-test-resources-fresh",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Call harness.NewWithRedis twice against the same shared Redis address. Verify the two TestServer instances have distinct gRPC servers, bufconn listeners, repos, and brokers (not shared).",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "state-isolation-flush-between-tests",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run two sequential tests against the shared container in internal/integration (e.g. DungeonCryptSuite methods). Verify no leftover Redis keys/state from the prior test are visible in the next.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "broker-grpc-cleanup-preserved",
       "feature": "shared-redis-integration-fixture",
       "prompt": "After each converted suite's TearDownTest runs, verify BrokerV2/LobbyBroker Close() still executes for that test's per-test resources (no goroutine/listener leak), independent of the shared Redis container's lifetime.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "lease-guard-serializes-flush",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Acquire the shared fixture's lease from two goroutines concurrently. Verify the second acquisition blocks until the first releases (no concurrent FlushRedis race is possible even if a suite method were mistakenly parallelized).",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "targeted-suites-green",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run -run targeted subtests for DungeonCryptSuite, EncounterV2IntegrationSuite, LobbyV1alpha1IntegrationSuite, LobbyStartThenMoveSuite, and CharacterCreationSuite after conversion. Verify all pass.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "race-clean",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run go test -race ./internal/integration/... (or targeted -race per suite during development). Verify no race detected around the shared container/client/lease.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     },
     {
       "id": "full-run-container-count-and-timing",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run go test ./internal/integration/... exactly once post-fix. Verify (via instrumentation/log evidence) the exact number of Redis containers started/terminated across all test processes under this path, and record wall-clock time against the ~283s/33-container baseline.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-23"
     }
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -4,6 +4,7 @@
       "id": "owned-close-terminates-once",
       "feature": "redis-container-lifecycle-ownership",
       "prompt": "Construct a TestServer via harness.New (or the underlying ownership seam) with a fake Redis container terminator. Call Close(). Verify Terminate was called exactly once.",
+      "test_ref": "internal/integration/harness/lifecycle_internal_test.go:TestServer_Close_OwnedContainer_TerminatesOnce",
       "passes": true,
       "last_checked": "2026-07-23"
     },
@@ -11,6 +12,7 @@
       "id": "borrowed-close-never-terminates",
       "feature": "redis-container-lifecycle-ownership",
       "prompt": "Construct a TestServer via harness.NewWithRedis against an already-running Redis address (non-owning). Call Close(). Verify the shared container's Terminate is never called.",
+      "test_ref": "internal/integration/harness/lifecycle_internal_test.go:TestServer_Close_BorrowedContainer_NeverTerminates",
       "passes": true,
       "last_checked": "2026-07-23"
     },
@@ -18,27 +20,33 @@
       "id": "shared-fixture-starts-terminates-once",
       "feature": "redis-container-lifecycle-ownership",
       "prompt": "Call harness.StartRedis once, then Terminate it twice. Verify the underlying container Terminate is invoked exactly once (idempotent double-terminate guard).",
+      "test_ref": "internal/integration/harness/lifecycle_internal_test.go:TestRedisContainer_TerminateIsIdempotent",
       "passes": true,
       "last_checked": "2026-07-23"
     },
     {
       "id": "per-test-resources-fresh",
       "feature": "shared-redis-integration-fixture",
-      "prompt": "Call harness.NewWithRedis twice against the same shared Redis address. Verify the two TestServer instances have distinct gRPC servers, bufconn listeners, repos, and brokers (not shared).",
+      "prompt": "Call harness.NewWithRedis twice against the same shared Redis address. Verify the two TestServer instances have distinct gRPC servers, in-memory encounter/lobby repos, and brokers (not shared).",
+      "test_ref": "internal/integration/shared_fixture_regression_test.go:TestSharedRedisFixture_PerTestFreshnessAndStateIsolation/per_test_application_freshness",
       "passes": true,
-      "last_checked": "2026-07-23"
+      "last_checked": "2026-07-23",
+      "notes": "Added 2026-07-23 to close an independent-review gap: prior evidence for this was manual/inline reasoning, not a durable test. Characterization test (passed immediately) — pins NewWithRedis's existing fresh-wiring behavior rather than fixing a bug. Asserts distinct gRPC server (new TestServer.GRPCServer() test-only seam), BrokerV2, LobbyBroker, EncRepoV2, LobbyRepo, CharacterRepo via pointer-address comparison."
     },
     {
       "id": "state-isolation-flush-between-tests",
       "feature": "shared-redis-integration-fixture",
-      "prompt": "Run two sequential tests against the shared container in internal/integration (e.g. DungeonCryptSuite methods). Verify no leftover Redis keys/state from the prior test are visible in the next.",
+      "prompt": "Write a fixed key through a first NewWithRedis instance against the shared container, close it, run the exact FlushRedis sequence SetupTest uses when creating a second instance, and verify the same fixed key is absent.",
+      "test_ref": "internal/integration/shared_fixture_regression_test.go:TestSharedRedisFixture_PerTestFreshnessAndStateIsolation/shared_redis_state_isolation_via_flush",
       "passes": true,
-      "last_checked": "2026-07-23"
+      "last_checked": "2026-07-23",
+      "notes": "Added 2026-07-23 to close an independent-review gap: prior evidence for this was manual/inline reasoning (DungeonCryptSuite passing), not a durable test with a fixed key immune to ID-collision false negatives. Mutation-tested: temporarily skipping the second cycle's FlushRedis call reproduced 'Should be zero, but was 1' (RED), then was reverted (GREEN)."
     },
     {
       "id": "broker-grpc-cleanup-preserved",
       "feature": "shared-redis-integration-fixture",
       "prompt": "After each converted suite's TearDownTest runs, verify BrokerV2/LobbyBroker Close() still executes for that test's per-test resources (no goroutine/listener leak), independent of the shared Redis container's lifetime.",
+      "test_ref": "manual: goroutine-count spot check (runtime.NumGoroutine, stable at 3 after 8 tests in internal/integration)",
       "passes": true,
       "last_checked": "2026-07-23"
     },
@@ -46,6 +54,7 @@
       "id": "lease-guard-serializes-flush",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Acquire the shared fixture's lease from two goroutines concurrently. Verify the second acquisition blocks until the first releases (no concurrent FlushRedis race is possible even if a suite method were mistakenly parallelized).",
+      "test_ref": "internal/integration/harness/lifecycle_internal_test.go:TestRedisContainer_LeaseSerializesAccess",
       "passes": true,
       "last_checked": "2026-07-23"
     },
@@ -53,6 +62,7 @@
       "id": "targeted-suites-green",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run -run targeted subtests for DungeonCryptSuite, EncounterV2IntegrationSuite, LobbyV1alpha1IntegrationSuite, LobbyStartThenMoveSuite, and CharacterCreationSuite after conversion. Verify all pass.",
+      "test_ref": "internal/integration/*_test.go, internal/integration/character/creation_test.go (existing suites)",
       "passes": true,
       "last_checked": "2026-07-23"
     },
@@ -60,6 +70,7 @@
       "id": "race-clean",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run go test -race ./internal/integration/... (or targeted -race per suite during development). Verify no race detected around the shared container/client/lease.",
+      "test_ref": "targeted -race runs per package during development; full-package -race left to CI (see full-run-container-count-and-timing)",
       "passes": true,
       "last_checked": "2026-07-23"
     },
@@ -67,6 +78,7 @@
       "id": "full-run-container-count-and-timing",
       "feature": "shared-redis-integration-fixture",
       "prompt": "Run go test ./internal/integration/... exactly once post-fix. Verify (via instrumentation/log evidence) the exact number of Redis containers started/terminated across all test processes under this path, and record wall-clock time against the ~283s/33-container baseline.",
+      "test_ref": "one local run (37.4s, 3 containers, PR #700 initial evidence); subsequent full-package confirmation deferred to CI per 2026-07-23 follow-up instructions (no repeated local full runs)",
       "passes": true,
       "last_checked": "2026-07-23"
     }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -1,81 +1,74 @@
 {
   "tests": [
     {
-      "id": "entrance-exactly-one-skeleton",
-      "feature": "crypt-monster-composition",
-      "prompt": "Start a crypt encounter. Verify exactly one monster (ref dnd5e:monsters:skeleton) is seeded in the entrance region.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "owned-close-terminates-once",
+      "feature": "redis-container-lifecycle-ownership",
+      "prompt": "Construct a TestServer via harness.New (or the underlying ownership seam) with a fake Redis container terminator. Call Close(). Verify Terminate was called exactly once.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "corridor-zero-monsters",
-      "feature": "crypt-monster-composition",
-      "prompt": "Start a crypt encounter. Verify zero monsters are seeded in the corridor region.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "borrowed-close-never-terminates",
+      "feature": "redis-container-lifecycle-ownership",
+      "prompt": "Construct a TestServer via harness.NewWithRedis against an already-running Redis address (non-owning). Call Close(). Verify the shared container's Terminate is never called.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "boss-exactly-one-skeleton-captain",
-      "feature": "crypt-monster-composition",
-      "prompt": "Start a crypt encounter. Verify exactly one monster (ref dnd5e:monsters:skeleton-captain, non-wight rpg-toolkit#816) is seeded in the boss region.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "shared-fixture-starts-terminates-once",
+      "feature": "redis-container-lifecycle-ownership",
+      "prompt": "Call harness.StartRedis once, then Terminate it twice. Verify the underlying container Terminate is invoked exactly once (idempotent double-terminate guard).",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "deterministic-seed-byte-identical",
-      "feature": "crypt-monster-determinism",
-      "prompt": "Start two crypt encounters with the same explicit RandomSeed. Verify monster positions are byte-identical.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "per-test-resources-fresh",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "Call harness.NewWithRedis twice against the same shared Redis address. Verify the two TestServer instances have distinct gRPC servers, bufconn listeners, repos, and brokers (not shared).",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "party-size-invariant",
-      "feature": "crypt-monster-determinism",
-      "prompt": "Start crypt encounters with the same seed and party sizes 1, 2, 3, 4. Verify monster positions are identical regardless of party size.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "state-isolation-flush-between-tests",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "Run two sequential tests against the shared container in internal/integration (e.g. DungeonCryptSuite methods). Verify no leftover Redis keys/state from the prior test are visible in the next.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "seed-sweep-zero-errors",
-      "feature": "crypt-monster-determinism",
-      "prompt": "Sweep seeds 1..1000 x party sizes 1..4. Verify zero placement errors across the full matrix.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "broker-grpc-cleanup-preserved",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "After each converted suite's TearDownTest runs, verify BrokerV2/LobbyBroker Close() still executes for that test's per-test resources (no goroutine/listener leak), independent of the shared Redis container's lifetime.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "no-position-oracle-no-search",
-      "feature": "crypt-monster-no-search",
-      "prompt": "Verify the crypt monster seeding EntityGroups carry FixedPositions with len==Quantity and PositionOracle==nil \u2014 no out-of-sight search/retry path is exercised.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "lease-guard-serializes-flush",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "Acquire the shared fixture's lease from two goroutines concurrently. Verify the second acquisition blocks until the first releases (no concurrent FlushRedis race is possible even if a suite method were mistakenly parallelized).",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "anchors-walkable-non-obstacle",
-      "feature": "crypt-monster-anchors",
-      "prompt": "Verify both the entrance and boss anchors resolve to positions Room.CanPlaceEntity accepts (not walls, not out of bounds) and are tagged into their expected region via RegionAt.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "targeted-suites-green",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "Run -run targeted subtests for DungeonCryptSuite, EncounterV2IntegrationSuite, LobbyV1alpha1IntegrationSuite, LobbyStartThenMoveSuite, and CharacterCreationSuite after conversion. Verify all pass.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "boss-concealed-by-door-not-search",
-      "feature": "crypt-monster-concealment",
-      "prompt": "Verify the boss anchor is not visible (perception.CanSeeAt) from the entrance anchor while the boss door is closed, using real LoS/wall geometry \u2014 not a placement-search predicate.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "race-clean",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "Run go test -race ./internal/integration/... (or targeted -race per suite during development). Verify no race detected around the shared container/client/lease.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "compact-cryptdungeonparams-fixture",
-      "feature": "crypt-monster-anchors",
-      "prompt": "Call tkenc.CryptDungeonParams directly (not through rpg-api's dungeonSpec) and apply the same production anchor-resolution helper. Verify it composes correctly against the toolkit's own canonical region/door/path shape, independent of PR #697.",
-      "passes": true,
-      "last_checked": "2026-07-23"
-    },
-    {
-      "id": "real-redis-integration-determinism",
-      "feature": "crypt-monster-determinism",
-      "prompt": "Against a real Redis-backed lobby+encounter repo (testcontainers), call StartEncounter twice with the same explicit seed. Verify byte-identical monster positions end to end.",
-      "passes": true,
-      "last_checked": "2026-07-23"
+      "id": "full-run-container-count-and-timing",
+      "feature": "shared-redis-integration-fixture",
+      "prompt": "Run go test ./internal/integration/... exactly once post-fix. Verify (via instrumentation/log evidence) the exact number of Redis containers started/terminated across all test processes under this path, and record wall-clock time against the ~283s/33-container baseline.",
+      "passes": false,
+      "last_checked": null
     }
   ]
 }

--- a/docs/architecture/components/integration-test-harness.md
+++ b/docs/architecture/components/integration-test-harness.md
@@ -1,13 +1,25 @@
 ---
 name: integration test harness
 description: Full-stack test server wiring real Redis, in-process gRPC, and testcontainers
-updated: 2026-07-13
+updated: 2026-07-23
 confidence: high — verified by reading harness.go and remaining integration test files
 ---
 
 # integration test harness
 
 The integration test harness (`internal/integration/harness/`) is the most valuable test asset in rpg-api. It wires the full stack — real Redis via testcontainers, real orchestrators and repositories, in-process gRPC via bufconn — and exercises complete game flows via proto-level client calls.
+
+**Updated 2026-07-23 (rpg-api#699):** container **ownership** is now split
+from per-test **service wiring**. `harness.New` still starts and owns its
+own dedicated Redis container (unchanged behavior for standalone callers).
+`harness.NewWithRedis` wires the identical gRPC server/repos/brokers/
+clients against an already-running Redis address without starting or
+owning a container. Every suite in `internal/integration` and
+`internal/integration/character` now shares one `harness.RedisContainer`
+per test process (started/terminated once in that package's `TestMain`)
+instead of starting a fresh container per test method — see
+`docs/how-to/run-integration-tests.md` for the full pattern and the
+one-Docker-runner-at-a-time rule this depends on.
 
 **Updated 2026-07-13 (rpg-api#642):** the v1-only `internal/integration/encounter/`
 suite (10 files: class-specific combat tests, `open_door_test.go`,
@@ -22,7 +34,10 @@ construction) are removed. Encounter coverage now lives entirely in
 
 | File | Purpose |
 |---|---|
-| `integration/harness/harness.go` | TestServer setup and teardown |
+| `integration/harness/harness.go` | TestServer wiring (`New`, `NewWithRedis`, `Close`) |
+| `integration/harness/redis_container.go` | `RedisContainer` shared-fixture: `StartRedis`, `Terminate`, `Lease` (rpg-api#699) |
+| `integration/main_test.go` | `TestMain` owning the one shared container for this package's process |
+| `integration/character/main_test.go` | Same, for the separate `internal/integration/character` process |
 | `integration/character/` | Character integration tests |
 | `integration/encounter_v2_test.go` | v1alpha2 encounter service tests |
 | `integration/lobby_v1alpha1_test.go` | LobbyService tests, incl. combat-entry flows |
@@ -30,8 +45,14 @@ construction) are removed. Encounter coverage now lives entirely in
 ## Architecture
 
 ```
-TestServer (harness.go)
-    ├── testcontainers Redis  ← real Redis process in Docker
+RedisContainer (redis_container.go)         ← package/process-level fixture
+    └── testcontainers Redis                 ← one real Redis process in Docker,
+                                                started once by TestMain, terminated once
+
+TestServer (harness.go), one fresh instance per test
+    ├── Redis client (New: owns a container it started itself;
+    │                 NewWithRedis: borrows a RedisContainer's Addr,
+    │                 owns only its own client connection)
     ├── bufconn               ← in-process gRPC (no network)
     ├── real orchestrators    ← same code as production (character, lobby)
     ├── real repositories     ← character (Redis), encounters/v2 (in-memory), lobby (in-memory)
@@ -42,29 +63,59 @@ TestServer (harness.go)
 
 ## TestServer lifecycle
 
+Standalone (owns its own container):
+
 ```go
-// Setup (per test file or suite)
 ctx := context.Background()
 server, err := harness.New(ctx, harness.DefaultConfig())
 defer server.Close()
 
-// Use clients
-resp, err := server.EncounterClient.CreateEncounter(ctx, &proto.CreateEncounterRequest{...})
+resp, err := server.EncounterClientV2.CreateEncounter(ctx, &proto.CreateEncounterRequest{...})
 ```
 
-`Close()` terminates the gRPC server and the Redis container.
+`Close()` terminates the gRPC server and, because this `TestServer` owns
+one, its Redis container.
+
+Shared-fixture (the pattern every suite in `internal/integration` and
+`internal/integration/character` uses — see that package's `TestMain`):
+
+```go
+// TestMain, once per process:
+sharedRedis, _ = harness.StartRedis(ctx)
+defer sharedRedis.Terminate(ctx) // or an explicit call after m.Run()
+
+// SetupTest, once per test:
+release := sharedRedis.Lease()
+srv, _ := harness.NewWithRedis(ctx, cfg, sharedRedis.Addr)
+srv.FlushRedis(ctx)
+
+// TearDownTest, once per test:
+srv.Close()   // closes gRPC server, brokers, this test's own Redis client —
+              // never terminates sharedRedis's container
+release()
+```
 
 ## Known gaps
+
+### ~~testcontainers startup time~~ FIXED (rpg-api#699, 2026-07-23)
+
+Previously: each test suite that created a new `TestServer` via `harness.
+New` started a fresh Redis container, adding ~2-5s of container create/
+health-check/teardown churn per test *method* (not just per suite) for
+every suite using `SetupTest` rather than `SetupSuite`. A full `go test ./internal/integration/...` run measured ~283s this way
+(accepted baseline, 33 container lifecycles). Fixed by splitting
+container ownership (`RedisContainer`) from per-test service wiring
+(`NewWithRedis`): a post-fix `go test -v -race ./internal/integration/...`
+run measured 37.4s wall clock and started/terminated exactly 3 containers
+total (one per Go test process) — see
+`docs/how-to/run-integration-tests.md` for the measured before/after and
+the exact per-process container count.
 
 ### ~~Round 2 tests not yet green on main~~ MOOT (rpg-api#642, 2026-07-13)
 
 The `open_door_test.go` and `stream_entity_state_test.go` this section
 described were part of the deleted v1-only `internal/integration/encounter/`
 suite. #468 and its stacked PRs are moot — see `docs/status.md`.
-
-### testcontainers startup time
-
-Each test suite that creates a new `TestServer` starts a fresh Redis container. Container startup adds ~2-5 seconds per test suite. Tests sharing a harness via `SetupSuite` amortize this cost; tests that create a harness per test case do not.
 
 ### v1alpha2 EncounterService character-store wiring (fixed rpg-api#634, 2026-07-11)
 

--- a/docs/architecture/components/integration-test-harness.md
+++ b/docs/architecture/components/integration-test-harness.md
@@ -37,6 +37,7 @@ construction) are removed. Encounter coverage now lives entirely in
 | `integration/harness/harness.go` | TestServer wiring (`New`, `NewWithRedis`, `Close`) |
 | `integration/harness/redis_container.go` | `RedisContainer` shared-fixture: `StartRedis`, `Terminate`, `Lease` (rpg-api#699) |
 | `integration/main_test.go` | `TestMain` owning the one shared container for this package's process |
+| `integration/shared_fixture_regression_test.go` | Regression coverage that the shared fixture actually delivers per-test freshness + Redis state isolation (rpg-api#699) |
 | `integration/character/main_test.go` | Same, for the separate `internal/integration/character` process |
 | `integration/character/` | Character integration tests |
 | `integration/encounter_v2_test.go` | v1alpha2 encounter service tests |

--- a/docs/how-to/run-integration-tests.md
+++ b/docs/how-to/run-integration-tests.md
@@ -79,8 +79,18 @@ these suites are still expected to run serially.
 Because these are three separate processes, `go test ./internal/integration/...`
 starts and terminates **3** Redis containers total (one per process), not
 1 — a single container object cannot be shared across OS process
-boundaries. This is down from one container **per test method** (36
-across all three packages) before #699.
+boundaries.
+
+There are 36 test methods total across the three packages (28 in
+`internal/integration`, 7 in `internal/integration/character`, 1 in
+`internal/integration/harness`), but the pre-#699 container count was
+**not** "one per test method" uniformly: `internal/integration`'s 28 test
+methods each started/terminated their own container (28 containers), but
+`internal/integration/character`'s `CharacterCreationSuite` already used
+`SetupSuite` (one `TestServer` shared across its 7 tests, 1 container) and
+`internal/integration/harness` has always had exactly 1 test (1
+container). The actual pre-#699 total was **30** containers, not 36 — down
+to the 3 above after this change.
 
 ## What the harness wires
 

--- a/docs/how-to/run-integration-tests.md
+++ b/docs/how-to/run-integration-tests.md
@@ -1,7 +1,7 @@
 ---
 name: run integration tests
 description: How to run the integration test harness — requires Docker for testcontainers
-updated: 2026-07-13
+updated: 2026-07-23
 ---
 
 # How to run integration tests
@@ -13,14 +13,27 @@ Integration tests live in `internal/integration/`. They use `testcontainers-go` 
 - Docker running (`docker ps`)
 - Go 1.24.1+
 
+## Only one Docker-backed integration runner at a time
+
+**Rule (rpg-api#699):** if more than one agent/worktree/session is working
+against this repo's Docker daemon, only ONE of them should be exercising
+`internal/integration/...` at a time. Two runners racing against the same
+Docker daemon compete for port allocation and disk I/O and will confound
+each other's timing evidence — the same daemon-contention effect that
+originally inflated container churn in #699's baseline measurement. Use
+targeted `-run <TestName>` while iterating (see below); reserve a full
+`go test ./internal/integration/...` run for when you actually need the
+whole-package signal, and don't run it back-to-back with another agent's
+integration run.
+
 ## Run all tests (unit + integration)
 
 ```bash
-cd /home/kirk/personal/rpg-api
+cd rpg-api
 go test -v -race ./...
 ```
 
-This runs everything. Integration tests are not build-tagged, so they run with the full test suite. Each suite that creates a `TestServer` will start a Redis container.
+This runs everything. Integration tests are not build-tagged, so they run with the full test suite.
 
 ## Run integration tests only
 
@@ -41,14 +54,56 @@ suite (which this section used to point at, including `TestOpenDoor` and
 exercised. Encounter coverage now lives in `internal/integration/
 encounter_v2_test.go` and `internal/integration/lobby_v1alpha1_test.go`.
 
+## Redis container lifecycle (rpg-api#699)
+
+Each of the three Go test binaries under `internal/integration/...` is its
+own OS process, and each owns exactly **one** shared Redis testcontainer for
+its process's whole run — not one container per test method:
+
+| Package (process) | Suites | Container ownership |
+|---|---|---|
+| `internal/integration` | `DungeonCryptSuite`, `EncounterV2IntegrationSuite`, `CryptMonsterSeedRedisSuite`, `LobbyStartThenMoveSuite`, `LobbyV1alpha1IntegrationSuite` (28 test methods) | One shared container, started/terminated once in `main_test.go`'s `TestMain` |
+| `internal/integration/character` | `CharacterCreationSuite` (7 test methods) | One shared container, started/terminated once in its own `main_test.go`'s `TestMain` |
+| `internal/integration/harness` | `TestHarness_StartsAndConnects` (1 test method, standalone `harness.New` smoke test) | Its own single container — already minimal since it's one test |
+
+Each package's `TestMain` calls `harness.StartRedis(ctx)` once before
+`m.Run()` and `(*harness.RedisContainer).Terminate(ctx)` once after —
+**do not** add a second `harness.New`/`StartRedis` call inside a suite in
+`internal/integration` or `internal/integration/character`; every suite's
+`SetupTest` should call `harness.NewWithRedis(ctx, cfg, sharedRedis.Addr)`
+against the package's `sharedRedis` var instead. `sharedRedis.Lease()` /
+the returned `release()` in `SetupTest`/`TearDownTest` is a
+belt-and-suspenders guard, not a requirement to add `t.Parallel()` —
+these suites are still expected to run serially.
+
+Because these are three separate processes, `go test ./internal/integration/...`
+starts and terminates **3** Redis containers total (one per process), not
+1 — a single container object cannot be shared across OS process
+boundaries. This is down from one container **per test method** (36
+across all three packages) before #699.
+
 ## What the harness wires
 
 `internal/integration/harness/harness.go` builds a `TestServer` with:
-- Real Redis container (via testcontainers)
+- Real Redis client (via testcontainers, owned or borrowed — see below)
 - In-process gRPC server via `bufconn` (no network overhead)
 - Real orchestrators (character, lobby), real repositories
 - The v2 encounter path's `tkenc.Broker` for live event fan-out
 - `DevMode: true` — uses `Dev <player_id>` auth
+
+Two constructors, split by **container ownership** (rpg-api#699):
+- `harness.New(ctx, cfg)` — starts its own dedicated Redis container and
+  owns it; `Close()` terminates that container. Use this for a standalone
+  test/script that isn't part of a shared-fixture package (e.g.
+  `internal/integration/harness/harness_test.go`'s own smoke test).
+- `harness.NewWithRedis(ctx, cfg, redisAddr)` — wires the exact same
+  gRPC server/repos/brokers/clients against an already-running Redis
+  address instead of starting a container; `Close()` closes this
+  TestServer's own Redis client connection but never terminates the
+  container backing `redisAddr` — that's the caller's (a package
+  `TestMain`'s) responsibility via `harness.StartRedis`/`RedisContainer.
+  Terminate`. This is what every suite in `internal/integration` and
+  `internal/integration/character` uses.
 
 Exported on `TestServer` (updated 2026-07-13, rpg-api#642 — `EncounterClient`
 and `EncounterPublisher` are gone with the v1alpha1 stack):
@@ -60,6 +115,22 @@ and `EncounterPublisher` are gone with the v1alpha1 stack):
 - `BrokerV2` / `EncRepoV2` — for seeding/inspecting v2 encounter state directly
 
 ## Writing new integration tests
+
+Adding a test method to an existing suite in `internal/integration` or
+`internal/integration/character`? Nothing to do beyond writing the test —
+`SetupTest` already leases the package's shared container and gives you a
+fresh `TestServer`.
+
+Adding a brand-new suite to one of those packages? Follow the existing
+pattern (e.g. `internal/integration/dungeon_crypt_test.go`'s
+`SetupTest`/`TearDownTest`): lease `sharedRedis`, call
+`harness.NewWithRedis(ctx, cfg, sharedRedis.Addr)`, `FlushRedis`, and
+release the lease in `TearDownTest`. Do not call `harness.New` or
+`harness.StartRedis` from inside a suite in these packages — that would
+reintroduce one container per test method.
+
+A standalone test outside those packages (or a throwaway script) can still
+use the simple owning constructor:
 
 ```go
 func TestMyScenario(t *testing.T) {
@@ -83,7 +154,19 @@ seeding a party and driving a fight end-to-end via `LobbyClient` +
 
 ## Test timing
 
-Container startup is the bottleneck — typically 2–5 seconds per test suite. Tests that use `SetupSuite` share one container per suite (fast). Tests that create a harness per test case pay startup cost per test.
+Before rpg-api#699, container create/health-check/teardown churn (one
+Redis container per test method) dominated wall time: a full
+`go test ./internal/integration/...` run measured ~283s across 33
+container lifecycles (accepted baseline, #699's issue description). After
+#699 (one shared container per process instead of per test method), a
+`go test -v -race ./internal/integration/...` run measured **37.4s wall
+clock** (`/usr/bin/time -v`, the single post-fix run) and started/
+terminated exactly **3** Redis containers total — one per Go test
+process (`internal/integration`, `internal/integration/character`,
+`internal/integration/harness`), confirmed by each process's `TestMain`
+STARTED/TERMINATED log lines and by counting `🐳 Creating container for
+image redis:7-alpine` occurrences in the run's output. See
+`docs/status.md` for the PR's full before/after writeup.
 
 ## Known gaps
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,7 +2,7 @@
 name: rpg-api status
 description: Where we are with rpg-api — active work, paused, known rough edges, per-subsystem confidence
 updated: 2026-07-23
-confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite; #656 movement-truncation fix verified against an isolated toolkit-level repro, a new RPC-level regression test (10x -race), and the full suite; #663 AbandonEncounter + combat pockets + rage-at-seating verified against passing unit/integration/-race full suite plus a live playtest against the real game route; #676 The Dungeon wave 2 Slice 2 (api leg) verified against passing unit tests + a new 3-test integration gate suite (8x stress-run, entropy-seeded layouts); #680 equipment on the wire verified against passing unit + integration suite (real AC, occupancy, non-equipment-field preservation) + adversarial-gate fixes + full CI green against published deps; #687 region/theme wire projection verified against passing unit (-race) + a real-RPC integration gate proving connect-time AND incremental-reveal zone_id/zones/theme projection against the real Redis harness, full `go test`/`golangci-lint` green against the published `rpg-api-protos` generated branch + `rpg-toolkit/encounter v0.35.0`; #688 N-region dungeon by key verified against passing unit (-race, 15x stress-run) + a rewritten 3-test integration gate suite against the real Redis harness, full `go test`/`golangci-lint` green against published `rpg-toolkit/encounter v0.35.0`; #689 deterministic crypt monster composition verified against passing unit (-race, 1000-seed x 4-party-size zero-error matrix, against BOTH this package's dungeonSpec and the toolkit's own CryptDungeonParams dimensions) + real-Redis integration (composition + seed-determinism + party-size-invariance) + the updated dungeon_crypt_test.go gate, full `go test`/`golangci-lint` green against published `rpg-toolkit/encounter v0.38.0` + `rulebooks/dnd5e v0.68.0`, zero new lint issues versus main
+confidence: high — Wave 2 Monk entries verified against passing integration tests; #636 entry verified against passing unit + integration tests; #642 v1alpha1 encounter stack deletion verified against passing build/vet/test/lint; #644 The Dungeon wave 1 (api) verified against passing unit + stress-run (50x) integration tests; #650 toolkit seam adoption (InitiativeRolled event + room-aware spawn) verified against passing unit/integration/-race full suite; #651 ActiveConditions projection verified against passing unit + integration (10x -race) + full suite; #656 movement-truncation fix verified against an isolated toolkit-level repro, a new RPC-level regression test (10x -race), and the full suite; #663 AbandonEncounter + combat pockets + rage-at-seating verified against passing unit/integration/-race full suite plus a live playtest against the real game route; #676 The Dungeon wave 2 Slice 2 (api leg) verified against passing unit tests + a new 3-test integration gate suite (8x stress-run, entropy-seeded layouts); #680 equipment on the wire verified against passing unit + integration suite (real AC, occupancy, non-equipment-field preservation) + adversarial-gate fixes + full CI green against published deps; #687 region/theme wire projection verified against passing unit (-race) + a real-RPC integration gate proving connect-time AND incremental-reveal zone_id/zones/theme projection against the real Redis harness, full `go test`/`golangci-lint` green against the published `rpg-api-protos` generated branch + `rpg-toolkit/encounter v0.35.0`; #688 N-region dungeon by key verified against passing unit (-race, 15x stress-run) + a rewritten 3-test integration gate suite against the real Redis harness, full `go test`/`golangci-lint` green against published `rpg-toolkit/encounter v0.35.0`; #689 deterministic crypt monster composition verified against passing unit (-race, 1000-seed x 4-party-size zero-error matrix, against BOTH this package's dungeonSpec and the toolkit's own CryptDungeonParams dimensions) + real-Redis integration (composition + seed-determinism + party-size-invariance) + the updated dungeon_crypt_test.go gate, full `go test`/`golangci-lint` green against published `rpg-toolkit/encounter v0.38.0` + `rulebooks/dnd5e v0.68.0`, zero new lint issues versus main; #699 shared-Redis integration harness verified against docker-free RED/GREEN/mutation lifecycle-ownership tests + a single post-fix `go test -race ./internal/integration/...` full run (37.4s, 3 containers total vs. the ~283s/33-container accepted baseline), zero new lint issues versus main
 ---
 
 # rpg-api: Where We Are
@@ -10,6 +10,42 @@ confidence: high — Wave 2 Monk entries verified against passing integration te
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**Shared Redis integration-harness container (rpg-api#699, 2026-07-23)** —
+Split Redis testcontainer **ownership** from per-test **service wiring** in
+`internal/integration/harness`: `harness.New` still starts and owns its own
+container (unchanged for standalone callers); a new `harness.NewWithRedis`
+wires the identical gRPC server/repos/brokers/clients against an
+already-running Redis address without owning a container. Each of the
+three `internal/integration/...` Go test processes now owns exactly one
+shared `harness.RedisContainer`, started/terminated once in that package's
+`TestMain` (`internal/integration/main_test.go`,
+`internal/integration/character/main_test.go`) — `internal/integration/
+harness`'s own 1-test smoke suite was already minimal (1 container) and is
+unchanged. Every suite (`DungeonCryptSuite`, `EncounterV2IntegrationSuite`,
+`CryptMonsterSeedRedisSuite`, `LobbyStartThenMoveSuite`,
+`LobbyV1alpha1IntegrationSuite`, `CharacterCreationSuite`) still gets a
+fresh `TestServer` per test method via `NewWithRedis` + `FlushRedis`; a
+`RedisContainer.Lease()`/`release()` pair around each `SetupTest`/
+`TearDownTest` is a belt-and-suspenders serialization guard (suites stay
+serial, no `t.Parallel()` added). `CharacterCreationSuite` additionally
+moved off `SetupSuite`-shared-everything onto the same per-test-fresh
+pattern as the other suites, improving isolation beyond its prior state.
+Verified: docker-free RED→GREEN→mutation-caught evidence for the ownership
+split (owned-Close-terminates-once, borrowed-Close-never-terminates,
+shared-fixture-idempotent-Terminate, Lease-serializes-access), plus one
+single post-fix `go test -v -race ./internal/integration/...` run: **37.4s
+wall clock**, **3** Redis containers started/terminated total (one per
+process — a container object cannot cross process boundaries, so 1 truly
+global container was never achievable; 3 is the honest minimum), all 36
+integration test methods green, race-clean. Compares to the accepted
+~283s/33-container-lifecycle baseline in the issue (that baseline's count
+undercounts `internal/integration/lobby_crypt_monster_seed_test.go`'s 3
+tests and didn't note `CharacterCreationSuite` already amortized its
+container via `SetupSuite`; the actual pre-#699 count this branch measured
+against was 30, still reduced to 3). `golangci-lint run`: 29 issues,
+byte-for-byte identical categories/counts versus a clean `origin/main`
+worktree — zero new lint debt.
 
 **Deterministic crypt monster composition — retires goblin out-of-sight search (rpg-api#689, 2026-07-23)** —
 The approved first-swing simplification: `StartEncounter` now seeds exactly 1

--- a/docs/status.md
+++ b/docs/status.md
@@ -47,6 +47,24 @@ against was 30, still reduced to 3). `golangci-lint run`: 29 issues,
 byte-for-byte identical categories/counts versus a clean `origin/main`
 worktree — zero new lint debt.
 
+**Closing an independent-review gap (2026-07-23):** the original lifecycle
+tests proved container ownership in isolation but had no durable coverage
+that the two properties every converted suite actually depends on at
+runtime hold: (1) two `NewWithRedis` `TestServer`s against the same shared
+container are wired to distinct gRPC servers/repos/brokers, and (2) the
+shared container's Redis state is actually isolated between tests by
+`FlushRedis`. Added `TestSharedRedisFixture_PerTestFreshnessAndStateIsolation`
+in `internal/integration` (the primary package, so a targeted `-run` of
+just this test starts only that package's one container). Freshness is a
+characterization test — it passed immediately, pinning behavior
+`NewWithRedis`'s `wireServices` path has had since #699 introduced it, not
+a bug fix. Isolation is mutation-tested: temporarily skipping the second
+cycle's `FlushRedis` call reproduced the exact failure (`Should be zero,
+but was 1`) the assertion exists to catch, then was reverted. Exposed one
+minimal test-only seam, `TestServer.GRPCServer()`, on the harness package
+(test-support code only, never imported by production) to make gRPC
+server identity assertable — no production API changed.
+
 **Deterministic crypt monster composition — retires goblin out-of-sight search (rpg-api#689, 2026-07-23)** —
 The approved first-swing simplification: `StartEncounter` now seeds exactly 1
 deterministic-anchor skeleton (`monsters.NewSkeleton`) in the entrance region, 0 monsters

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -20,9 +20,10 @@ import (
 // CharacterCreationSuite tests character creation for all classes.
 type CharacterCreationSuite struct {
 	suite.Suite
-	ctx    context.Context
-	cancel context.CancelFunc
-	server *harness.TestServer
+	ctx     context.Context
+	cancel  context.CancelFunc
+	server  *harness.TestServer
+	release func()
 }
 
 func TestCharacterCreationSuite(t *testing.T) {
@@ -32,30 +33,31 @@ func TestCharacterCreationSuite(t *testing.T) {
 	suite.Run(t, new(CharacterCreationSuite))
 }
 
-func (s *CharacterCreationSuite) SetupSuite() {
+func (s *CharacterCreationSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 3*time.Minute)
 
-	var err error
-	s.server, err = harness.New(s.ctx, nil)
-	s.Require().NoError(err, "failed to create test server")
+	// Lease this package's shared Redis container (rpg-api#699) — see
+	// main_test.go. Released in TearDownTest. Each test still gets its
+	// own fresh TestServer (gRPC server, repos, brokers, clients); only
+	// the Redis container/connection is shared across tests.
+	s.release = sharedRedis.Lease()
 
-	s.T().Log("╔══════════════════════════════════════════════════════════════════╗")
-	s.T().Log("║  Character Creation Integration Tests                            ║")
-	s.T().Log("╚══════════════════════════════════════════════════════════════════╝")
+	var err error
+	s.server, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
+	s.Require().NoError(err, "failed to create test server")
+	s.Require().NoError(s.server.FlushRedis(s.ctx), "failed to flush redis")
 }
 
-func (s *CharacterCreationSuite) TearDownSuite() {
+func (s *CharacterCreationSuite) TearDownTest() {
 	if s.server != nil {
 		s.server.Close()
 	}
 	if s.cancel != nil {
 		s.cancel()
 	}
-}
-
-func (s *CharacterCreationSuite) SetupTest() {
-	err := s.server.FlushRedis(s.ctx)
-	s.Require().NoError(err, "failed to flush redis")
+	if s.release != nil {
+		s.release()
+	}
 }
 
 func (s *CharacterCreationSuite) authCtx(playerID string) context.Context {

--- a/internal/integration/character/main_test.go
+++ b/internal/integration/character/main_test.go
@@ -32,9 +32,8 @@ var sharedRedis *harness.RedisContainer
 
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	rc, err := harness.StartRedis(ctx)
+	cancel()
 	if err != nil {
 		log.Fatalf("character_integration TestMain: failed to start shared redis container: %v", err)
 	}
@@ -44,12 +43,12 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer termCancel()
 	if err := rc.Terminate(termCtx); err != nil {
 		log.Printf("character_integration TestMain: failed to terminate shared redis container: %v", err)
 	} else {
 		log.Printf("character_integration TestMain: shared redis container TERMINATED (addr=%s)", rc.Addr)
 	}
+	termCancel()
 
 	os.Exit(code)
 }

--- a/internal/integration/character/main_test.go
+++ b/internal/integration/character/main_test.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character_integration
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+)
+
+// sharedRedis is the single Redis testcontainer shared by every test in
+// this package's process (rpg-api#699 — see
+// docs/how-to/run-integration-tests.md). internal/integration/character is
+// its own Go test binary/process, separate from internal/integration and
+// internal/integration/harness, so it owns its own single container — it
+// cannot literally share the container object across process boundaries,
+// only the *pattern* (one container per process, started once, terminated
+// once) is shared with those other packages.
+//
+// Started once here in TestMain before any test runs, terminated exactly
+// once after m.Run() returns. Every individual test still gets its own
+// fresh TestServer (gRPC server, bufconn listener, repos, brokers, proto
+// clients) via harness.NewWithRedis(ctx, cfg, sharedRedis.Addr) in
+// CharacterCreationSuite.SetupTest — only the Redis container/connection
+// endpoint is shared, and SetupTest flushes it before each test runs.
+var sharedRedis *harness.RedisContainer
+
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rc, err := harness.StartRedis(ctx)
+	if err != nil {
+		log.Fatalf("character_integration TestMain: failed to start shared redis container: %v", err)
+	}
+	sharedRedis = rc
+	log.Printf("character_integration TestMain: shared redis container STARTED (addr=%s)", rc.Addr)
+
+	code := m.Run()
+
+	termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer termCancel()
+	if err := rc.Terminate(termCtx); err != nil {
+		log.Printf("character_integration TestMain: failed to terminate shared redis container: %v", err)
+	} else {
+		log.Printf("character_integration TestMain: shared redis container TERMINATED (addr=%s)", rc.Addr)
+	}
+
+	os.Exit(code)
+}

--- a/internal/integration/dungeon_crypt_test.go
+++ b/internal/integration/dungeon_crypt_test.go
@@ -57,9 +57,10 @@ const dungeonGateHP = 100
 
 type DungeonCryptSuite struct {
 	suite.Suite
-	ctx    context.Context
-	cancel context.CancelFunc
-	srv    *harness.TestServer
+	ctx     context.Context
+	cancel  context.CancelFunc
+	srv     *harness.TestServer
+	release func()
 }
 
 func TestDungeonCryptSuite(t *testing.T) {
@@ -68,9 +69,15 @@ func TestDungeonCryptSuite(t *testing.T) {
 
 func (s *DungeonCryptSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+	// Lease the package's shared Redis container (rpg-api#699) — see
+	// main_test.go. Released in TearDownTest.
+	s.release = sharedRedis.Lease()
+
 	var err error
-	s.srv, err = harness.New(s.ctx, nil)
+	s.srv, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
 	s.Require().NoError(err, "failed to create test server")
+	s.Require().NoError(s.srv.FlushRedis(s.ctx), "failed to flush shared redis")
 }
 
 func (s *DungeonCryptSuite) TearDownTest() {
@@ -79,6 +86,9 @@ func (s *DungeonCryptSuite) TearDownTest() {
 	}
 	if s.cancel != nil {
 		s.cancel()
+	}
+	if s.release != nil {
+		s.release()
 	}
 }
 

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -24,17 +24,23 @@ import (
 // It proves: two players in mutual LoS, one moves, both receive EntityMoved.
 type EncounterV2IntegrationSuite struct {
 	suite.Suite
-	ctx    context.Context
-	cancel context.CancelFunc
-	srv    *harness.TestServer
+	ctx     context.Context
+	cancel  context.CancelFunc
+	srv     *harness.TestServer
+	release func()
 }
 
 func (s *EncounterV2IntegrationSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
 
+	// Lease the package's shared Redis container (rpg-api#699) — see
+	// main_test.go. Released in TearDownTest.
+	s.release = sharedRedis.Lease()
+
 	var err error
-	s.srv, err = harness.New(s.ctx, nil)
+	s.srv, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
 	s.Require().NoError(err, "failed to create test server")
+	s.Require().NoError(s.srv.FlushRedis(s.ctx), "failed to flush shared redis")
 }
 
 func (s *EncounterV2IntegrationSuite) TearDownTest() {
@@ -43,6 +49,9 @@ func (s *EncounterV2IntegrationSuite) TearDownTest() {
 	}
 	if s.cancel != nil {
 		s.cancel()
+	}
+	if s.release != nil {
+		s.release()
 	}
 }
 

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -8,11 +8,10 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"strings"
+	"sync"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
-	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -50,9 +49,15 @@ type TestServer struct {
 	listener   *bufconn.Listener
 	conn       *grpc.ClientConn
 
-	// Container management
+	// Container management. redisContainer is non-nil only when this
+	// TestServer owns its Redis container (constructed via New) — it is
+	// nil when constructed via NewWithRedis against a shared fixture
+	// another owner (e.g. a package TestMain) is responsible for
+	// terminating. Close() must only ever terminate a non-nil
+	// redisContainer; see TestServer.Close.
 	redisContainer testcontainers.Container
 	redisClient    redis.Client
+	closeOnce      sync.Once
 
 	// Proto-generated clients for tests to use
 	CharacterClient   dnd5ev1alpha1.CharacterServiceClient
@@ -81,38 +86,66 @@ func DefaultConfig() *Config {
 	}
 }
 
-// New creates a new TestServer with real Redis and in-process gRPC.
-// Call Close() when done to clean up containers.
+// New creates a new TestServer with its own dedicated Redis container and
+// in-process gRPC. Call Close() when done to clean up containers.
+//
+// This is the standalone, container-owning path: each call to New starts a
+// fresh Redis testcontainer. Callers running many tests against the same
+// process (e.g. an `internal/integration` test package) should prefer
+// starting one shared *RedisContainer via StartRedis (typically from
+// TestMain) and calling NewWithRedis per test instead — New here remains
+// for standalone callers (smoke tests, other packages, ad-hoc scripts)
+// that want a fully self-contained, disposable server.
 func New(ctx context.Context, cfg *Config) (*TestServer, error) {
+	rc, err := StartRedis(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ts, err := newWithClientSource(ctx, cfg, rc.Addr)
+	if err != nil {
+		// Nothing wired successfully owns rc yet, so terminate it directly.
+		_ = rc.Terminate(ctx)
+		return nil, err
+	}
+
+	// From this point Close() owns rc's lifetime.
+	ts.redisContainer = rc.container
+
+	return ts, nil
+}
+
+// NewWithRedis creates a new TestServer wired against an already-running
+// Redis instance (e.g. a *RedisContainer started once by a package
+// TestMain and shared across many tests) instead of starting its own
+// container. Every other piece of per-test state — the gRPC server,
+// bufconn listener, repositories, brokers, and proto clients — is fresh,
+// matching New. The returned TestServer does not own the Redis container
+// backing redisAddr: Close() closes this TestServer's own Redis client
+// connection but never attempts to terminate the shared container.
+//
+// Callers are responsible for calling FlushRedis before (or after) each
+// test to keep the shared instance's state isolated between tests.
+func NewWithRedis(ctx context.Context, cfg *Config, redisAddr string) (*TestServer, error) {
+	return newWithClientSource(ctx, cfg, redisAddr)
+}
+
+// newWithClientSource wires a TestServer against redisAddr. It never sets
+// redisContainer — ownership of the container backing redisAddr is the
+// caller's concern (New sets it afterward for the owning path).
+func newWithClientSource(ctx context.Context, cfg *Config, redisAddr string) (*TestServer, error) {
 	if cfg == nil {
 		cfg = DefaultConfig()
 	}
 
 	ts := &TestServer{}
 
-	// Start Redis container
-	redisC, err := tcredis.Run(ctx, "redis:7-alpine")
-	if err != nil {
-		return nil, fmt.Errorf("failed to start redis container: %w", err)
-	}
-	ts.redisContainer = redisC
-
-	// Get Redis connection string
-	redisAddr, err := redisC.ConnectionString(ctx)
-	if err != nil {
-		ts.Close()
-		return nil, fmt.Errorf("failed to get redis connection string: %w", err)
-	}
-
-	// Strip redis:// prefix if present (go-redis expects host:port)
-	redisAddr = strings.TrimPrefix(redisAddr, "redis://")
-
-	log.Printf("Integration test Redis started at: %s", redisAddr)
-
-	// Create Redis client
+	// Each TestServer gets its own Redis client connection, even when
+	// several TestServers share the same underlying container/address.
+	// This keeps Close() simple and safe: closing this connection can
+	// never affect another TestServer's connection to the same container.
 	redisClient, err := redis.NewClient(redisAddr, nil)
 	if err != nil {
-		ts.Close()
 		return nil, fmt.Errorf("failed to create redis client: %w", err)
 	}
 	ts.redisClient = redisClient
@@ -321,8 +354,19 @@ func (ts *TestServer) bufDialer(ctx context.Context, _ string) (net.Conn, error)
 	return ts.listener.DialContext(ctx)
 }
 
-// Close cleans up all resources.
+// Close cleans up everything this TestServer owns: the gRPC server,
+// bufconn listener, brokers, and its own Redis client connection. It only
+// terminates a Redis container when ts.redisContainer is set — that is
+// only true for TestServers constructed via New. TestServers constructed
+// via NewWithRedis leave redisContainer nil, so Close() closes their
+// per-instance Redis client but never terminates the shared container a
+// package-level fixture (e.g. TestMain) owns. Close is idempotent — safe
+// to call more than once (e.g. an explicit call plus a deferred one).
 func (ts *TestServer) Close() {
+	ts.closeOnce.Do(ts.closeLocked)
+}
+
+func (ts *TestServer) closeLocked() {
 	if ts.conn != nil {
 		ts.conn.Close()
 	}

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -363,10 +363,10 @@ func (ts *TestServer) bufDialer(ctx context.Context, _ string) (net.Conn, error)
 // package-level fixture (e.g. TestMain) owns. Close is idempotent — safe
 // to call more than once (e.g. an explicit call plus a deferred one).
 func (ts *TestServer) Close() {
-	ts.closeOnce.Do(ts.closeLocked)
+	ts.closeOnce.Do(ts.closeAll)
 }
 
-func (ts *TestServer) closeLocked() {
+func (ts *TestServer) closeAll() {
 	if ts.conn != nil {
 		ts.conn.Close()
 	}

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -410,3 +410,13 @@ func (ts *TestServer) FlushRedis(ctx context.Context) error {
 func (ts *TestServer) RedisClient() redis.Client {
 	return ts.redisClient
 }
+
+// GRPCServer returns the underlying gRPC server. This package is
+// test-support code only (never imported by production), so this is a
+// minimal test-only seam — not a production API — exposed so tests can
+// assert that two TestServers built against the same shared Redis
+// container (see RedisContainer/NewWithRedis, rpg-api#699) are wired to
+// distinct gRPC servers, not just distinct Go struct pointers.
+func (ts *TestServer) GRPCServer() *grpc.Server {
+	return ts.grpcServer
+}

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -104,8 +104,15 @@ func New(ctx context.Context, cfg *Config) (*TestServer, error) {
 
 	ts, err := newWithClientSource(ctx, cfg, rc.Addr)
 	if err != nil {
-		// Nothing wired successfully owns rc yet, so terminate it directly.
-		_ = rc.Terminate(ctx)
+		// Nothing wired successfully owns rc yet, so terminate it
+		// directly. Use a fresh background context with its own timeout
+		// rather than ctx: ctx is a common reason newWithClientSource
+		// just failed (e.g. already canceled/deadline-exceeded), and
+		// reusing it here for best-effort cleanup could fail immediately
+		// and leak the container.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = rc.Terminate(cleanupCtx)
+		cancel()
 		return nil, err
 	}
 

--- a/internal/integration/harness/lifecycle_internal_test.go
+++ b/internal/integration/harness/lifecycle_internal_test.go
@@ -13,8 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 
-	redismocks "github.com/KirkDiggler/rpg-api/internal/redis/mocks"
 	"go.uber.org/mock/gomock"
+
+	redismocks "github.com/KirkDiggler/rpg-api/internal/redis/mocks"
 )
 
 // fakeContainer satisfies testcontainers.Container by embedding a nil

--- a/internal/integration/harness/lifecycle_internal_test.go
+++ b/internal/integration/harness/lifecycle_internal_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package harness
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	redismocks "github.com/KirkDiggler/rpg-api/internal/redis/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+// fakeContainer satisfies testcontainers.Container by embedding a nil
+// interface (any method other than Terminate would panic if called, which
+// is intentional: these lifecycle tests must never touch Docker) and
+// overriding Terminate to record how many times it was invoked.
+type fakeContainer struct {
+	testcontainers.Container
+
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (f *fakeContainer) Terminate(_ context.Context, _ ...testcontainers.TerminateOption) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.err
+}
+
+func (f *fakeContainer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// TestRedisContainer_TerminateIsIdempotent proves the shared fixture only
+// terminates its underlying container once, even if Terminate is called
+// multiple times (e.g. a defer plus an explicit TestMain cleanup).
+func TestRedisContainer_TerminateIsIdempotent(t *testing.T) {
+	fc := &fakeContainer{}
+	rc := &RedisContainer{Addr: "127.0.0.1:6379", container: fc}
+
+	require.NoError(t, rc.Terminate(context.Background()))
+	require.NoError(t, rc.Terminate(context.Background()))
+	require.NoError(t, rc.Terminate(context.Background()))
+
+	assert.Equal(t, 1, fc.callCount(), "underlying container Terminate must be called exactly once")
+}
+
+// TestRedisContainer_LeaseSerializesAccess proves a second Lease() call
+// blocks until the first is released, which is what prevents a concurrent
+// FlushRedis race if a suite method is ever accidentally parallelized.
+func TestRedisContainer_LeaseSerializesAccess(t *testing.T) {
+	rc := &RedisContainer{Addr: "127.0.0.1:6379", container: &fakeContainer{}}
+
+	release := rc.Lease()
+
+	acquired := make(chan struct{})
+	go func() {
+		release2 := rc.Lease()
+		close(acquired)
+		release2()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second Lease() acquired while first still held")
+	case <-time.After(100 * time.Millisecond):
+		// expected: still blocked
+	}
+
+	release()
+
+	select {
+	case <-acquired:
+		// expected: unblocked after release
+	case <-time.After(2 * time.Second):
+		t.Fatal("second Lease() never acquired after release")
+	}
+}
+
+// TestServer_Close_OwnedContainer_TerminatesOnce proves a TestServer
+// constructed via the owning path (redisContainer set) terminates its
+// container exactly once on Close(), and that Close() is itself safe to
+// call more than once.
+func TestServer_Close_OwnedContainer_TerminatesOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := redismocks.NewMockClient(ctrl)
+	mockClient.EXPECT().Close().Return(nil).Times(1)
+
+	fc := &fakeContainer{}
+	ts := &TestServer{
+		redisClient:    mockClient,
+		redisContainer: fc,
+	}
+
+	ts.Close()
+	ts.Close() // safe to call twice; must not double-terminate
+
+	assert.Equal(t, 1, fc.callCount(), "owning TestServer must terminate its container exactly once")
+}
+
+// TestServer_Close_BorrowedContainer_NeverTerminates proves a TestServer
+// constructed via the non-owning path (redisContainer nil, e.g.
+// NewWithRedis against a shared fixture) never calls Terminate on any
+// container, while still closing its own per-instance Redis client.
+func TestServer_Close_BorrowedContainer_NeverTerminates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := redismocks.NewMockClient(ctrl)
+	mockClient.EXPECT().Close().Return(nil).Times(1)
+
+	// A shared fixture that a *different* owner (TestMain) is responsible
+	// for. This TestServer must never touch it.
+	shared := &RedisContainer{Addr: "127.0.0.1:6379", container: &fakeContainer{}}
+
+	ts := &TestServer{
+		redisClient: mockClient,
+		// redisContainer intentionally left nil: this TestServer borrowed
+		// the shared fixture's address but does not own its container.
+	}
+
+	ts.Close()
+
+	assert.Equal(t, 0, shared.container.(*fakeContainer).callCount(),
+		"borrowed TestServer must never terminate the shared container")
+}

--- a/internal/integration/harness/redis_container.go
+++ b/internal/integration/harness/redis_container.go
@@ -39,9 +39,10 @@ type RedisContainer struct {
 }
 
 // StartRedis starts a single redis:7-alpine testcontainer and returns a
-// handle to it. The caller owns the returned *RedisContainer and must call
-// Terminate exactly once (typically from TestMain, after m.Run() returns)
-// to tear it down.
+// handle to it. The caller owns the returned *RedisContainer and is
+// responsible for cleaning it up — typically a single call to Terminate
+// (from TestMain, after m.Run() returns) — though Terminate is idempotent,
+// so an explicit call plus a deferred one is also safe.
 func StartRedis(ctx context.Context) (*RedisContainer, error) {
 	redisC, err := tcredis.Run(ctx, "redis:7-alpine")
 	if err != nil {
@@ -56,7 +57,7 @@ func StartRedis(ctx context.Context) (*RedisContainer, error) {
 	// Strip redis:// prefix if present (go-redis expects host:port).
 	addr = strings.TrimPrefix(addr, "redis://")
 
-	log.Printf("Shared integration-test Redis container started at: %s", addr)
+	log.Printf("harness: redis container started at %s", addr)
 
 	return &RedisContainer{Addr: addr, container: redisC}, nil
 }
@@ -69,7 +70,11 @@ func StartRedis(ctx context.Context) (*RedisContainer, error) {
 func (rc *RedisContainer) Terminate(ctx context.Context) error {
 	rc.termOnce.Do(func() {
 		rc.termErr = rc.container.Terminate(ctx)
-		log.Printf("Shared integration-test Redis container terminated (addr=%s)", rc.Addr)
+		if rc.termErr != nil {
+			log.Printf("harness: failed to terminate redis container (addr=%s): %v", rc.Addr, rc.termErr)
+		} else {
+			log.Printf("harness: redis container terminated (addr=%s)", rc.Addr)
+		}
 	})
 	return rc.termErr
 }

--- a/internal/integration/harness/redis_container.go
+++ b/internal/integration/harness/redis_container.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package harness
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"github.com/testcontainers/testcontainers-go"
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+// RedisContainer is a shared Redis testcontainer fixture, owned at the
+// package/process level (typically by a TestMain) rather than by any
+// single TestServer. Start one with StartRedis, hand its Addr to
+// NewWithRedis for every test in the process, and call Terminate exactly
+// once when the process is done running tests.
+//
+// A RedisContainer is not itself a TestServer: it owns only the container
+// and connection address. Each test still builds its own fresh TestServer
+// via NewWithRedis(ctx, cfg, rc.Addr) — fresh gRPC server, repos, brokers,
+// and clients — and is responsible for calling FlushRedis against it
+// before relying on a clean slate.
+type RedisContainer struct {
+	// Addr is the host:port address of the running Redis container,
+	// suitable for NewWithRedis.
+	Addr string
+
+	container testcontainers.Container
+
+	leaseMu sync.Mutex
+
+	termOnce sync.Once
+	termErr  error
+}
+
+// StartRedis starts a single redis:7-alpine testcontainer and returns a
+// handle to it. The caller owns the returned *RedisContainer and must call
+// Terminate exactly once (typically from TestMain, after m.Run() returns)
+// to tear it down.
+func StartRedis(ctx context.Context) (*RedisContainer, error) {
+	redisC, err := tcredis.Run(ctx, "redis:7-alpine")
+	if err != nil {
+		return nil, fmt.Errorf("failed to start redis container: %w", err)
+	}
+
+	addr, err := redisC.ConnectionString(ctx)
+	if err != nil {
+		_ = redisC.Terminate(ctx)
+		return nil, fmt.Errorf("failed to get redis connection string: %w", err)
+	}
+	// Strip redis:// prefix if present (go-redis expects host:port).
+	addr = strings.TrimPrefix(addr, "redis://")
+
+	log.Printf("Shared integration-test Redis container started at: %s", addr)
+
+	return &RedisContainer{Addr: addr, container: redisC}, nil
+}
+
+// Terminate stops and removes the underlying container. It is safe to call
+// more than once — only the first call actually terminates the container;
+// later calls are no-ops that return the same result. This lets a TestMain
+// call Terminate unconditionally in a deferred cleanup without worrying
+// about whether an earlier explicit call already ran.
+func (rc *RedisContainer) Terminate(ctx context.Context) error {
+	rc.termOnce.Do(func() {
+		rc.termErr = rc.container.Terminate(ctx)
+		log.Printf("Shared integration-test Redis container terminated (addr=%s)", rc.Addr)
+	})
+	return rc.termErr
+}
+
+// Lease acquires exclusive access to the shared container for the
+// duration of one test and returns a release function to call when that
+// test is done (typically paired in SetupTest/TearDownTest). Integration
+// suites are expected to stay serial (no t.Parallel()), so in normal use
+// Lease never actually blocks — it exists as a belt-and-suspenders guard
+// so that if a suite method is ever accidentally parallelized, concurrent
+// FlushRedis calls against the shared instance serialize instead of racing.
+func (rc *RedisContainer) Lease() (release func()) {
+	rc.leaseMu.Lock()
+	return rc.leaseMu.Unlock
+}

--- a/internal/integration/lobby_crypt_monster_seed_test.go
+++ b/internal/integration/lobby_crypt_monster_seed_test.go
@@ -6,8 +6,9 @@
 // against REAL Redis-backed lobby + encounter repositories, not the
 // in-memory LobbySuite (internal/orchestrators/lobby's unit tests) or the
 // shared harness.TestServer (whose LobbyRepo/EncRepoV2 are in-memory by
-// design — see harness.go's own comment). Reuses harness.New purely for
-// Redis container lifecycle + a real Redis-backed CharacterRepo
+// design — see harness.go's own comment). Reuses harness.NewWithRedis
+// against this package's shared Redis container (rpg-api#699, see
+// main_test.go) purely for a real Redis-backed CharacterRepo
 // (srv.RedisClient()), then wires a SECOND, independent lobbyorch.
 // Orchestrator directly onto Redis-backed lobbyrepo.NewRedis/encountersv2.
 // NewRedis — real production repository constructors, no test-only
@@ -42,9 +43,10 @@ const cryptMonsterSeedTestTTL = time.Hour
 // CryptMonsterSeedRedisSuite is rpg-api#689's real-Redis integration gate.
 type CryptMonsterSeedRedisSuite struct {
 	suite.Suite
-	ctx    context.Context
-	cancel context.CancelFunc
-	srv    *harness.TestServer
+	ctx     context.Context
+	cancel  context.CancelFunc
+	srv     *harness.TestServer
+	release func()
 
 	lobbyRepo lobbyrepo.Repository
 	encRepo   encountersv2.Repository
@@ -54,9 +56,14 @@ type CryptMonsterSeedRedisSuite struct {
 func (s *CryptMonsterSeedRedisSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
 
+	// Lease the package's shared Redis container (rpg-api#699) — see
+	// main_test.go. Released in TearDownTest.
+	s.release = sharedRedis.Lease()
+
 	var err error
-	s.srv, err = harness.New(s.ctx, nil)
-	s.Require().NoError(err, "failed to create test server (real Redis container)")
+	s.srv, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
+	s.Require().NoError(err, "failed to create test server against shared redis container")
+	s.Require().NoError(s.srv.FlushRedis(s.ctx), "failed to flush shared redis")
 
 	// Real Redis-backed lobby + encounter repositories — production
 	// constructors, sharing the harness's own Redis container/client.
@@ -90,6 +97,9 @@ func (s *CryptMonsterSeedRedisSuite) TearDownTest() {
 	}
 	if s.cancel != nil {
 		s.cancel()
+	}
+	if s.release != nil {
+		s.release()
 	}
 }
 

--- a/internal/integration/lobby_start_then_move_test.go
+++ b/internal/integration/lobby_start_then_move_test.go
@@ -32,9 +32,10 @@ import (
 
 type LobbyStartThenMoveSuite struct {
 	suite.Suite
-	ctx    context.Context
-	cancel context.CancelFunc
-	srv    *harness.TestServer
+	ctx     context.Context
+	cancel  context.CancelFunc
+	srv     *harness.TestServer
+	release func()
 }
 
 func TestLobbyStartThenMoveSuite(t *testing.T) {
@@ -43,9 +44,15 @@ func TestLobbyStartThenMoveSuite(t *testing.T) {
 
 func (s *LobbyStartThenMoveSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+	// Lease the package's shared Redis container (rpg-api#699) — see
+	// main_test.go. Released in TearDownTest.
+	s.release = sharedRedis.Lease()
+
 	var err error
-	s.srv, err = harness.New(s.ctx, nil)
+	s.srv, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
 	s.Require().NoError(err, "failed to create test server")
+	s.Require().NoError(s.srv.FlushRedis(s.ctx), "failed to flush shared redis")
 }
 
 func (s *LobbyStartThenMoveSuite) TearDownTest() {
@@ -54,6 +61,9 @@ func (s *LobbyStartThenMoveSuite) TearDownTest() {
 	}
 	if s.cancel != nil {
 		s.cancel()
+	}
+	if s.release != nil {
+		s.release()
 	}
 }
 

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -30,17 +30,23 @@ import (
 // LobbyV1alpha1IntegrationSuite is the Party Assembles gate test suite.
 type LobbyV1alpha1IntegrationSuite struct {
 	suite.Suite
-	ctx    context.Context
-	cancel context.CancelFunc
-	srv    *harness.TestServer
+	ctx     context.Context
+	cancel  context.CancelFunc
+	srv     *harness.TestServer
+	release func()
 }
 
 func (s *LobbyV1alpha1IntegrationSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
 
+	// Lease the package's shared Redis container (rpg-api#699) — see
+	// main_test.go. Released in TearDownTest.
+	s.release = sharedRedis.Lease()
+
 	var err error
-	s.srv, err = harness.New(s.ctx, nil)
+	s.srv, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
 	s.Require().NoError(err, "failed to create test server")
+	s.Require().NoError(s.srv.FlushRedis(s.ctx), "failed to flush shared redis")
 }
 
 func (s *LobbyV1alpha1IntegrationSuite) TearDownTest() {
@@ -49,6 +55,9 @@ func (s *LobbyV1alpha1IntegrationSuite) TearDownTest() {
 	}
 	if s.cancel != nil {
 		s.cancel()
+	}
+	if s.release != nil {
+		s.release()
 	}
 }
 

--- a/internal/integration/main_test.go
+++ b/internal/integration/main_test.go
@@ -38,9 +38,8 @@ var sharedRedis *harness.RedisContainer
 // per-process container count this achieves.
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	rc, err := harness.StartRedis(ctx)
+	cancel()
 	if err != nil {
 		log.Fatalf("integration_test TestMain: failed to start shared redis container: %v", err)
 	}
@@ -50,12 +49,12 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer termCancel()
 	if err := rc.Terminate(termCtx); err != nil {
 		log.Printf("integration_test TestMain: failed to terminate shared redis container: %v", err)
 	} else {
 		log.Printf("integration_test TestMain: shared redis container TERMINATED (addr=%s)", rc.Addr)
 	}
+	termCancel()
 
 	os.Exit(code)
 }

--- a/internal/integration/main_test.go
+++ b/internal/integration/main_test.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package integration_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+)
+
+// sharedRedis is the single Redis testcontainer shared by every test in
+// this package's process (rpg-api#699 — see
+// docs/how-to/run-integration-tests.md). It is started once here in
+// TestMain before any test runs, and terminated exactly once after
+// m.Run() returns. Every individual test still gets its own fresh
+// TestServer (gRPC server, bufconn listener, repos, brokers, proto
+// clients) via harness.NewWithRedis(ctx, cfg, sharedRedis.Addr) in that
+// suite's SetupTest — only the Redis container/connection endpoint is
+// shared, and each SetupTest flushes it before running.
+//
+// The suites in this package (DungeonCryptSuite, EncounterV2Integration
+// Suite, LobbyV1alpha1IntegrationSuite, LobbyStartThenMoveSuite) run
+// serially today (no t.Parallel()); sharedRedis.Lease() is taken in each
+// SetupTest and released in TearDownTest as a belt-and-suspenders guard
+// so an accidental future t.Parallel() cannot race FlushRedis against
+// this shared instance.
+var sharedRedis *harness.RedisContainer
+
+// TestMain owns the one Redis container this whole test binary uses.
+// `internal/integration/character` and `internal/integration/harness` are
+// separate packages/processes with their own TestMain and their own
+// shared container each — see rpg-api#699's PR description for the exact
+// per-process container count this achieves.
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rc, err := harness.StartRedis(ctx)
+	if err != nil {
+		log.Fatalf("integration_test TestMain: failed to start shared redis container: %v", err)
+	}
+	sharedRedis = rc
+	log.Printf("integration_test TestMain: shared redis container STARTED (addr=%s)", rc.Addr)
+
+	code := m.Run()
+
+	termCtx, termCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer termCancel()
+	if err := rc.Terminate(termCtx); err != nil {
+		log.Printf("integration_test TestMain: failed to terminate shared redis container: %v", err)
+	} else {
+		log.Printf("integration_test TestMain: shared redis container TERMINATED (addr=%s)", rc.Addr)
+	}
+
+	os.Exit(code)
+}

--- a/internal/integration/shared_fixture_regression_test.go
+++ b/internal/integration/shared_fixture_regression_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+)
+
+// TestSharedRedisFixture_PerTestFreshnessAndStateIsolation is rpg-api#699's
+// closing regression coverage, added in response to an independent
+// review gap: the original PR asserted container-ownership lifecycle
+// (owned Close terminates once, borrowed Close never terminates, the
+// shared fixture's Terminate/Lease) with docker-free unit tests, but had
+// no durable test proving the two behaviors every converted suite in this
+// package actually depends on at runtime:
+//
+//  1. Two TestServers built via NewWithRedis against the SAME shared
+//     Redis container are wired to distinct application-level resources
+//     (gRPC server, in-memory encounter/lobby repos, brokers) — not just
+//     distinct Go struct pointers wrapping shared internals.
+//  2. The shared container's Redis STATE is actually isolated between
+//     tests by the FlushRedis call every SetupTest in this package makes
+//     — using a fixed key, so this cannot pass merely because two tests
+//     happened to use different IDs.
+//
+// This lives in the primary internal/integration package (not a new
+// package) so a targeted `-run` of just this test starts only this
+// package's one shared container, not an additional one.
+func TestSharedRedisFixture_PerTestFreshnessAndStateIsolation(t *testing.T) {
+	t.Run("per_test_application_freshness", func(t *testing.T) {
+		release := sharedRedis.Lease()
+		t.Cleanup(release)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		srv1, err := harness.NewWithRedis(ctx, nil, sharedRedis.Addr)
+		require.NoError(t, err, "failed to create first test server")
+		t.Cleanup(srv1.Close)
+
+		srv2, err := harness.NewWithRedis(ctx, nil, sharedRedis.Addr)
+		require.NoError(t, err, "failed to create second test server")
+		t.Cleanup(srv2.Close)
+
+		// This is a characterization test: NewWithRedis's wireServices
+		// path already constructs a fresh gRPC server, bufconn listener,
+		// and in-memory repo/broker per call (see harness.go) — it has
+		// always behaved this way since #699 introduced NewWithRedis.
+		// This pins that behavior down as an explicit, durable assertion
+		// rather than leaving it as an implicit, undocumented property
+		// every suite's SetupTest happens to rely on.
+		assertDistinctInstances(t, "gRPC server", srv1.GRPCServer(), srv2.GRPCServer())
+		assertDistinctInstances(t, "v2 encounter broker", srv1.BrokerV2, srv2.BrokerV2)
+		assertDistinctInstances(t, "lobby broker", srv1.LobbyBroker, srv2.LobbyBroker)
+		assertDistinctInstances(t, "v2 encounter repo", srv1.EncRepoV2, srv2.EncRepoV2)
+		assertDistinctInstances(t, "lobby repo", srv1.LobbyRepo, srv2.LobbyRepo)
+		assertDistinctInstances(t, "character repo", srv1.CharacterRepo, srv2.CharacterRepo)
+	})
+
+	t.Run("shared_redis_state_isolation_via_flush", func(t *testing.T) {
+		const fixedKey = "rpg-api-699-regression-fixed-key"
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		// Cycle A: models one test's SetupTest/TearDownTest, ending with
+		// a fixed key written directly into the shared Redis instance —
+		// standing in for whatever state a real test leaves behind.
+		releaseA := sharedRedis.Lease()
+		srvA, err := harness.NewWithRedis(ctx, nil, sharedRedis.Addr)
+		require.NoError(t, err, "failed to create first test server")
+		require.NoError(t, srvA.FlushRedis(ctx), "failed to flush shared redis before cycle A")
+		require.NoError(t, srvA.RedisClient().Set(ctx, fixedKey, "leaked-if-isolation-is-broken", 0).Err(),
+			"failed to seed fixed key")
+		srvA.Close()
+		releaseA()
+
+		// Cycle B: the next test in this process. Its SetupTest does
+		// exactly this — NewWithRedis against the same shared address,
+		// then FlushRedis — before any test body runs.
+		releaseB := sharedRedis.Lease()
+		t.Cleanup(releaseB)
+		srvB, err := harness.NewWithRedis(ctx, nil, sharedRedis.Addr)
+		require.NoError(t, err, "failed to create second test server")
+		t.Cleanup(srvB.Close)
+		require.NoError(t, srvB.FlushRedis(ctx), "failed to flush shared redis before cycle B")
+
+		exists, err := srvB.RedisClient().Exists(ctx, fixedKey).Result()
+		require.NoError(t, err, "failed to check fixed key")
+		assert.Zero(t, exists,
+			"fixed key %q written by a prior test must not survive FlushRedis into the next test", fixedKey)
+	})
+}
+
+// assertDistinctInstances fails the test if a and b are the same pointer.
+// a and b are expected to be interface or pointer values wrapping a
+// pointer-typed concrete instance (true for every TestServer field this
+// test checks); %p reports that pointer's address regardless of the
+// static type, so this works uniformly across gRPC servers, brokers, and
+// repository interfaces without depending on their concrete types.
+func assertDistinctInstances(t *testing.T, label string, a, b any) {
+	t.Helper()
+	pa := fmt.Sprintf("%p", a)
+	pb := fmt.Sprintf("%p", b)
+	assert.NotEqual(t, pa, pb, "%s must be a distinct instance per TestServer, both were %s", label, pa)
+}


### PR DESCRIPTION
Closes #699

## Architecture

Split Redis testcontainer **ownership** from per-test **service wiring** in
`internal/integration/harness`:

- `harness.New(ctx, cfg)` — unchanged behavior for standalone callers: starts
  and owns its own dedicated Redis container; `Close()` terminates it.
- `harness.NewWithRedis(ctx, cfg, redisAddr)` — **new**. Wires the identical
  gRPC server / repos / brokers / proto clients as `New`, but against an
  already-running Redis address instead of starting a container.
  `TestServer.Close()` closes only this instance's own Redis client
  connection; it never terminates a container it doesn't own.
- `harness.RedisContainer` — **new**. A package/process-level shared
  fixture: `StartRedis(ctx)` starts one, `(*RedisContainer).Terminate(ctx)`
  is idempotent (safe to call more than once), `Lease()`/`release()` is a
  belt-and-suspenders mutex guard against accidental parallel use.
- `TestServer.Close()` is now itself idempotent (`sync.Once`).

Each of the three `internal/integration/...` Go test **processes** (a
container object cannot cross process boundaries) now owns exactly one
`RedisContainer`, started/terminated once in that package's `TestMain`:

| Package (process) | Suites | Container ownership |
|---|---|---|
| `internal/integration` | `DungeonCryptSuite`, `EncounterV2IntegrationSuite`, `CryptMonsterSeedRedisSuite`, `LobbyStartThenMoveSuite`, `LobbyV1alpha1IntegrationSuite` (28 test methods) | 1 shared container, `internal/integration/main_test.go`'s `TestMain` |
| `internal/integration/character` | `CharacterCreationSuite` (7 test methods) | 1 shared container, its own `main_test.go`'s `TestMain` |
| `internal/integration/harness` | `TestHarness_StartsAndConnects` (1 test) | Its own container via `harness.New` — already minimal, left unchanged |

Every suite's `SetupTest` still builds a **fresh** `TestServer` per test
method via `NewWithRedis` (fresh gRPC server, bufconn listener, repos,
brokers, proto clients) and calls `FlushRedis` before the test runs — only
the Redis container/connection endpoint is shared. `CharacterCreationSuite`
additionally moved off `SetupSuite`-shared-everything (one `TestServer` for
all 7 tests) onto the same per-test-fresh discipline as every other suite —
an isolation improvement beyond its prior state, not just a container-count
fix.

Suites stay serial (no `t.Parallel()` added); `RedisContainer.Lease()` is a
guard against a *future* accidental parallelization racing `FlushRedis`
against the shared instance, not an enabler of concurrency now.

No production code touched — every changed file is under
`internal/integration/**`, `docs/**`, or `.claude/**`.

## RED → GREEN → mutation evidence (docker-free)

`internal/integration/harness/lifecycle_internal_test.go` — whitebox,
using a `fakeContainer` (embeds a nil `testcontainers.Container`, overrides
only `Terminate`) and `redismocks.MockClient`, so these never touch Docker:

- `TestServer_Close_OwnedContainer_TerminatesOnce`
- `TestServer_Close_BorrowedContainer_NeverTerminates`
- `TestRedisContainer_TerminateIsIdempotent`
- `TestRedisContainer_LeaseSerializesAccess`

RED first (compile failure before `RedisContainer` existed), then GREEN.
Mutation check on each invariant — dropped `closeOnce.Do`, dropped
`leaseMu.Lock`, dropped `termOnce.Do` — each reproduced exactly the failure
its test exists to catch, then reverted:

```
# closeOnce removed:
Unexpected call to *redismocks.MockClient.Close(...) ... has already been called the max number of times
--- FAIL: TestServer_Close_OwnedContainer_TerminatesOnce

# leaseMu.Lock() removed:
lifecycle_internal_test.go:76: second Lease() acquired while first still held
--- FAIL: TestRedisContainer_LeaseSerializesAccess

# termOnce.Do() removed:
expected: 1, actual: 3
--- FAIL: TestRedisContainer_TerminateIsIdempotent
```

## Full-run evidence (exactly one authorized run)

```
$ go build ./... && /usr/bin/time -v go test -v -race ./internal/integration/...
...
ok  	github.com/KirkDiggler/rpg-api/internal/integration            35.290s
ok  	github.com/KirkDiggler/rpg-api/internal/integration/character  14.542s
ok  	github.com/KirkDiggler/rpg-api/internal/integration/harness    12.158s
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:37.40
	Exit status: 0
```

- **Wall clock: 37.4s** vs. the accepted **~283s** baseline in #699 (33
  container lifecycles) — ~7.6x faster.
- **Exactly 3** `redis:7-alpine` containers created/terminated total for
  the whole `./internal/integration/...` run — one per Go test process,
  confirmed by counting `🐳 Creating container for image redis:7-alpine`
  (3 occurrences) and each `TestMain`'s STARTED/TERMINATED log lines (2
  explicit shared-fixture pairs + `harness`'s own unconverted smoke test).
  `docker ps` after the run: zero leaked containers.
- All 36 integration test methods across 7 suites pass, race-clean.
- Goroutine-count spot check after 8 tests in `internal/integration`:
  stable at 3 (no broker/gRPC leak from the ownership split).

**Honesty note on the baseline:** #699's issue table states 33 container
lifecycles, but `internal/integration/character`'s `CharacterCreationSuite`
was already using `SetupSuite` (one `TestServer` shared across its 7
tests) *before* this PR, so its actual pre-#699 container count was 1, not
7. This branch's actual measured pre-#699 total would have been 30, not
33. I'm citing the accepted 283s/33 baseline as instructed rather than
re-benchmarking it, but wanted the discrepancy on record rather than
silently repeating an uncritical number — see `docs/status.md`.

Per #699's explicit process rule, this was run as the sole Docker
integration runner against this daemon, and is the **only** full
`./internal/integration/...` run performed for this PR (targeted `-run`
was used throughout development/iteration — see commit history).

## Closing an independent-review gap (2026-07-23 update)

The lifecycle tests above proved container **ownership** in isolation but
had no durable coverage that the two properties every converted suite
actually depends on at runtime hold. Added
`TestSharedRedisFixture_PerTestFreshnessAndStateIsolation` to the primary
`internal/integration` package (so a targeted `-run` of just this test
starts only that package's one container, not an extra one):

- **`per_test_application_freshness`** — two `harness.NewWithRedis`
  `TestServer`s built against the *same* shared Redis container must be
  wired to distinct gRPC servers, v2 encounter/lobby brokers, and
  in-memory encounter/lobby/character repos, not just distinct Go struct
  pointers. This is a **characterization test**: it passed immediately,
  pinning behavior `NewWithRedis`'s `wireServices` path has had since this
  PR introduced it — not a bug fix. Added `TestServer.GRPCServer()`, a
  minimal test-only seam on the harness package (test-support code only,
  never imported by production — not a production API), to make gRPC
  server identity assertable alongside the already-exported
  `BrokerV2`/`LobbyBroker`/`EncRepoV2`/`LobbyRepo`/`CharacterRepo` fields.
- **`shared_redis_state_isolation_via_flush`** — writes a **fixed** key
  through a first instance, closes its per-test resources, runs the exact
  `NewWithRedis` + `FlushRedis` sequence every `SetupTest` in this package
  uses to build a second instance, and proves that fixed key is absent —
  a fixed identifier (not a fresh/unique one) so this cannot pass merely
  because two tests happened to use different IDs.
  **Mutation-tested:** temporarily skipping the second cycle's
  `FlushRedis` call reproduced the exact target failure:
  ```
  Error: Should be zero, but was 1
  Messages: fixed key "rpg-api-699-regression-fixed-key" written by a
    prior test must not survive FlushRedis into the next test
  --- FAIL: .../shared_redis_state_isolation_via_flush
  ```
  then was reverted to GREEN.

Targeted run (`-run TestSharedRedisFixture... -race -count=1`): 1
`redis:7-alpine` container, **14.3s wall clock** (mostly container
start/teardown; the test body itself is 0.03s), race-clean.

Also corrected `docs/how-to/run-integration-tests.md`'s inaccurate claim
of "36 containers before #699" to the verified actual pre-#699 count of
**30** (`CharacterCreationSuite` already amortized its 7 tests onto 1
container via `SetupSuite`, as noted in the honesty note above) — 36
remains correct as the total **test-method** count and is now kept as a
clearly separate figure.

Per this update's instructions, `go test ./internal/integration/...` was
**not** re-run locally — only the new test was targeted locally, and the
full-package run/count is read from this push's CI log rather than
re-benchmarked. **CI confirmation (this PR's `test` job, commit
`10719a4`):** all 3 packages green, exactly 3 `redis:7-alpine` containers
total (one `🐳 Creating container for image redis:7-alpine` per package) —
`internal/integration` 26.9s, `internal/integration/character` 4.0s,
`internal/integration/harness` 1.8s — including the new
`TestSharedRedisFixture_PerTestFreshnessAndStateIsolation` and both its
subtests passing. No `--- FAIL` anywhere in the job log.

## Verification

- `go build ./...`, `go vet ./...`: clean.
- `make fmt` (gofmt -s + goimports): clean after one goimports reorder.
- `go mod tidy`: no changes.
- `go generate ./...`: surfaces the same pre-existing mockgen-version
  import-ordering drift in 7 unrelated mock files as a clean `origin/main`
  worktree (verified side-by-side) — reverted, out of scope, same
  precedent as #689/PR#698.
- `golangci-lint run`: **29 issues**, byte-for-byte identical
  categories/counts (`errcheck:2, goconst:19, govet:3, staticcheck:1,
  unconvert:3, unused:1`) vs. a clean `origin/main` worktree — **zero new
  lint debt**.
- `go test -race` on every non-`internal/integration` package: green.
- Targeted `-run`/`-race` passes for every converted suite during
  development (see commit messages for per-suite container-count/timing
  evidence at each step).

## Docs

- `docs/status.md` — new Active work entry.
- `docs/how-to/run-integration-tests.md` — one-Docker-runner-at-a-time
  rule, per-process container-count table, `New` vs `NewWithRedis`,
  measured before/after.
- `docs/architecture/components/integration-test-harness.md` —
  architecture diagram + lifecycle section updated for the ownership
  split; "testcontainers startup time" known gap marked FIXED.

## Out of scope (unchanged, per issue)

- No `t.Parallel()` added.
- No production Redis config/usage changed.
- No test *behavior* changed (only fixture/lifecycle — except
  `CharacterCreationSuite`'s isolation improvement noted above, which adds
  freshness, not a behavior change to what's asserted).
- No miniredis, no Ryuk disabling, no skipped/weakened tests.

— platform agent, on behalf of KirkDiggler