### PR TITLE
feat(encounter): project revealed static obstacles

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -163,6 +163,21 @@ for `*tkevents.HexRevealedEvent`, so a hex a player reveals mid-session via
 `Move` carries its `zone_id` immediately — not only after their next
 reconnect re-projects the whole snapshot via `ProjectFor`.
 
+### Static obstacle projection (rpg-api#692)
+
+`SpaceData.Obstacles` is toolkit-owned static instance data. `ProjectFor`
+includes an obstacle only when its position is in the viewer's persisted
+`RevealedHexes`, then orders the selected instances by stable ID and copies its
+ID, position, opaque ref, `BlocksMovement`, and `BlocksLoS` into the existing
+`ENTITY_TYPE_OBSTACLE`/`ObstacleData` wire shape. This is explored-map state,
+not current-LoS state: a revealed obstacle remains in later snapshots.
+
+Toolkit encounter v0.39.0 emits its existing `EntityAppeared` once when a
+static obstacle's hex is newly revealed. The stream's existing data-aware
+translator looks up that ID in `SpaceData.Obstacles` and uses the same obstacle
+builder as snapshots. Static obstacles never produce `EntityDisappeared`; the
+API creates no alternative event or visibility policy.
+
 ### CharacterData equipment projection (rpg-api#680)
 
 `playerEntity`'s `CharacterData` carries `equipped`/`inventory`/`slots`/

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,21 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**Static obstacles on the v1alpha2 wire (rpg-api#692, 2026-07-23)** —
+`ProjectFor` projects only `SpaceData.Obstacles` whose positions belong to the
+viewer's persisted `RevealedHexes`, ordered by stable obstacle ID. Each becomes
+an `ENTITY_TYPE_OBSTACLE` with its toolkit ID, position, opaque ref, and both
+blocking flags copied verbatim. The stream's existing data-aware
+`EntityAppeared` translation now resolves obstacle IDs from `SpaceData.Obstacles`
+through the same builder, consuming toolkit encounter v0.39.0's one-time reveal
+event. Obstacles have sticky explored-map semantics: no hidden-region leak, no
+disappearance event after visibility changes, and reconnect snapshots retain
+previously revealed obstacles. No placement, collision, rendering, theme, or
+proto behavior lives here. `DungeonCryptSuite` proves the real Redis
+`StartEncounter` path persists crypt obstacles, keeps boss obstacles hidden,
+emits exactly one enriched event upon a real reveal, and retains it on a later
+snapshot.
+
 **Shared Redis integration fixture (rpg-api#699, merged via PR #700)** —
 `internal/integration` and `internal/integration/character` each own one
 process-scoped Redis container through `TestMain`. Every suite leases that

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260723025004-0e4e2d77d73a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.38.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.39.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.38.0 h1:j9NmG+zJT3NoIAiejpceXrCZGwvhQeVJCBU+1N2A6so=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.38.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.39.0 h1:CVxaR7uy9sOEOtQvCzQ8k+giqH3OmJcCkMbtVr95yDQ=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.39.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/hydrate_players_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/hydrate_players_test.go
@@ -284,3 +284,28 @@ func (s *HydratePlayersReconcileSuite) TestTranslateEntityAppearedEventWithData_
 	s.Require().Empty(app.GetEntity().GetDisplayName())
 	s.Require().Nil(app.GetEntity().GetCharacter().GetClassRef())
 }
+
+func (s *HydratePlayersReconcileSuite) TestTranslateEntityAppearedEventWithData_ProjectsObstacle() {
+	data := tkenc.NewData("enc-1")
+	data.Space = &tkenc.SpaceData{Obstacles: []tkenc.ObstacleData{{
+		ID: "obstacle-altar", Ref: "dnd5e:props:altar", Position: tkenccore.Hex{Q: 2, R: -1, S: -1}, BlocksMovement: true, BlocksLoS: true,
+	}}}
+	evt := tkencevents.NewEntityAppearedEvent(
+		"enc-1", uint64(1), "obstacle-altar", tkenccore.Hex{Q: 2, R: -1, S: -1},
+		map[tkenccore.PlayerID]struct{}{"player-A": {}},
+	)
+
+	out, err := translateEntityAppearedEventWithData(s.ctx, nil, evt, "player-A", time.Now(), data)
+	s.Require().NoError(err)
+	appeared := out.GetEntityAppeared().GetEntity()
+	s.Require().Equal("obstacle-altar", appeared.GetId())
+	s.Require().Equal(encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE, appeared.GetType())
+	s.Require().Equal(int32(2), appeared.GetPosition().GetX())
+	s.Require().Equal(int32(-1), appeared.GetPosition().GetY())
+	s.Require().Equal(int32(-1), appeared.GetPosition().GetZ())
+	s.Require().Equal("dnd5e", appeared.GetObstacle().GetObstacleRef().GetModule())
+	s.Require().Equal("props", appeared.GetObstacle().GetObstacleRef().GetType())
+	s.Require().Equal("altar", appeared.GetObstacle().GetObstacleRef().GetId())
+	s.Require().True(appeared.GetObstacle().GetBlocksMovement())
+	s.Require().True(appeared.GetObstacle().GetBlocksLineOfSight())
+}

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -186,6 +186,25 @@ func ProjectFor(
 		entities = append(entities, monsterEntity(m))
 	}
 
+	// Static obstacles are sticky exploration data, not currently-visible
+	// combatants: once their hex is revealed, include them on snapshots even
+	// when it is outside the viewer's current line of sight. Their stable IDs
+	// provide deterministic ordering across the toolkit's placement slice.
+	if data.Space != nil {
+		obstacles := make([]tkenc.ObstacleData, 0, len(data.Space.Obstacles))
+		for _, obstacle := range data.Space.Obstacles {
+			if snap.RevealedHexes.Has(obstacle.Position) {
+				obstacles = append(obstacles, obstacle)
+			}
+		}
+		sort.Slice(obstacles, func(i, j int) bool {
+			return string(obstacles[i].ID) < string(obstacles[j].ID)
+		})
+		for _, obstacle := range obstacles {
+			entities = append(entities, obstacleEntity(obstacle))
+		}
+	}
+
 	return &encounterv2pb.Encounter{
 		Id:        string(data.ID),
 		Mode:      encounterModeToProto(data.Mode),
@@ -643,4 +662,27 @@ func monsterRefFor(toolkitMonsterRef string) *encounterv2pb.Ref {
 		return &encounterv2pb.Ref{Module: parts[0], Type: parts[1], Id: parts[2]}
 	}
 	return &encounterv2pb.Ref{Module: refModuleDnd5e, Type: "monster", Id: toolkitMonsterRef}
+}
+
+func obstacleEntity(obstacle tkenc.ObstacleData) *encounterv2pb.Entity {
+	return &encounterv2pb.Entity{
+		Id:       string(obstacle.ID),
+		Position: HexToPosition(obstacle.Position),
+		Type:     encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE,
+		Data: &encounterv2pb.Entity_Obstacle{
+			Obstacle: &encounterv2pb.ObstacleData{
+				ObstacleRef:       obstacleRefFor(obstacle.Ref),
+				BlocksMovement:    obstacle.BlocksMovement,
+				BlocksLineOfSight: obstacle.BlocksLoS,
+			},
+		},
+	}
+}
+
+func obstacleRefFor(toolkitObstacleRef string) *encounterv2pb.Ref {
+	parts := splitRef(toolkitObstacleRef)
+	if len(parts) == 3 {
+		return &encounterv2pb.Ref{Module: parts[0], Type: parts[1], Id: parts[2]}
+	}
+	return &encounterv2pb.Ref{Module: refModuleDnd5e, Type: "obstacle", Id: toolkitObstacleRef}
 }

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -203,7 +203,14 @@ func (s *ProjectSuite) TestProjectFor_ObstacleMalformedRefAndEmptyFallback() {
 	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
 	s.Require().NoError(err)
 	s.Require().Len(pb.GetSpace().GetEntities(), 2)
-	obstacle := pb.GetSpace().GetEntities()[1]
+	var obstacle *encounterv2pb.Entity
+	for _, entity := range pb.GetSpace().GetEntities() {
+		if entity.GetId() == "obstacle-bad" {
+			obstacle = entity
+			break
+		}
+	}
+	s.Require().NotNil(obstacle)
 	s.Require().Equal(encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE, obstacle.GetType())
 	s.Require().Equal("dnd5e", obstacle.GetObstacle().GetObstacleRef().GetModule())
 	s.Require().Equal("obstacle", obstacle.GetObstacle().GetObstacleRef().GetType())

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -157,6 +157,64 @@ func (s *ProjectSuite) TestProjectFor_TurnBased_EmitsModeTurnStateAndMonsters() 
 	s.Require().Equal(int32(15), gob.GetArmorClass(), "armor_class must match MonsterData.AC")
 }
 
+func (s *ProjectSuite) TestProjectFor_ProjectsOnlyRevealedObstaclesInStableIDOrder() {
+	enc := tkenc.New(context.Background(), "enc-obstacles", s.broker)
+	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-alice", EntityID: "char-alice", Position: originHex, SightRange: 2,
+	}))
+	s.Require().NoError(enc.AddObstacle("obstacle-z", "dnd5e:props:altar", core.Hex{Q: 1, R: -1, S: 0}, true, false))
+	s.Require().NoError(enc.AddObstacle("obstacle-hidden", "dnd5e:props:coffin", core.Hex{Q: 5, R: -5, S: 0}, true, true))
+	s.Require().NoError(enc.AddObstacle("obstacle-a", "dnd5e:props:obelisk", core.Hex{Q: 2, R: -2, S: 0}, false, true))
+	data := enc.ToData()
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+
+	var obstacles []*encounterv2pb.Entity
+	for _, entity := range pb.GetSpace().GetEntities() {
+		if entity.GetType() == encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE {
+			obstacles = append(obstacles, entity)
+		}
+	}
+	s.Require().Len(obstacles, 2, "unrevealed obstacles must not leak into a snapshot")
+	s.Require().Equal([]string{"obstacle-a", "obstacle-z"}, []string{obstacles[0].GetId(), obstacles[1].GetId()})
+	s.Require().Equal(int32(2), obstacles[0].GetPosition().GetX())
+	s.Require().Equal(int32(-2), obstacles[0].GetPosition().GetY())
+	s.Require().Equal(int32(0), obstacles[0].GetPosition().GetZ())
+	s.Require().Equal("dnd5e", obstacles[0].GetObstacle().GetObstacleRef().GetModule())
+	s.Require().Equal("props", obstacles[0].GetObstacle().GetObstacleRef().GetType())
+	s.Require().Equal("obelisk", obstacles[0].GetObstacle().GetObstacleRef().GetId())
+	s.Require().False(obstacles[0].GetObstacle().GetBlocksMovement())
+	s.Require().True(obstacles[0].GetObstacle().GetBlocksLineOfSight())
+	s.Require().True(obstacles[1].GetObstacle().GetBlocksMovement())
+	s.Require().False(obstacles[1].GetObstacle().GetBlocksLineOfSight())
+}
+
+func (s *ProjectSuite) TestProjectFor_ObstacleMalformedRefAndEmptyFallback() {
+	enc := tkenc.New(context.Background(), "enc-obstacles-fallback", s.broker)
+	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "player-alice", EntityID: "char-alice", Position: originHex, SightRange: 1,
+	}))
+	s.Require().NoError(enc.AddObstacle("obstacle-bad", "unqualified-prop", core.Hex{Q: 1, R: -1, S: 0}, false, false))
+	data := enc.ToData()
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+	s.Require().Len(pb.GetSpace().GetEntities(), 2)
+	obstacle := pb.GetSpace().GetEntities()[1]
+	s.Require().Equal(encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE, obstacle.GetType())
+	s.Require().Equal("dnd5e", obstacle.GetObstacle().GetObstacleRef().GetModule())
+	s.Require().Equal("obstacle", obstacle.GetObstacle().GetObstacleRef().GetType())
+	s.Require().Equal("unqualified-prop", obstacle.GetObstacle().GetObstacleRef().GetId())
+
+	data.Space.Obstacles = nil
+	pb, err = v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+	s.Require().Len(pb.GetSpace().GetEntities(), 1, "empty obstacles must preserve the prior snapshot shape")
+}
+
 func (s *ProjectSuite) TestProjectFor_TurnBased_SkipsMonsterOutsideLOS() {
 	// Goblin parked far outside alice's sight — must NOT appear on the wire.
 	data := tkenc.NewData("enc-los")

--- a/internal/handlers/dnd5e/v2/encounter/translate.go
+++ b/internal/handlers/dnd5e/v2/encounter/translate.go
@@ -467,6 +467,13 @@ func entityForID(ctx context.Context, charRepo characterrepo.Repository, data *e
 	if m, ok := data.Monsters[id]; ok {
 		return monsterEntity(m)
 	}
+	if data.Space != nil {
+		for _, obstacle := range data.Space.Obstacles {
+			if obstacle.ID == id {
+				return obstacleEntity(obstacle)
+			}
+		}
+	}
 	if pid := playerSeatForEntity(data, id); pid != "" {
 		if pd := data.Players[pid]; pd != nil {
 			name, classRef, equip := characterDataFor(ctx, charRepo, string(pd.EntityID))

--- a/internal/integration/dungeon_crypt_test.go
+++ b/internal/integration/dungeon_crypt_test.go
@@ -577,7 +577,11 @@ func (s *DungeonCryptSuite) TestStaticObstacles_ProjectOnlyWhenRevealedAndRemain
 	postReveal := drainAvailable(events, 1500*time.Millisecond)
 	appeared := 0
 	for _, event := range postReveal {
-		entity := event.GetEntityAppeared().GetEntity()
+		appearance := event.GetEntityAppeared()
+		if appearance == nil {
+			continue
+		}
+		entity := appearance.GetEntity()
 		if entity.GetId() != string(revealed.ID) {
 			continue
 		}

--- a/internal/integration/dungeon_crypt_test.go
+++ b/internal/integration/dungeon_crypt_test.go
@@ -511,6 +511,99 @@ func (s *DungeonCryptSuite) TestBossMonster_NoEntityAppeared_UntilBothDoorsOpenA
 		"a sightline that actually forms (alice standing on the boss monster's hex) must emit EntityAppeared")
 }
 
+func (s *DungeonCryptSuite) TestStaticObstacles_ProjectOnlyWhenRevealedAndRemainExplored() {
+	encounterID, characterID, encData := s.startCryptDungeon("obstacles", "alice")
+	s.Require().NotEmpty(encData.Space.Obstacles, "#697 must persist canonical crypt obstacles")
+
+	bossObstacleIDs := make(map[string]bool)
+	for _, obstacle := range encData.Space.Obstacles {
+		archetype, ok := regionArchetypeAt(encData.Space, obstacle.Position)
+		if ok && archetype == tkenc.ArchetypeBoss {
+			bossObstacleIDs[string(obstacle.ID)] = true
+		}
+	}
+	s.Require().NotEmpty(bossObstacleIDs, "crypt must persist boss-region obstacle instances")
+
+	initial, err := s.srv.EncounterClientV2.GetEncounter(s.authCtx("alice"), &encounterv2pb.GetEncounterRequest{EncounterId: encounterID})
+	s.Require().NoError(err)
+	initialObstacleIDs := map[string]bool{}
+	for _, entity := range initial.GetEncounter().GetSpace().GetEntities() {
+		if entity.GetType() == encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE {
+			initialObstacleIDs[entity.GetId()] = true
+		}
+	}
+	for id := range bossObstacleIDs {
+		s.Require().False(initialObstacleIDs[id], "hidden boss obstacle %q must not leak in the initial snapshot", id)
+	}
+
+	stream, err := s.srv.EncounterClientV2.StreamEncounter(s.authCtx("alice"), &encounterv2pb.StreamEncounterRequest{EncounterId: encounterID})
+	s.Require().NoError(err)
+	events := s.streamEvents(stream)
+	_ = drainAvailable(events, 500*time.Millisecond)
+
+	doorIDs := make([]string, 0, len(encData.Doors))
+	for id := range encData.Doors {
+		doorIDs = append(doorIDs, string(id))
+	}
+	sort.Strings(doorIDs)
+	s.Require().Len(doorIDs, 2)
+	s.openDoor(encounterID, doorIDs[0])
+	_ = drainAvailable(events, 500*time.Millisecond)
+	s.openDoor(encounterID, doorIDs[1])
+	_ = drainAvailable(events, 500*time.Millisecond)
+
+	current, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	var revealed tkenc.ObstacleData
+	var target core.Hex
+	for _, obstacle := range current.Space.Obstacles {
+		if !bossObstacleIDs[string(obstacle.ID)] || obstacle.BlocksLoS {
+			continue
+		}
+		for _, neighbor := range perception.HexNeighbors(obstacle.Position) {
+			if _, pathErr := planWalk(current.Space, current.Doors, current.Players["alice"].View.Position, neighbor); pathErr == nil {
+				revealed = obstacle
+				target = neighbor
+				break
+			}
+		}
+		if revealed.ID != "" {
+			break
+		}
+	}
+	s.Require().NotEmpty(revealed.ID, "a boss obstacle with an adjacent walkable reveal target must exist")
+
+	s.Require().NoError(s.moveAlongPath(encounterID, characterID, target, 10))
+	postReveal := drainAvailable(events, 1500*time.Millisecond)
+	appeared := 0
+	for _, event := range postReveal {
+		entity := event.GetEntityAppeared().GetEntity()
+		if entity.GetId() != string(revealed.ID) {
+			continue
+		}
+		appeared++
+		s.Require().Equal(encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE, entity.GetType())
+		s.Require().Equal(string(revealed.ID), entity.GetId())
+		s.Require().Equal(int32(revealed.Position.Q), entity.GetPosition().GetX())
+		s.Require().Equal(int32(revealed.Position.R), entity.GetPosition().GetY())
+		s.Require().Equal(int32(revealed.Position.S), entity.GetPosition().GetZ())
+		s.Require().Equal(revealed.Ref, entity.GetObstacle().GetObstacleRef().GetModule()+":"+entity.GetObstacle().GetObstacleRef().GetType()+":"+entity.GetObstacle().GetObstacleRef().GetId())
+		s.Require().Equal(revealed.BlocksMovement, entity.GetObstacle().GetBlocksMovement())
+		s.Require().Equal(revealed.BlocksLoS, entity.GetObstacle().GetBlocksLineOfSight())
+	}
+	s.Require().Equal(1, appeared, "one toolkit EntityAppeared must become one wire envelope")
+
+	reconnect, err := s.srv.EncounterClientV2.GetEncounter(s.authCtx("alice"), &encounterv2pb.GetEncounterRequest{EncounterId: encounterID})
+	s.Require().NoError(err)
+	var found bool
+	for _, entity := range reconnect.GetEncounter().GetSpace().GetEntities() {
+		if entity.GetId() == string(revealed.ID) {
+			found = true
+		}
+	}
+	s.Require().True(found, "a revealed static obstacle must remain in reconnect snapshots")
+}
+
 // TestSpaceZonesAndHexZoneId_ProjectRegionsOnTheWire is rpg-api#687's Done
 // bar verified end to end through the REAL RPC surface (not a hand-seeded
 // project_test.go fixture), ported here after rpg-api#693 retired the


### PR DESCRIPTION
Closes #692

## Data flow

Pure projection of toolkit `SpaceData.Obstacles` into the existing v1alpha2 `Entity`/`ObstacleData` wire shape. Snapshot projection filters by each viewer's persisted `RevealedHexes`; static obstacles remain in later snapshots once explored. Toolkit encounter v0.39.0 emits the existing singular `EntityAppeared` on first reveal, and the existing data-aware stream path enriches it from persisted obstacle data. No placement, game rules, proto, web, or toolkit-source changes.

## Verification

- RED: new projector tests failed with zero projected obstacles; live translation failed as `ENTITY_TYPE_UNSPECIFIED`.
- GREEN: `go test -race ./internal/handlers/dnd5e/v2/encounter`; real Redis `DungeonCryptSuite` with the new obstacle gate.
- Crypt gate proves persisted canonical obstacles, no initial boss-region leak, one enriched reveal event through real door/move traversal, and reconnect retention.
- `go build ./...`, `go vet ./...`, non-integration `go test -race`, format/imports/tidy passed.
- `golangci-lint run` reports the existing 29 baseline findings only.
- Mutation: inverted the snapshot reveal predicate; the revealed-only test failed by projecting the hidden coffin.

— platform agent, on behalf of KirkDiggler