### PR TITLE
feat(encounter)#704: consume toolkit perimeter edge walls — bump + projection regression test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260723025004-0e4e2d77d73a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.40.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.40.0 h1:SLKQxU4pboNc7rkYc6Xk6YP1pQWG2KgQAInZDtVXmWA=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.40.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0 h1:1HQbBwZn5R3b6uzUH0sxigCaMm08vHNly3qH3AMTrUo=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/project.go
+++ b/internal/handlers/dnd5e/v2/encounter/project.go
@@ -274,9 +274,14 @@ func wallsToProto(space *tkenc.SpaceData) []*encounterv2pb.Wall {
 		if !ok {
 			continue
 		}
-		// Wave 1 persists one degenerate (Start == End) segment per
-		// discretized wall hex (SpaceData.Walls doc) — From/To both convert
-		// the same cube coordinate.
+		// Two shapes coexist on the wire (SpaceData.Walls doc, rpg-toolkit#834):
+		// wave-1 interior/connector walls persist one degenerate (Start == End)
+		// segment per discretized wall hex, so From/To convert the same cube
+		// coordinate; InitDungeon's outer-perimeter segments (rpg-toolkit#834)
+		// persist Start != End (exactly one hex step apart, Start real floor,
+		// End just outside the room), which this passthrough projects as a
+		// distinct non-degenerate From/To pair with no extra handling needed —
+		// see TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolidAndDoorsUnchanged.
 		from := HexToPosition(core.HexFromCube(w.Start))
 		to := HexToPosition(core.HexFromCube(w.End))
 		walls = append(walls, &encounterv2pb.Wall{From: from, To: to, Kind: kind})

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -1141,10 +1141,10 @@ func (s *ProjectSuite) TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolid
 	s.Require().NotEmpty(walls)
 
 	var degenerateCount, perimeterEdgeCount int
-	doorWalls := make(map[string]*encounterv2pb.Wall, 2)
+	var doorWallList []*encounterv2pb.Wall
 	for _, w := range walls {
 		if w.GetId() != "" {
-			doorWalls[w.GetId()] = w
+			doorWallList = append(doorWallList, w)
 			continue // door walls are covered separately below
 		}
 		from, to := w.GetFrom(), w.GetTo()
@@ -1168,7 +1168,19 @@ func (s *ProjectSuite) TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolid
 	// doors (entrance plain, boss locked) must still each project exactly
 	// one wall, carrying their entity id and passage edge, unaffected by
 	// the much larger Walls list the new perimeter segments add.
-	s.Require().Len(doorWalls, 2)
+	//
+	// Asserted by COUNT first (Copilot review, PR #705), not just by
+	// distinct-id map membership: a map keyed by id would silently
+	// collapse an accidental duplicate id emission (e.g. 3 door walls
+	// where 2 share an id) down to 2 entries, hiding exactly the
+	// regression this test exists to catch.
+	s.Require().Len(doorWallList, 2, "expected exactly one wall per connector door, by count not merely by distinct id")
+	doorWalls := make(map[string]*encounterv2pb.Wall, len(doorWallList))
+	for _, w := range doorWallList {
+		_, dup := doorWalls[w.GetId()]
+		s.Require().False(dup, "duplicate door wall id %q -- ProjectFor must emit exactly one wall per door", w.GetId())
+		doorWalls[w.GetId()] = w
+	}
 	entranceWall := doorWalls[string(entranceDoorID)]
 	bossWall := doorWalls[string(bossDoorID)]
 	s.Require().NotNil(entranceWall)

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -1099,6 +1099,89 @@ func (s *ProjectSuite) TestProjectFor_HexZoneId_SetViaRegionMembership_NotGeomet
 		"the door hex is adjacent to both regions but tagged into neither — zone_id must stay empty, not inherit a neighbor's zone")
 }
 
+// abs32 is a tiny int32 absolute-value helper for the cube-distance check
+// below -- Go has no builtin for it.
+func abs32(n int32) int32 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolidAndDoorsUnchanged
+// covers rpg-api#704 (rpg-toolkit#834's api half): wallsToProto's From/To
+// passthrough was independently verified (toolkit#838's gate review, and a
+// direct read of this file) to already project a boundary-edge segment
+// (Start != End) as a distinct, non-degenerate Wall{From, To} pair -- no
+// code change was needed here. This is the regression guard the gate
+// review flagged was missing: every wall-projection test above hand-builds
+// SpaceData.Walls with degenerate (Start == End) fixtures only, so none of
+// them would catch a regression in this passthrough for the NEW shape.
+// Built from a REAL rpg-toolkit encounter.CryptDungeonParams/InitDungeon
+// fixture (fixed seed) rather than a hand-rolled SpaceData, so this
+// exercises the exact generator output rpg-api receives in production.
+func (s *ProjectSuite) TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolidAndDoorsUnchanged() {
+	const (
+		entranceDoorID = core.EntityID("crypt-door-entrance-corridor")
+		bossDoorID     = core.EntityID("crypt-door-corridor-boss")
+		cryptSeed      = int64(191919)
+	)
+	enc := tkenc.New(context.Background(), "enc-crypt-projection", s.broker)
+	s.Require().NoError(enc.InitDungeon(tkenc.CryptDungeonParams(cryptSeed, entranceDoorID, bossDoorID)))
+
+	data := enc.ToData()
+	data.Mode = core.ModeFreeRoam
+	alice := newPlayerData("player-alice", "char-alice", data.Space.Entrance, 2)
+	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
+
+	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
+	s.Require().NoError(err)
+
+	walls := pb.GetSpace().GetWalls()
+	s.Require().NotEmpty(walls)
+
+	var degenerateCount, perimeterEdgeCount int
+	doorWalls := make(map[string]*encounterv2pb.Wall, 2)
+	for _, w := range walls {
+		if w.GetId() != "" {
+			doorWalls[w.GetId()] = w
+			continue // door walls are covered separately below
+		}
+		from, to := w.GetFrom(), w.GetTo()
+		if from.GetX() == to.GetX() && from.GetY() == to.GetY() && from.GetZ() == to.GetZ() {
+			degenerateCount++
+			continue
+		}
+		// Non-degenerate: a boundary-edge perimeter segment (rpg-toolkit#834).
+		perimeterEdgeCount++
+		dist := (abs32(from.GetX()-to.GetX()) + abs32(from.GetY()-to.GetY()) + abs32(from.GetZ()-to.GetZ())) / 2
+		s.Require().Equal(int32(1), dist, "perimeter-edge wall %+v must be exactly one hex step apart", w)
+		s.Require().Equal(encounterv2pb.WallKind_WALL_KIND_SOLID, w.GetKind(),
+			"a perimeter-edge segment (BlocksMovement+BlocksLoS both true) must project as WALL_KIND_SOLID")
+	}
+	s.Require().Positive(degenerateCount,
+		"the crypt's interior/connector walls must still project degenerate (From==To)")
+	s.Require().Positive(perimeterEdgeCount,
+		"the crypt must project at least one non-degenerate perimeter-edge wall")
+
+	// doorWallsToProto output unchanged in shape: the crypt's two connector
+	// doors (entrance plain, boss locked) must still each project exactly
+	// one wall, carrying their entity id and passage edge, unaffected by
+	// the much larger Walls list the new perimeter segments add.
+	s.Require().Len(doorWalls, 2)
+	entranceWall := doorWalls[string(entranceDoorID)]
+	bossWall := doorWalls[string(bossDoorID)]
+	s.Require().NotNil(entranceWall)
+	s.Require().NotNil(bossWall)
+	s.Require().Equal(encounterv2pb.WallKind_WALL_KIND_DOOR_CLOSED, entranceWall.GetKind(),
+		"the crypt's entrance connector is a plain closed door")
+	s.Require().Equal(encounterv2pb.WallKind_WALL_KIND_DOOR_LOCKED, bossWall.GetKind(),
+		"the crypt's boss connector is locked per CryptDungeonParams")
+	s.Require().NotEqual(entranceWall.GetFrom(), entranceWall.GetTo(),
+		"a door wall must project its passage edge, not a degenerate Start==End segment")
+	s.Require().NotEqual(bossWall.GetFrom(), bossWall.GetTo())
+}
+
 func TestProjectSuite(t *testing.T) {
 	suite.Run(t, new(ProjectSuite))
 }

--- a/internal/integration/dungeon_crypt_test.go
+++ b/internal/integration/dungeon_crypt_test.go
@@ -238,7 +238,11 @@ func planWalk(space *tkenc.SpaceData, doors map[core.EntityID]*tkenc.DoorData, f
 		}
 	}
 	for _, wall := range space.Walls {
-		if wall.BlocksMovement {
+		// isDegenerateBlockingWall (lobby_start_then_move_test.go, same
+		// package) is the shared rpg-api#704 filter: a boundary-edge
+		// perimeter segment (Start != End) is real walkable floor with a
+		// render-only wall on one edge, never an actual blocker cell.
+		if isDegenerateBlockingWall(wall) {
 			blocked[core.HexFromCube(wall.Start)] = true
 		}
 	}

--- a/internal/integration/lobby_start_then_move_test.go
+++ b/internal/integration/lobby_start_then_move_test.go
@@ -28,6 +28,7 @@ import (
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
 type LobbyStartThenMoveSuite struct {
@@ -293,21 +294,7 @@ func hexBlocksMovement(space *tkenc.SpaceData, hex core.Hex) bool {
 		return false
 	}
 	for _, w := range space.Walls {
-		// rpg-api#704 (rpg-toolkit#834): SpaceData.Walls now also carries
-		// boundary-edge perimeter segments (Start != End) -- real walkable
-		// floor hexes with a render-only wall on one outward-facing edge,
-		// never an actual spatial.Room blocker (rpg-toolkit's
-		// rebuildRoomFromData skips placing an entity for these). The
-		// crypt's entrance sits at the room's own column-0 edge, so the
-		// ENTIRE spawn column now carries one of these -- without this
-		// filter, every entrance spawn would misclassify as blocked (a
-		// false #656-regression report: the entity actually moves, but
-		// this helper predicted it wouldn't). Only a degenerate
-		// (Start == End) wall entry is ever a real movement blocker.
-		if w.Start != w.End {
-			continue
-		}
-		if w.BlocksMovement && core.HexFromCube(w.Start) == hex {
+		if isDegenerateBlockingWall(w) && core.HexFromCube(w.Start) == hex {
 			return true
 		}
 	}
@@ -317,4 +304,27 @@ func hexBlocksMovement(space *tkenc.SpaceData, hex core.Hex) bool {
 		}
 	}
 	return false
+}
+
+// isDegenerateBlockingWall reports whether w marks its OWN Start hex as a
+// blocked cell -- rpg-api#704 (rpg-toolkit#834): SpaceData.Walls now
+// carries two shapes. A degenerate entry (Start == End) is a real,
+// walkable-cell-sized blocker: interior pattern walls, connector boundary
+// columns. A boundary-edge entry (Start != End) is a render-only
+// perimeter segment -- Start is real walkable floor with a wall drawn on
+// one outward-facing edge, never an actual spatial.Room blocker
+// (rpg-toolkit's rebuildRoomFromData skips placing an entity for these).
+// Its BlocksMovement is true too (Copilot review, PR #705) -- that flag
+// describes the WALL, not the hex; it says nothing about whether Start
+// itself is impassable. The crypt's entrance sits at the room's own
+// column-0 edge, so the ENTIRE spawn column carries one of these --
+// without this filter, every entrance spawn would misclassify as blocked
+// (a false #656-regression report: the entity actually moves, but the
+// caller predicted it wouldn't).
+//
+// Shared by hexBlocksMovement (this file) and planWalk
+// (dungeon_crypt_test.go, same package) so this filter can't be
+// reintroduced independently, wrong, a third time.
+func isDegenerateBlockingWall(w environments.WallSegmentData) bool {
+	return w.Start == w.End && w.BlocksMovement
 }

--- a/internal/integration/lobby_start_then_move_test.go
+++ b/internal/integration/lobby_start_then_move_test.go
@@ -293,6 +293,20 @@ func hexBlocksMovement(space *tkenc.SpaceData, hex core.Hex) bool {
 		return false
 	}
 	for _, w := range space.Walls {
+		// rpg-api#704 (rpg-toolkit#834): SpaceData.Walls now also carries
+		// boundary-edge perimeter segments (Start != End) -- real walkable
+		// floor hexes with a render-only wall on one outward-facing edge,
+		// never an actual spatial.Room blocker (rpg-toolkit's
+		// rebuildRoomFromData skips placing an entity for these). The
+		// crypt's entrance sits at the room's own column-0 edge, so the
+		// ENTIRE spawn column now carries one of these -- without this
+		// filter, every entrance spawn would misclassify as blocked (a
+		// false #656-regression report: the entity actually moves, but
+		// this helper predicted it wouldn't). Only a degenerate
+		// (Start == End) wall entry is ever a real movement blocker.
+		if w.Start != w.End {
+			continue
+		}
 		if w.BlocksMovement && core.HexFromCube(w.Start) == hex {
 			return true
 		}


### PR DESCRIPTION
— implementer (asset-pipeline), on behalf of KirkDiggler

## Summary

Bumps `github.com/KirkDiggler/rpg-toolkit/encounter` v0.40.0 → v0.42.0 (rpg-toolkit#834/#838 boundary-edge perimeter walls, rpg-toolkit#835/#837 crypt PatternEmpty interiors), and adds the projection regression test rpg-toolkit#838's gate review recommended.

## Why no `wallsToProto` code change was needed

Verified independently twice (rpg-toolkit#838's gate review, and a direct read of this repo's `project.go` during this PR): `wallsToProto` already reads `w.Start`/`w.End` separately and passes them through as distinct `From`/`To` — has since rpg-api#645, the original walls-on-the-wire commit. A `Start != End` perimeter segment therefore already projects as `Wall{From: floorHex, To: outsideHex, Kind: WALL_KIND_SOLID}` with zero extra handling — the client's `hexDistance==1` edge renderer (rpg-dnd5e-web#566, live on the real route) can already draw it as one clean slab. The earlier "api collapses `From=To`" claim (rpg-toolkit#834's original PR body) was a stale in-code comment being misread as behavior; see that PR's correction comment. This PR corrects that same stale comment here (`project.go`'s `wallsToProto`), since it described only the wave-1 degenerate shape.

## Test evidence

New `TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolidAndDoorsUnchanged` (`project_test.go`), built from a REAL `encounter.CryptDungeonParams`/`InitDungeon` fixture (fixed seed) rather than a hand-built `SpaceData` — every existing wall-projection test in this file uses degenerate-only (`Start == End`) fixtures, so none of them would have caught a regression in this passthrough for the new shape. Asserts:
- Non-degenerate perimeter segments project `From != To`, exactly one hex apart, `Kind = WALL_KIND_SOLID`.
- Degenerate interior/connector walls still project `From == To`.
- `doorWallsToProto` output (id, kind, passage edge) is unchanged in shape — the crypt's two connector doors (entrance plain/closed, boss locked) still each project exactly one wall correctly, unaffected by the much larger `Walls` list the new perimeter segments add.

Discrimination check: this test fails pre-bump (`perimeterEdgeCount == 0` against the old toolkit version — confirmed) and passes post-bump.

## Second, unplanned fix this bump surfaced: `internal/integration/lobby_start_then_move_test.go`

Running the full suite (including the shared-Redis integration tests) surfaced a real regression from the bump itself, in test code rather than production code: `hexBlocksMovement` (the rpg-api#656 regression gate's helper) iterated `SpaceData.Walls` checking `BlocksMovement` + `Start` match, without filtering to degenerate (`Start == End`) entries — the exact same interaction class already fixed twice upstream in rpg-toolkit (`boss_primary_axis_test.go`, `crypt_dungeon_test.go`). The crypt's entrance sits at the room's own column-0 edge (by design — "a dungeon entrance has nothing behind it"), so the entire spawn column now legitimately carries boundary-edge perimeter segments. Without the filter, `TestLobbyStartThenMoveSuite` misclassified every entrance spawn as movement-blocked and failed asserting the entity stayed at spawn when it had actually (correctly) moved.

Fixed by adding the same `if w.Start != w.End { continue }` filter, preserving the test's actual intent (no *real* blocking wall on the movement path). Verified: reverting the filter locally reproduces the failure (confirmed RED), restoring it passes (confirmed GREEN).

## Test results

Unit + integration (shared Redis via testcontainers), fresh run, no cache:
```
go test -count=1 -short -race ./...
ok  	.../internal/handlers/dnd5e/v2/encounter	3.5s
ok  	.../internal/integration	26.3s
ok  	.../internal/integration/character	14.3s
ok  	.../internal/integration/harness	1.3s
... (all other packages ok)
```
`golangci-lint run` and `go generate ./...` both show pre-existing, unrelated repo-wide drift (19 goconst + assorted other lint findings in unconnected files; 7 mock files with an import-order-only diff from a different installed `mockgen` version) — none in any file this PR touches; left untouched as out of scope.

## go.mod note

Open PR rpg-api#703 (now merged into `main` as of this branch's base) also bumped this module; this branch is cut from current `main`, so there's no version conflict to resolve.

Refs: rpg-toolkit#834, rpg-toolkit#838, rpg-toolkit#835, rpg-toolkit#837, rpg-dnd5e-web#562, rpg-dnd5e-web#566.

Closes #704