### PR TITLE
feat(encounter)#707: consume toolkit crypt dressing -- bump to v0.43.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260723025004-0e4e2d77d73a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.43.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0 h1:1HQbBwZn5R3b6uzUH0sxigCaMm08vHNly3qH3AMTrUo=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.43.0 h1:xNnvksMVMP1PbwBkPeJtCFL1KI0dxGdrKNBCUc4Kw+8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.43.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -1131,7 +1131,15 @@ func (s *ProjectSuite) TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolid
 
 	data := enc.ToData()
 	data.Mode = core.ModeFreeRoam
-	alice := newPlayerData("player-alice", "char-alice", data.Space.Entrance, 2)
+	// SightRange 30 comfortably covers the whole entrance region (width
+	// 10, height 8) from the entrance spawn -- unlike walls/doors (whole-
+	// room, unconditional), obstacle visibility on the wire IS
+	// LOS/reveal-gated, and rpg-toolkit#839's dressing lands wherever its
+	// PreferBorder draw happens to place it within the region, not
+	// necessarily near the spawn cell. A short sight range here would
+	// make the bone-pile assertion below seed-dependent instead of a
+	// reliable proof.
+	alice := newPlayerData("player-alice", "char-alice", data.Space.Entrance, 30)
 	data.Players = map[core.PlayerID]*tkenc.PlayerData{"player-alice": alice}
 
 	pb, err := v2encounter.ProjectFor(context.Background(), data, "player-alice", s.broker, nil, s.now)
@@ -1139,6 +1147,26 @@ func (s *ProjectSuite) TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolid
 
 	walls := pb.GetSpace().GetWalls()
 	s.Require().NotEmpty(walls)
+
+	// rpg-api#707: rpg-toolkit#839's dressing (bone-pile, candles, chain,
+	// skeleton-remains) is the FIRST real crypt content with
+	// BlocksMovement=false -- every obstacle before it always blocked
+	// movement. Confirms the wire projection actually carries that flag
+	// through for a REAL CryptDungeonParams-placed instance, not just the
+	// hand-built fixture TestProjectFor_ProjectsOnlyRevealedObstaclesInStableIDOrder
+	// already covers generically.
+	var bonePile *encounterv2pb.Entity
+	for _, entity := range pb.GetSpace().GetEntities() {
+		if entity.GetType() == encounterv2pb.EntityType_ENTITY_TYPE_OBSTACLE &&
+			entity.GetObstacle().GetObstacleRef().GetId() == "bone-pile" {
+			bonePile = entity
+			break
+		}
+	}
+	s.Require().NotNil(bonePile, "the entrance region's bone-pile dressing must be revealed and projected")
+	s.Require().False(bonePile.GetObstacle().GetBlocksMovement(),
+		"a bone-pile is walkable-past floor dressing -- must project blocks_movement=false on the wire")
+	s.Require().False(bonePile.GetObstacle().GetBlocksLineOfSight())
 
 	var degenerateCount, perimeterEdgeCount int
 	var doorWallList []*encounterv2pb.Wall

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -617,16 +617,28 @@ func (s *LobbySuite) TestStartEncounter_CryptObstacles_ExactRefsCountsAndBlockin
 
 	entranceCounts, entranceBlocking := obstaclesByRef(s.T(), byRegion[tkenc.ArchetypeEntrance])
 	s.Require().Equal(map[string]int{
-		tkenc.CryptObstacleRefObelisk: 1,
-		tkenc.CryptObstacleRefPillar:  2,
-	}, entranceCounts, "entrance region: exactly 1 obelisk + 2 pillars")
+		tkenc.CryptObstacleRefObelisk:  1,
+		tkenc.CryptObstacleRefPillar:   2,
+		tkenc.CryptObstacleRefBrazier:  2,
+		tkenc.CryptObstacleRefBonePile: 2,
+	}, entranceCounts, "entrance region: exactly 1 obelisk + 2 pillars + 2 braziers + 2 bone-piles "+
+		"(rpg-toolkit#839 depth-pass dressing)")
 	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: true}, entranceBlocking[tkenc.CryptObstacleRefObelisk])
 	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: true}, entranceBlocking[tkenc.CryptObstacleRefPillar])
+	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: false}, entranceBlocking[tkenc.CryptObstacleRefBrazier],
+		"a brazier blocks movement but not line of sight -- you can see over the flame")
+	s.Require().Equal(obstacleBlocking{blocksMovement: false, blocksLoS: false}, entranceBlocking[tkenc.CryptObstacleRefBonePile],
+		"a bone-pile is walkable-past floor dressing -- blocks neither movement nor line of sight")
 
-	corridorCounts, _ := obstaclesByRef(s.T(), byRegion[tkenc.ArchetypeCorridor])
+	corridorCounts, corridorBlocking := obstaclesByRef(s.T(), byRegion[tkenc.ArchetypeCorridor])
 	s.Require().Equal(map[string]int{
-		tkenc.CryptObstacleRefPillar: 1,
-	}, corridorCounts, "corridor region: exactly 1 sparse pillar, no others")
+		tkenc.CryptObstacleRefPillar:      1,
+		tkenc.CryptObstacleRefTorchOrnate: 1,
+	}, corridorCounts, "corridor region: exactly 1 sparse pillar + 1 torch-ornate light anchor "+
+		"(rpg-toolkit#839), still no others")
+	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: false},
+		corridorBlocking[tkenc.CryptObstacleRefTorchOrnate],
+		"a torch-ornate blocks movement but not line of sight -- same shape as a brazier")
 
 	bossCounts, bossBlocking := obstaclesByRef(s.T(), byRegion[tkenc.ArchetypeBoss])
 	s.Require().Equal(map[string]int{
@@ -634,13 +646,27 @@ func (s *LobbySuite) TestStartEncounter_CryptObstacles_ExactRefsCountsAndBlockin
 		tkenc.CryptObstacleRefAltar:              1,
 		tkenc.CryptObstacleRefStatueReaper:       1,
 		tkenc.CryptObstacleRefStatueKnightHooded: 1,
-	}, bossCounts, "boss region: coffin + altar + one of each statue variant")
+		tkenc.CryptObstacleRefCandles:            2,
+		tkenc.CryptObstacleRefBrazier:            2,
+		tkenc.CryptObstacleRefChain:              1,
+		tkenc.CryptObstacleRefSkeletonRemains:    1,
+	}, bossCounts, "boss region: coffin + altar + one of each statue variant, plus rpg-toolkit#839's "+
+		"2 candles + 2 braziers + 1 chain + 1 skeleton-remains")
 	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: false}, bossBlocking[tkenc.CryptObstacleRefCoffin],
 		"the coffin/tomb blocks movement but not line of sight -- walk around, see over")
 	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: true}, bossBlocking[tkenc.CryptObstacleRefAltar])
 	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: true}, bossBlocking[tkenc.CryptObstacleRefStatueReaper])
 	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: true},
 		bossBlocking[tkenc.CryptObstacleRefStatueKnightHooded])
+	s.Require().Equal(obstacleBlocking{blocksMovement: true, blocksLoS: false}, bossBlocking[tkenc.CryptObstacleRefBrazier],
+		"a brazier blocks movement but not line of sight -- you can see over the flame")
+	s.Require().Equal(obstacleBlocking{blocksMovement: false, blocksLoS: false}, bossBlocking[tkenc.CryptObstacleRefCandles],
+		"candles are walkable-past floor dressing -- block neither movement nor line of sight")
+	s.Require().Equal(obstacleBlocking{blocksMovement: false, blocksLoS: false}, bossBlocking[tkenc.CryptObstacleRefChain],
+		"a chain is walkable-past floor dressing -- blocks neither movement nor line of sight")
+	s.Require().Equal(obstacleBlocking{blocksMovement: false, blocksLoS: false},
+		bossBlocking[tkenc.CryptObstacleRefSkeletonRemains],
+		"skeleton-remains is walkable-past floor dressing -- blocks neither movement nor line of sight")
 }
 
 // TestStartEncounter_CryptObstacles_ExplicitSeed_DeterministicPositions


### PR DESCRIPTION
Bumps github.com/KirkDiggler/rpg-toolkit/encounter v0.42.0 -> v0.43.0 (rpg-toolkit#840/#839: crypt dressing + light-anchor set pieces per region, per-spec PreferBorder placement). No api code changes needed -- obstacle refs are opaque passthrough (api#702 projection already copies Ref/BlocksMovement/BlocksLoS verbatim regardless of value).

Extends TestStartEncounter_CryptObstacles_ExactRefsCountsAndBlockingByRegion (internal/orchestrators/lobby/start_encounter_test.go) honestly to the new refs/counts/blocking flags a real StartEncounter call now persists: entrance +2 brazier (true/false) +2 bone-pile (false/false); corridor +1 torch-ornate (true/false); boss +2 candles +2 brazier +1 chain +1 skeleton-remains (dressing false/false). Every prior assertion is kept, none weakened -- this only adds coverage for the new content.

Extends TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolidAndDoorsUnchanged (internal/handlers/dnd5e/v2/encounter/project_test.go) with the first real non-blocking-obstacle wire-projection proof from an actual CryptDungeonParams fixture: asserts a bone-pile instance projects blocks_movement=false (and blocks_line_of_sight=false) on the wire. Every crypt obstacle before rpg-toolkit#839 always blocked movement, so this is genuinely new ground for the real crypt content path (the generic non-blocking-obstacle wire mechanism was already covered separately by a hand-built fixture in
TestProjectFor_ProjectsOnlyRevealedObstaclesInStableIDOrder). Also bumped that test's SightRange from 2 to 30: unlike walls/doors (whole- room, unconditional), obstacle visibility on the wire IS LOS/reveal- gated, and the dressing's PreferBorder draw can land anywhere in the entrance region, not necessarily near the spawn cell -- verified the sight-range bump is actually load-bearing (temporarily reverted to SightRange 2, confirmed the bone-pile assertion fails at this fixture's seed; restored, confirmed green).

Full suite, fresh (-count=1), no cache, including non-short integration: go test -count=1 -race ./...
ok  	.../internal/handlers/dnd5e/v2/encounter	3.658s ok  	.../internal/integration	40.267s
ok  	.../internal/integration/character	14.948s
ok  	.../internal/integration/harness	12.641s
ok  	.../internal/orchestrators/lobby	18.258s
... (all other packages ok)

gofmt/goimports clean on all changed files.

Closes #707