### PR TITLE
feat(content)#709: reference-tomb becomes the 3-room tomb (entrance/hall/boss) — Kirk-approved live

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -237,6 +237,11 @@ func runServer(_ *cobra.Command, _ []string) error {
 		LobbyIDGenerator:      idgen.NewUUID("lobby"),
 		JoinRefGenerator:      idgen.NewUUID("join"),
 		EncounterIDGenerator:  idgen.NewUUID(""),
+		// RPG_DUNGEON_KEY (Task E2b): the M1 manual-walkthrough mechanism --
+		// unset in every real deployment today (zero player-facing change),
+		// validated at construction below (a misconfigured value fails
+		// server startup loudly, not the first StartEncounter call).
+		DungeonKeyOverride: os.Getenv("RPG_DUNGEON_KEY"),
 	})
 	if err != nil {
 		return fmt.Errorf("lobby orchestrator: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260723025004-0e4e2d77d73a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.43.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.44.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.0
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.1
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0
@@ -25,6 +25,7 @@ require (
 	go.uber.org/mock v0.6.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -88,5 +89,4 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.43.0 h1:xNnvksMVMP1PbwBkPeJtCFL1KI0dxGdrKNBCUc4Kw+8=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.43.0/go.mod h1:H16tYrimI/y9UX4/0XISFbfHsBYNIH4hnT/H7IB9PL8=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.44.0 h1:qPruibDIY+NrP/iWR2Xpy+ic7xdSOXI1NakaGZFj5jE=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.44.0/go.mod h1:aYGY8a2YADbnKO4qXy38vEMMsQLhgVuHUZozR7F2GVs=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.0 h1:Cugi+0R4EofSJ9fhS1I2W9InLRTm3HgrNTZ3/CSoX+4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.0 h1:BukBLS76ot7xbE4WpY38ua9cU5tUq6C4baLIWPbGnXE=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4 h1:v7Imq00j5KrQ/PLOR3sOuaxBf3h5ERmHePpQuhGJr9g=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -1,26 +1,28 @@
 // Copyright (C) 2024 Kirk Diggler
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package content hosts dungeon spec YAML files: embedded at build time
-// from dungeons/*.yaml, with an optional RPG_CONTENT_DIR directory that
-// augments the embedded set at runtime — an author editing a file under
-// that directory sees their edit on the next process restart, no rebuild
-// (dungeon-authoring design.md §Content hosting).
+// Package content hosts dungeon spec YAML files, indexed by each file's
+// declared key: field (not filename). The embedded dungeons/*.yaml set is
+// compiled into the binary; an optional RPG_CONTENT_DIR directory
+// augments it at runtime with *.yaml/*.yml files of its own, winning over
+// an embedded file on a key collision.
 //
-// This package only hosts raw bytes indexed by each spec's declared `key:`
-// field. It never decodes beyond that key — validating and compiling a
-// spec is rpg-toolkit's encounter/dungeonspec.Load, called by callers (see
-// TestEveryEmbeddedSpecLoads).
+// This package only reads and indexes raw bytes -- it never validates a
+// spec's contents; that's rpg-toolkit's encounter/dungeonspec.Load,
+// called by callers (see TestEveryEmbeddedSpecLoads). It also only reads
+// RPG_CONTENT_DIR fresh on every call -- whether an edit there takes
+// effect immediately or requires a process restart is a property of
+// whoever calls AllSpecs/SpecByKey and how often they cache the result,
+// not of this package.
 package content
 
 import (
 	"embed"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 //go:embed dungeons/*.yaml
@@ -28,103 +30,105 @@ var embeddedFS embed.FS
 
 const embeddedDir = "dungeons"
 
-// contentDirEnvVar is the dev-loop override: when set, every *.yaml file in
-// this directory is indexed alongside the embedded set. On a key collision
-// with an embedded file, the override wins — this is what makes the
-// edit-restart authoring loop work (an author's local edit must be seen,
-// not the stale embedded copy baked in at the last build).
+// contentDirEnvVar is the dev-loop override directory. See the package
+// doc and AllSpecs for the augment/override-wins contract.
 const contentDirEnvVar = "RPG_CONTENT_DIR"
 
-// specHeader is the minimal shape needed to index a spec by its declared
-// key without fully decoding or validating it.
-type specHeader struct {
-	Key string `yaml:"key"`
-}
-
 // AllSpecs returns every known dungeon spec's raw YAML bytes, indexed by
-// each file's declared `key:` field (not filename) — the embedded set,
-// augmented by RPG_CONTENT_DIR when set (override wins on key collision).
-func AllSpecs() map[string][]byte {
-	specs := make(map[string][]byte)
-	loadEmbedded(specs)
-	loadOverrideDir(specs)
-	return specs
+// key, plus any RPG_CONTENT_DIR file that couldn't be indexed -- a
+// malformed/missing key: field, or a key colliding with another override
+// file. Those are non-fatal: reported in problems for the caller to log,
+// the affected file simply doesn't participate in the registry (an
+// author's dev-loop mistake, not a reason to fail the whole registry).
+//
+// Returns an error only when RPG_CONTENT_DIR is set but its directory
+// itself can't be read -- an operator/config mistake that must fail
+// construction loudly rather than silently falling back to
+// embedded-only content.
+//
+// Builds the registry fresh on every call -- a caller invoking this
+// per-request rather than once at startup should cache the result.
+func AllSpecs() (specs map[string][]byte, problems []string, err error) {
+	specs, _ = buildRegistry(embeddedFiles(), true) // fatal mode never returns problems -- it panics instead
+
+	dir := os.Getenv(contentDirEnvVar)
+	if dir == "" {
+		return specs, nil, nil
+	}
+
+	overrideFiles, err := readOverrideDir(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	overrides, problems := buildRegistry(overrideFiles, false)
+	for k, v := range overrides {
+		specs[k] = v // override wins over embedded on collision
+	}
+	return specs, problems, nil
 }
 
 // SpecByKey returns the raw YAML bytes for a dungeon spec by its declared
-// key, and whether that key is known.
-func SpecByKey(key string) ([]byte, bool) {
-	raw, ok := AllSpecs()[key]
-	return raw, ok
+// key, and whether that key is known. Propagates the same
+// RPG_CONTENT_DIR unreadable-directory error AllSpecs does.
+func SpecByKey(key string) (raw []byte, ok bool, err error) {
+	specs, _, err := AllSpecs()
+	if err != nil {
+		return nil, false, err
+	}
+	raw, ok = specs[key]
+	return raw, ok, nil
 }
 
-// loadEmbedded indexes every file baked into the binary at build time. A
-// file here that fails to yield a key is a broken commit — panicking is
-// intentional: this is compiled-in content, not runtime input, and a
-// silent skip would defeat the whole point of TestEveryEmbeddedSpecLoads
-// (a broken commit must fail CI, not silently vanish from the registry).
-func loadEmbedded(specs map[string][]byte) {
+// embeddedFiles reads every file under the embedded dungeons/ directory.
+// A read failure here means the embed itself is broken -- panicking is
+// intentional, compiled-in content should never fail to read.
+func embeddedFiles() []fileEntry {
 	entries, err := embeddedFS.ReadDir(embeddedDir)
 	if err != nil {
 		panic(fmt.Sprintf("content: embedded %q directory unreadable: %v", embeddedDir, err))
 	}
+	files := make([]fileEntry, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-		raw, err := embeddedFS.ReadFile(filepath.Join(embeddedDir, entry.Name()))
+		// embed.FS paths are always forward-slash regardless of OS --
+		// path.Join, not filepath.Join (which would use the OS separator).
+		raw, err := embeddedFS.ReadFile(path.Join(embeddedDir, entry.Name()))
 		if err != nil {
 			panic(fmt.Sprintf("content: embedded file %q unreadable: %v", entry.Name(), err))
 		}
-		key, err := headerKey(raw)
-		if err != nil {
-			panic(fmt.Sprintf("content: embedded file %q has no usable key: %v", entry.Name(), err))
-		}
-		specs[key] = raw
+		files = append(files, fileEntry{name: entry.Name(), raw: raw})
 	}
+	return files
 }
 
-// loadOverrideDir indexes RPG_CONTENT_DIR's *.yaml files when the env var
-// is set, overwriting any embedded entry with the same key. Unlike the
-// embedded set, a malformed file here is a local dev-loop mistake, not a
-// committed regression — it fails loudly (an author will see it
-// immediately on the next request) rather than panicking the whole
-// registry for every other content-backed key.
-func loadOverrideDir(specs map[string][]byte) {
-	dir := os.Getenv(contentDirEnvVar)
-	if dir == "" {
-		return
-	}
-
+// readOverrideDir reads every *.yaml/*.yml file in dir. Returns a hard
+// error if dir itself can't be listed (RPG_CONTENT_DIR pointing at a path
+// that doesn't exist or isn't readable) or if the OS refuses to read a
+// file it just listed (rare -- e.g. a permissions problem specific to one
+// file). Both are operator/environment problems, distinct from a file
+// whose YAML *content* is the issue -- that's buildRegistry's non-fatal
+// problems path.
+func readOverrideDir(dir string) ([]fileEntry, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		panic(fmt.Sprintf("content: %s=%q unreadable: %v", contentDirEnvVar, dir, err))
+		return nil, fmt.Errorf("content: %s=%q unreadable: %w", contentDirEnvVar, dir, err)
 	}
+	files := make([]fileEntry, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".yaml" {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".yaml" && ext != ".yml" {
 			continue
 		}
 		raw, err := os.ReadFile(filepath.Join(dir, entry.Name())) //nolint:gosec // dev-only override dir, operator-controlled path
 		if err != nil {
-			panic(fmt.Sprintf("content: %s file %q unreadable: %v", contentDirEnvVar, entry.Name(), err))
+			return nil, fmt.Errorf("content: %s file %q unreadable: %w", contentDirEnvVar, entry.Name(), err)
 		}
-		key, err := headerKey(raw)
-		if err != nil {
-			panic(fmt.Sprintf("content: %s file %q has no usable key: %v", contentDirEnvVar, entry.Name(), err))
-		}
-		specs[key] = raw // override wins on collision — plain overwrite
+		files = append(files, fileEntry{name: entry.Name(), raw: raw})
 	}
-}
-
-// headerKey decodes just enough of raw to find its declared `key:` field,
-// without running the full dungeonspec.Load validation.
-func headerKey(raw []byte) (string, error) {
-	var header specHeader
-	if err := yaml.Unmarshal(raw, &header); err != nil {
-		return "", fmt.Errorf("decode key header: %w", err)
-	}
-	if header.Key == "" {
-		return "", fmt.Errorf("empty key field")
-	}
-	return header.Key, nil
+	return files, nil
 }

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package content hosts dungeon spec YAML files: embedded at build time
+// from dungeons/*.yaml, with an optional RPG_CONTENT_DIR directory that
+// augments the embedded set at runtime — an author editing a file under
+// that directory sees their edit on the next process restart, no rebuild
+// (dungeon-authoring design.md §Content hosting).
+//
+// This package only hosts raw bytes indexed by each spec's declared `key:`
+// field. It never decodes beyond that key — validating and compiling a
+// spec is rpg-toolkit's encounter/dungeonspec.Load, called by callers (see
+// TestEveryEmbeddedSpecLoads).
+package content
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed dungeons/*.yaml
+var embeddedFS embed.FS
+
+const embeddedDir = "dungeons"
+
+// contentDirEnvVar is the dev-loop override: when set, every *.yaml file in
+// this directory is indexed alongside the embedded set. On a key collision
+// with an embedded file, the override wins — this is what makes the
+// edit-restart authoring loop work (an author's local edit must be seen,
+// not the stale embedded copy baked in at the last build).
+const contentDirEnvVar = "RPG_CONTENT_DIR"
+
+// specHeader is the minimal shape needed to index a spec by its declared
+// key without fully decoding or validating it.
+type specHeader struct {
+	Key string `yaml:"key"`
+}
+
+// AllSpecs returns every known dungeon spec's raw YAML bytes, indexed by
+// each file's declared `key:` field (not filename) — the embedded set,
+// augmented by RPG_CONTENT_DIR when set (override wins on key collision).
+func AllSpecs() map[string][]byte {
+	specs := make(map[string][]byte)
+	loadEmbedded(specs)
+	loadOverrideDir(specs)
+	return specs
+}
+
+// SpecByKey returns the raw YAML bytes for a dungeon spec by its declared
+// key, and whether that key is known.
+func SpecByKey(key string) ([]byte, bool) {
+	raw, ok := AllSpecs()[key]
+	return raw, ok
+}
+
+// loadEmbedded indexes every file baked into the binary at build time. A
+// file here that fails to yield a key is a broken commit — panicking is
+// intentional: this is compiled-in content, not runtime input, and a
+// silent skip would defeat the whole point of TestEveryEmbeddedSpecLoads
+// (a broken commit must fail CI, not silently vanish from the registry).
+func loadEmbedded(specs map[string][]byte) {
+	entries, err := embeddedFS.ReadDir(embeddedDir)
+	if err != nil {
+		panic(fmt.Sprintf("content: embedded %q directory unreadable: %v", embeddedDir, err))
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		raw, err := embeddedFS.ReadFile(filepath.Join(embeddedDir, entry.Name()))
+		if err != nil {
+			panic(fmt.Sprintf("content: embedded file %q unreadable: %v", entry.Name(), err))
+		}
+		key, err := headerKey(raw)
+		if err != nil {
+			panic(fmt.Sprintf("content: embedded file %q has no usable key: %v", entry.Name(), err))
+		}
+		specs[key] = raw
+	}
+}
+
+// loadOverrideDir indexes RPG_CONTENT_DIR's *.yaml files when the env var
+// is set, overwriting any embedded entry with the same key. Unlike the
+// embedded set, a malformed file here is a local dev-loop mistake, not a
+// committed regression — it fails loudly (an author will see it
+// immediately on the next request) rather than panicking the whole
+// registry for every other content-backed key.
+func loadOverrideDir(specs map[string][]byte) {
+	dir := os.Getenv(contentDirEnvVar)
+	if dir == "" {
+		return
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		panic(fmt.Sprintf("content: %s=%q unreadable: %v", contentDirEnvVar, dir, err))
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".yaml" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, entry.Name())) //nolint:gosec // dev-only override dir, operator-controlled path
+		if err != nil {
+			panic(fmt.Sprintf("content: %s file %q unreadable: %v", contentDirEnvVar, entry.Name(), err))
+		}
+		key, err := headerKey(raw)
+		if err != nil {
+			panic(fmt.Sprintf("content: %s file %q has no usable key: %v", contentDirEnvVar, entry.Name(), err))
+		}
+		specs[key] = raw // override wins on collision — plain overwrite
+	}
+}
+
+// headerKey decodes just enough of raw to find its declared `key:` field,
+// without running the full dungeonspec.Load validation.
+func headerKey(raw []byte) (string, error) {
+	var header specHeader
+	if err := yaml.Unmarshal(raw, &header); err != nil {
+		return "", fmt.Errorf("decode key header: %w", err)
+	}
+	if header.Key == "" {
+		return "", fmt.Errorf("empty key field")
+	}
+	return header.Key, nil
+}

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -106,6 +107,7 @@ func OverriddenKeys() ([]string, error) {
 			shadowed = append(shadowed, k)
 		}
 	}
+	sort.Strings(shadowed) // deterministic order -- stable logs, stable test assertions
 	return shadowed, nil
 }
 

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -79,6 +79,36 @@ func SpecByKey(key string) (raw []byte, ok bool, err error) {
 	return raw, ok, nil
 }
 
+// OverriddenKeys returns the RPG_CONTENT_DIR keys that also exist in the
+// embedded set -- i.e. the keys where the override actually SHADOWS an
+// embedded file, as distinct from a wholly new key the override merely
+// adds. Empty (never an error) when RPG_CONTENT_DIR is unset. Intended
+// for a one-line startup debug log confirming, to an author mid
+// edit-restart loop, that their local edit actually took effect -- not
+// for the resolution path itself (AllSpecs/SpecByKey already apply the
+// override correctly regardless of whether a caller ever calls this).
+func OverriddenKeys() ([]string, error) {
+	dir := os.Getenv(contentDirEnvVar)
+	if dir == "" {
+		return nil, nil
+	}
+
+	embedded, _ := buildRegistry(embeddedFiles(), true)
+	overrideFiles, err := readOverrideDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	overrides, _ := buildRegistry(overrideFiles, false)
+
+	var shadowed []string
+	for k := range overrides {
+		if _, embeddedHasKey := embedded[k]; embeddedHasKey {
+			shadowed = append(shadowed, k)
+		}
+	}
+	return shadowed, nil
+}
+
 // embeddedFiles reads every file under the embedded dungeons/ directory.
 // A read failure here means the embed itself is broken -- panicking is
 // intentional, compiled-in content should never fail to read.

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -202,3 +202,49 @@ func (s *ContentTestSuite) TestContentDirOverride_UnreadablePathReturnsError() {
 	_, _, err = content.SpecByKey("reference-tomb")
 	s.Require().Error(err, "SpecByKey must propagate the same unreadable-path error")
 }
+
+// TestOverriddenKeys_UnsetIsEmpty covers the no-override baseline: with
+// RPG_CONTENT_DIR unset, nothing is shadowed.
+func (s *ContentTestSuite) TestOverriddenKeys_UnsetIsEmpty() {
+	shadowed, err := content.OverriddenKeys()
+	s.Require().NoError(err)
+	s.Assert().Empty(shadowed)
+}
+
+// TestOverriddenKeys_DistinguishesShadowedFromNewKeys is the E2 debug-log
+// enabler: a caller (the lobby orchestrator's startup registry) needs to
+// tell "an override REPLACED an embedded key" (worth a debug line — an
+// author's confirmation their edit took effect) apart from "an override
+// merely ADDED a new key" (nothing was shadowed, no such confirmation is
+// meaningful). reference-tomb collides with the embedded set; atlantis is
+// wholly new and must NOT appear here even though it resolves fine via
+// SpecByKey.
+func (s *ContentTestSuite) TestOverriddenKeys_DistinguishesShadowedFromNewKeys() {
+	dir := s.T().TempDir()
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "reference-tomb.yaml"),
+		[]byte("version: 1\nkey: reference-tomb\nname: Overridden Reference Tomb\n"),
+		0o600,
+	))
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "atlantis.yaml"),
+		[]byte("version: 1\nkey: atlantis\nname: Atlantis\n"),
+		0o600,
+	))
+	s.T().Setenv("RPG_CONTENT_DIR", dir)
+
+	shadowed, err := content.OverriddenKeys()
+	s.Require().NoError(err)
+	s.Assert().Equal([]string{"reference-tomb"}, shadowed)
+}
+
+// TestOverriddenKeys_UnreadablePathReturnsError mirrors AllSpecs'/
+// SpecByKey's posture: an unreadable RPG_CONTENT_DIR is a hard error here
+// too, never silently treated as "nothing shadowed."
+func (s *ContentTestSuite) TestOverriddenKeys_UnreadablePathReturnsError() {
+	missing := filepath.Join(s.T().TempDir(), "does-not-exist")
+	s.T().Setenv("RPG_CONTENT_DIR", missing)
+
+	_, err := content.OverriddenKeys()
+	s.Require().Error(err)
+}

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package content_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+
+	"github.com/KirkDiggler/rpg-api/internal/content"
+)
+
+type ContentTestSuite struct {
+	suite.Suite
+}
+
+func TestContentSuite(t *testing.T) {
+	suite.Run(t, new(ContentTestSuite))
+}
+
+// TestEveryEmbeddedSpecLoads is the CI safety net for content authoring: a
+// broken commit to any content/dungeons/*.yaml file must fail here, not
+// surface later at StartEncounter time in prod.
+func (s *ContentTestSuite) TestEveryEmbeddedSpecLoads() {
+	specs := content.AllSpecs()
+	s.Require().NotEmpty(specs, "at least the reference-tomb fixture must be embedded")
+	for key, raw := range specs {
+		_, err := dungeonspec.Load(raw)
+		s.Require().NoError(err, "embedded spec %q must load — a broken commit fails CI, not prod", key)
+	}
+}
+
+func (s *ContentTestSuite) TestSpecByKey_UnknownKey() {
+	_, ok := content.SpecByKey("atlantis")
+	s.Assert().False(ok)
+}
+
+func (s *ContentTestSuite) TestSpecByKey_KnownKeyResolves() {
+	raw, ok := content.SpecByKey("reference-tomb")
+	s.Require().True(ok)
+	s.Assert().Contains(string(raw), "key: reference-tomb")
+}
+
+// TestContentDirOverride covers the full augment + override-wins-on-collision
+// contract: RPG_CONTENT_DIR pointing at a temp dir with one yaml file makes
+// that (new) key resolve; embedded keys not present in the override dir
+// still resolve (override AUGMENTS, doesn't replace wholesale); and on a
+// key collision between the two sources, the override wins — the mechanism
+// that makes the edit-restart authoring loop work (an author editing their
+// local content/dungeons/reference-tomb.yaml via RPG_CONTENT_DIR must see
+// their edit, not the stale embedded copy).
+func (s *ContentTestSuite) TestContentDirOverride() {
+	dir := s.T().TempDir()
+
+	// A wholly new key, not present in the embedded set at all.
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "atlantis.yaml"),
+		[]byte("version: 1\nkey: atlantis\nname: Atlantis\n"),
+		0o600,
+	))
+
+	// A key that collides with the embedded reference-tomb — distinguishable
+	// content so the test can prove which copy won.
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "reference-tomb.yaml"),
+		[]byte("version: 1\nkey: reference-tomb\nname: Overridden Reference Tomb\n"),
+		0o600,
+	))
+
+	s.T().Setenv("RPG_CONTENT_DIR", dir)
+
+	// New key from the override dir resolves.
+	atlantis, ok := content.SpecByKey("atlantis")
+	s.Require().True(ok)
+	s.Assert().Contains(string(atlantis), "Atlantis")
+
+	// Collision: override wins over the embedded copy.
+	tomb, ok := content.SpecByKey("reference-tomb")
+	s.Require().True(ok)
+	s.Assert().Contains(string(tomb), "Overridden Reference Tomb")
+
+	// AllSpecs reflects both the augmented and the overridden entry.
+	all := content.AllSpecs()
+	s.Assert().Contains(all, "atlantis")
+	s.Assert().Contains(string(all["reference-tomb"]), "Overridden Reference Tomb")
+}
+
+func (s *ContentTestSuite) TestContentDirOverride_UnsetLeavesEmbeddedIntact() {
+	// Sanity check that not setting the override doesn't change embedded
+	// behavior — guards against a future implementation accidentally
+	// treating an unset/empty RPG_CONTENT_DIR as "override with cwd".
+	raw, ok := content.SpecByKey("reference-tomb")
+	s.Require().True(ok)
+	s.Assert().Contains(string(raw), "key: reference-tomb")
+	s.Assert().NotContains(string(raw), "Overridden")
+
+	assert.NotEmpty(s.T(), raw) // keep the assert import meaningfully used alongside require above
+}

--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -26,10 +25,12 @@ func TestContentSuite(t *testing.T) {
 }
 
 // TestEveryEmbeddedSpecLoads is the CI safety net for content authoring: a
-// broken commit to any content/dungeons/*.yaml file must fail here, not
+// broken commit to any embedded dungeons/*.yaml file must fail here, not
 // surface later at StartEncounter time in prod.
 func (s *ContentTestSuite) TestEveryEmbeddedSpecLoads() {
-	specs := content.AllSpecs()
+	specs, problems, err := content.AllSpecs()
+	s.Require().NoError(err)
+	s.Assert().Empty(problems, "no RPG_CONTENT_DIR override is set in this test")
 	s.Require().NotEmpty(specs, "at least the reference-tomb fixture must be embedded")
 	for key, raw := range specs {
 		_, err := dungeonspec.Load(raw)
@@ -38,24 +39,42 @@ func (s *ContentTestSuite) TestEveryEmbeddedSpecLoads() {
 }
 
 func (s *ContentTestSuite) TestSpecByKey_UnknownKey() {
-	_, ok := content.SpecByKey("atlantis")
+	_, ok, err := content.SpecByKey("atlantis")
+	s.Require().NoError(err)
 	s.Assert().False(ok)
 }
 
 func (s *ContentTestSuite) TestSpecByKey_KnownKeyResolves() {
-	raw, ok := content.SpecByKey("reference-tomb")
+	raw, ok, err := content.SpecByKey("reference-tomb")
+	s.Require().NoError(err)
 	s.Require().True(ok)
 	s.Assert().Contains(string(raw), "key: reference-tomb")
 }
 
-// TestContentDirOverride covers the full augment + override-wins-on-collision
-// contract: RPG_CONTENT_DIR pointing at a temp dir with one yaml file makes
-// that (new) key resolve; embedded keys not present in the override dir
-// still resolve (override AUGMENTS, doesn't replace wholesale); and on a
-// key collision between the two sources, the override wins — the mechanism
-// that makes the edit-restart authoring loop work (an author editing their
-// local content/dungeons/reference-tomb.yaml via RPG_CONTENT_DIR must see
-// their edit, not the stale embedded copy).
+// TestSpecByKey_UnsetContentDirLeavesEmbeddedIntact pins that with
+// RPG_CONTENT_DIR unset, SpecByKey resolves the embedded reference-tomb
+// verbatim — a regression guard against a future implementation
+// accidentally reading some override directory (e.g. cwd, or a stale
+// value leaking from another test) when the env var is genuinely unset.
+func (s *ContentTestSuite) TestSpecByKey_UnsetContentDirLeavesEmbeddedIntact() {
+	s.Require().Empty(os.Getenv("RPG_CONTENT_DIR"), "precondition: no override active in this test")
+
+	raw, ok, err := content.SpecByKey("reference-tomb")
+	s.Require().NoError(err)
+	s.Require().True(ok)
+	s.Assert().Contains(string(raw), "key: reference-tomb")
+	s.Assert().NotContains(string(raw), "Overridden")
+}
+
+// TestContentDirOverride covers the full augment + override-wins-on-
+// collision contract: RPG_CONTENT_DIR pointing at a temp dir with one
+// yaml file makes that (new) key resolve; embedded keys not present in
+// the override dir still resolve (override AUGMENTS, doesn't replace
+// wholesale); and on a key collision between the two sources, the
+// override wins — the mechanism that makes the edit-restart authoring
+// loop work (an author editing their local
+// internal/content/dungeons/reference-tomb.yaml via RPG_CONTENT_DIR must
+// see their edit, not the stale embedded copy).
 func (s *ContentTestSuite) TestContentDirOverride() {
 	dir := s.T().TempDir()
 
@@ -77,29 +96,109 @@ func (s *ContentTestSuite) TestContentDirOverride() {
 	s.T().Setenv("RPG_CONTENT_DIR", dir)
 
 	// New key from the override dir resolves.
-	atlantis, ok := content.SpecByKey("atlantis")
+	atlantis, ok, err := content.SpecByKey("atlantis")
+	s.Require().NoError(err)
 	s.Require().True(ok)
 	s.Assert().Contains(string(atlantis), "Atlantis")
 
 	// Collision: override wins over the embedded copy.
-	tomb, ok := content.SpecByKey("reference-tomb")
+	tomb, ok, err := content.SpecByKey("reference-tomb")
+	s.Require().NoError(err)
 	s.Require().True(ok)
 	s.Assert().Contains(string(tomb), "Overridden Reference Tomb")
 
-	// AllSpecs reflects both the augmented and the overridden entry.
-	all := content.AllSpecs()
+	// AllSpecs reflects both the augmented and the overridden entry, with
+	// no problems reported (both override files are well-formed).
+	all, problems, err := content.AllSpecs()
+	s.Require().NoError(err)
+	s.Assert().Empty(problems)
 	s.Assert().Contains(all, "atlantis")
 	s.Assert().Contains(string(all["reference-tomb"]), "Overridden Reference Tomb")
 }
 
-func (s *ContentTestSuite) TestContentDirOverride_UnsetLeavesEmbeddedIntact() {
-	// Sanity check that not setting the override doesn't change embedded
-	// behavior — guards against a future implementation accidentally
-	// treating an unset/empty RPG_CONTENT_DIR as "override with cwd".
-	raw, ok := content.SpecByKey("reference-tomb")
-	s.Require().True(ok)
-	s.Assert().Contains(string(raw), "key: reference-tomb")
-	s.Assert().NotContains(string(raw), "Overridden")
+// TestContentDirOverride_AcceptsYmlExtension covers the should-fix: a
+// .yml file (not just .yaml) in the override dir must be picked up — the
+// dev loop's most likely typo/variant shouldn't be a silent no-op.
+func (s *ContentTestSuite) TestContentDirOverride_AcceptsYmlExtension() {
+	dir := s.T().TempDir()
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "shortform.yml"),
+		[]byte("version: 1\nkey: shortform\nname: Short Form\n"),
+		0o600,
+	))
+	s.T().Setenv("RPG_CONTENT_DIR", dir)
 
-	assert.NotEmpty(s.T(), raw) // keep the assert import meaningfully used alongside require above
+	raw, ok, err := content.SpecByKey("shortform")
+	s.Require().NoError(err)
+	s.Require().True(ok)
+	s.Assert().Contains(string(raw), "Short Form")
+}
+
+// TestContentDirOverride_IndexedByDeclaredKeyNotFilename is the black-box
+// pin for BLOCKING 2: an override file whose name doesn't match its
+// declared key resolves ONLY by that key, never by its filename stem —
+// the same contract registry_internal_test.go verifies directly against
+// buildRegistry, exercised here through the real SpecByKey entry point.
+func (s *ContentTestSuite) TestContentDirOverride_IndexedByDeclaredKeyNotFilename() {
+	dir := s.T().TempDir()
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "zzz-scratch.yaml"),
+		[]byte("version: 1\nkey: my-dungeon\nname: Scratch\n"),
+		0o600,
+	))
+	s.T().Setenv("RPG_CONTENT_DIR", dir)
+
+	raw, ok, err := content.SpecByKey("my-dungeon")
+	s.Require().NoError(err)
+	s.Require().True(ok, "must resolve by its declared key field")
+	s.Assert().Contains(string(raw), "Scratch")
+
+	_, ok, err = content.SpecByKey("zzz-scratch")
+	s.Require().NoError(err)
+	s.Assert().False(ok, "must not resolve by its filename stem")
+}
+
+// TestContentDirOverride_MalformedHeaderFileSkippedAndReported covers
+// BLOCKING 1(a): a malformed/undecodable-header file in the override dir
+// must not panic the whole registry — it's excluded, reported in
+// problems (loggable, for Task E2's startup registry), and every other
+// key still resolves.
+func (s *ContentTestSuite) TestContentDirOverride_MalformedHeaderFileSkippedAndReported() {
+	dir := s.T().TempDir()
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "broken.yaml"),
+		[]byte("this: is: not: valid: yaml:"),
+		0o600,
+	))
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "atlantis.yaml"),
+		[]byte("version: 1\nkey: atlantis\nname: Atlantis\n"),
+		0o600,
+	))
+	s.T().Setenv("RPG_CONTENT_DIR", dir)
+
+	specs, problems, err := content.AllSpecs()
+	s.Require().NoError(err, "a malformed override FILE must not become a hard error")
+	s.Require().Len(problems, 1)
+	s.Assert().Contains(problems[0], "broken.yaml")
+	s.Assert().Contains(specs, "atlantis", "other override files still resolve")
+	s.Assert().Contains(specs, "reference-tomb", "the embedded set is untouched")
+}
+
+// TestContentDirOverride_UnreadablePathReturnsError covers BLOCKING 1(b):
+// RPG_CONTENT_DIR pointing at a path that can't be listed at all (an
+// operator/config mistake, not a single bad file) must fail construction
+// loudly via a returned error — never a panic, since this is runtime
+// input, not compiled-in content.
+func (s *ContentTestSuite) TestContentDirOverride_UnreadablePathReturnsError() {
+	missing := filepath.Join(s.T().TempDir(), "does-not-exist")
+	s.T().Setenv("RPG_CONTENT_DIR", missing)
+
+	specs, problems, err := content.AllSpecs()
+	s.Require().Error(err)
+	s.Assert().Nil(specs)
+	s.Assert().Nil(problems)
+
+	_, _, err = content.SpecByKey("reference-tomb")
+	s.Require().Error(err, "SpecByKey must propagate the same unreadable-path error")
 }

--- a/internal/content/dungeons/reference-tomb.yaml
+++ b/internal/content/dungeons/reference-tomb.yaml
@@ -1,0 +1,22 @@
+version: 1
+key: reference-tomb
+name: The Reference Tomb
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    place:
+      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
+      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
+connectors:
+  - { from: entrance, to: tomb }

--- a/internal/content/dungeons/reference-tomb.yaml
+++ b/internal/content/dungeons/reference-tomb.yaml
@@ -1,22 +1,39 @@
 version: 1
 key: reference-tomb
-name: The Reference Tomb
+name: The Tomb of the Captain
 theme: crypt
 height: 8
 rooms:
   - id: entrance
     archetype: entrance
     width: 6
+    place:
+      - { ref: "dnd5e:props:brazier", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier", at: [1, 6] }
+  - id: hall
+    archetype: chamber
+    width: 10
+    place:
+      - { ref: "dnd5e:props:pillar", at: [2, 2] }
+      - { ref: "dnd5e:props:pillar", at: [2, 5] }
+      - { ref: "dnd5e:props:pillar", at: [6, 2] }
+      - { ref: "dnd5e:props:pillar", at: [6, 5] }
+      - { ref: "dnd5e:props:torch-ornate", at: [4, 1] }
+      - { ref: "dnd5e:props:bone-pile", at: [8, 6] }
+      - { ref: "dnd5e:monsters:skeleton", at: [5, 3] }
+      - { ref: "dnd5e:monsters:skeleton", at: [7, 5] }
   - id: tomb
     archetype: boss
     width: 12
     boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
     place:
-      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
-      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:coffin", at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar", at: [9, 3] }
       - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
-      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
-      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
-      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
+      - { ref: "dnd5e:props:statue-knight-hooded", at: [1, 6] }
+      - { ref: "dnd5e:props:brazier", at: [3, 1] }
+      - { ref: "dnd5e:props:brazier", at: [3, 6] }
+      - { ref: "dnd5e:props:candles", at: [10, 5] }
 connectors:
-  - { from: entrance, to: tomb }
+  - { from: entrance, to: hall }
+  - { from: hall, to: tomb, locked: { dc: 12, ability: dex } }

--- a/internal/content/registry.go
+++ b/internal/content/registry.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package content
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// fileEntry is one file's name and raw content, prior to being indexed by
+// its declared key: field.
+type fileEntry struct {
+	name string
+	raw  []byte
+}
+
+// specHeader is the minimal shape needed to index a spec by its declared
+// key without fully decoding or validating it -- that's
+// encounter/dungeonspec.Load's job downstream (see TestEveryEmbeddedSpecLoads).
+type specHeader struct {
+	Key string `yaml:"key"`
+}
+
+// buildRegistry indexes files by each one's declared key: field, NOT
+// filename -- an author's file named zzz-scratch.yaml with key: my-dungeon
+// inside must resolve as "my-dungeon", never as "zzz-scratch" (pinned by
+// TestSpecByKey_IndexedByDeclaredKeyNotFilename).
+//
+// A file whose key can't be decoded (invalid YAML, or an empty/missing
+// key field) is always excluded from the returned registry; so is the
+// second (and any later) file in this same call to declare an
+// already-used key. panicOnProblem controls how those exclusions are
+// reported:
+//
+//   - true (the embedded set): panics immediately. Embedded content is
+//     compiled in -- a bad key or a key collision between two embedded
+//     files is unambiguously a broken commit, and panicking is what makes
+//     it fail CI instead of silently shadowing one file behind another
+//     (TestEveryEmbeddedSpecLoads can only see whatever this function
+//     actually returns, so a silent drop would defeat its whole purpose).
+//   - false (the RPG_CONTENT_DIR override set): non-fatal. Each excluded
+//     file is instead appended to problems as a loggable line -- an
+//     author's dev-loop mistake, not a reason to fail the whole registry.
+func buildRegistry(files []fileEntry, panicOnProblem bool) (registry map[string][]byte, problems []string) {
+	registry = make(map[string][]byte, len(files))
+	for _, f := range files {
+		key, err := headerKey(f.raw)
+		if err != nil {
+			if panicOnProblem {
+				panic(fmt.Sprintf("content: file %q has no usable key: %v", f.name, err))
+			}
+			problems = append(problems, fmt.Sprintf("%s: %v", f.name, err))
+			continue
+		}
+		if _, exists := registry[key]; exists {
+			if panicOnProblem {
+				panic(fmt.Sprintf(
+					"content: file %q declares key %q, already used by another file in this set", f.name, key))
+			}
+			problems = append(problems,
+				fmt.Sprintf("%s: key %q already used by another file in this directory", f.name, key))
+			continue
+		}
+		registry[key] = f.raw
+	}
+	return registry, problems
+}
+
+// headerKey decodes just enough of raw to find its declared key: field,
+// without running the full dungeonspec.Load validation.
+func headerKey(raw []byte) (string, error) {
+	var header specHeader
+	if err := yaml.Unmarshal(raw, &header); err != nil {
+		return "", fmt.Errorf("decode key header: %w", err)
+	}
+	if header.Key == "" {
+		return "", fmt.Errorf("empty key field")
+	}
+	return header.Key, nil
+}

--- a/internal/content/registry_internal_test.go
+++ b/internal/content/registry_internal_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package content
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildRegistry_DuplicateKeyAcrossFilesPanicsWhenFatal covers the
+// embedded set's posture: a broken commit that ships two files declaring
+// the same key must fail CI loudly, not let the lexically-last file
+// silently shadow the earlier one (a shadowed file is invisible to
+// TestEveryEmbeddedSpecLoads since that test only ever sees whatever
+// buildRegistry actually returns). This can't be exercised through the
+// real embedded fixture without committing a second, deliberately broken
+// content file -- hence a direct unit test on the extracted helper with
+// two in-memory byte slices instead.
+func TestBuildRegistry_DuplicateKeyAcrossFilesPanicsWhenFatal(t *testing.T) {
+	files := []fileEntry{
+		{name: "a.yaml", raw: []byte("version: 1\nkey: same-key\n")},
+		{name: "b.yaml", raw: []byte("version: 1\nkey: same-key\n")},
+	}
+
+	assert.Panics(t, func() {
+		buildRegistry(files, true)
+	})
+}
+
+// TestBuildRegistry_DuplicateKeyNonFatalExcludesAndReports covers the
+// RPG_CONTENT_DIR override posture: a duplicate key within the override
+// set is a dev-loop mistake, not a reason to fail construction -- the
+// second file is excluded and reported, the first wins, no panic.
+func TestBuildRegistry_DuplicateKeyNonFatalExcludesAndReports(t *testing.T) {
+	files := []fileEntry{
+		{name: "a.yaml", raw: []byte("version: 1\nkey: same-key\nname: First\n")},
+		{name: "b.yaml", raw: []byte("version: 1\nkey: same-key\nname: Second\n")},
+	}
+
+	registry, problems := buildRegistry(files, false)
+
+	require.Contains(t, registry, "same-key")
+	assert.Contains(t, string(registry["same-key"]), "First")
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "b.yaml")
+	assert.Contains(t, problems[0], "same-key")
+}
+
+// TestBuildRegistry_MalformedHeaderPanicsWhenFatal mirrors the duplicate-
+// key case for an embedded file with no usable key: field at all
+// (invalid YAML, or an empty key) -- also a broken commit, also must
+// panic rather than be silently dropped from the registry.
+func TestBuildRegistry_MalformedHeaderPanicsWhenFatal(t *testing.T) {
+	files := []fileEntry{
+		{name: "broken.yaml", raw: []byte("not: valid: yaml: at: all:")},
+	}
+
+	assert.Panics(t, func() {
+		buildRegistry(files, true)
+	})
+}
+
+// TestBuildRegistry_MalformedHeaderNonFatalExcludesAndReports is the
+// override-dir posture for the same malformed input: excluded, reported,
+// no panic -- an author's local mistake surfaces as a loggable problem
+// the next time they look, not a crash.
+func TestBuildRegistry_MalformedHeaderNonFatalExcludesAndReports(t *testing.T) {
+	files := []fileEntry{
+		{name: "broken.yaml", raw: []byte("not: valid: yaml: at: all:")},
+		{name: "empty-key.yaml", raw: []byte("version: 1\nkey: \"\"\n")},
+	}
+
+	registry, problems := buildRegistry(files, false)
+
+	assert.Empty(t, registry)
+	require.Len(t, problems, 2)
+	assert.Contains(t, problems[0], "broken.yaml")
+	assert.Contains(t, problems[1], "empty-key.yaml")
+}
+
+// TestBuildRegistry_IndexedByDeclaredKeyNotFilename is the direct,
+// mutation-verified pin for BLOCKING 2: a file whose name doesn't match
+// its declared key must be found ONLY by that key, never by its filename
+// stem. Verified by temporarily swapping buildRegistry's indexing to use
+// the filename stem instead of the decoded key and confirming this test
+// fails -- see the E1 fix report for that mutation's before/after output.
+func TestBuildRegistry_IndexedByDeclaredKeyNotFilename(t *testing.T) {
+	files := []fileEntry{
+		{name: "zzz-scratch.yaml", raw: []byte("version: 1\nkey: my-dungeon\nname: Scratch\n")},
+	}
+
+	registry, problems := buildRegistry(files, false)
+
+	assert.Empty(t, problems)
+	_, foundByFilenameStem := registry["zzz-scratch"]
+	assert.False(t, foundByFilenameStem, "must not be indexed by filename stem")
+	raw, foundByDeclaredKey := registry["my-dungeon"]
+	require.True(t, foundByDeclaredKey, "must be indexed by its declared key field")
+	assert.Contains(t, string(raw), "Scratch")
+}

--- a/internal/handlers/dnd5e/lobby/v1alpha1/status.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/status.go
@@ -21,13 +21,24 @@ import (
 //   - ErrCharacterNotFound → NotFound
 //   - ErrLobbyAlreadyStarted / ErrLobbyFull / ErrNotAllReady / ErrLobbyNotStarted /
 //     ErrEncounterAlreadyEnded → FailedPrecondition
+//   - ErrUnknownDungeonKey → NotFound (Task E3 — previously fell through to
+//     Internal; unreachable via any real proto surface until a caller can
+//     supply a DungeonKey, but honest regardless)
+//   - *DisabledDungeonKeyError → InvalidArgument, carrying the stored
+//     validation CAUSE (Task E3 — Unwrap()'s Cause, never Error()'s own
+//     "lobby orchestrator: dungeon key ... is disabled:" wrapping prefix,
+//     which is internal error-taxonomy language, not something a client
+//     authoring content should ever see)
 //   - unclassified → Internal
 func lobbyStatusError(err error) error {
+	var disabledErr *lobbyorch.DisabledDungeonKeyError
 	switch {
 	case errors.Is(err, lobbyorch.ErrLobbyNotFound):
 		return status.Error(codes.NotFound, "lobby not found")
 	case errors.Is(err, lobbyorch.ErrCharacterNotFound):
 		return status.Error(codes.NotFound, "character not found")
+	case errors.Is(err, lobbyorch.ErrUnknownDungeonKey):
+		return status.Error(codes.NotFound, "unknown dungeon key")
 	case errors.Is(err, lobbyorch.ErrPlayerNotInLobby):
 		return status.Error(codes.PermissionDenied, "player is not a member of this lobby")
 	case errors.Is(err, lobbyorch.ErrNotHost):
@@ -44,6 +55,8 @@ func lobbyStatusError(err error) error {
 		return status.Error(codes.FailedPrecondition, "lobby has not started an encounter")
 	case errors.Is(err, lobbyorch.ErrEncounterAlreadyEnded):
 		return status.Error(codes.FailedPrecondition, "encounter has already ended")
+	case errors.As(err, &disabledErr):
+		return status.Error(codes.InvalidArgument, disabledErr.Cause.Error())
 	}
 	return status.Errorf(codes.Internal, "lobby: %v", err)
 }

--- a/internal/handlers/dnd5e/lobby/v1alpha1/status.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/status.go
@@ -12,7 +12,7 @@ import (
 // lobbyStatusError maps the lobby orchestrator's sentinel errors onto gRPC
 // status codes. Shared by every RPC handler in this package — each RPC only
 // ever returns a subset of these sentinels, so one exhaustive switch covers
-// all six rather than duplicating the mapping per verb.
+// all eight rather than duplicating the mapping per verb.
 //
 //   - ErrLobbyNotFound → NotFound
 //   - ErrPlayerNotInLobby → PermissionDenied
@@ -28,7 +28,11 @@ import (
 //     validation CAUSE (Task E3 — Unwrap()'s Cause, never Error()'s own
 //     "lobby orchestrator: dungeon key ... is disabled:" wrapping prefix,
 //     which is internal error-taxonomy language, not something a client
-//     authoring content should ever see)
+//     authoring content should ever see). Falls back to Error() if Cause
+//     is nil — DisabledDungeonKeyError is exported, so a future
+//     construction site could build one without a Cause; a handler
+//     panicking on that malformed error would be worse than a message
+//     that's merely less specific.
 //   - unclassified → Internal
 func lobbyStatusError(err error) error {
 	var disabledErr *lobbyorch.DisabledDungeonKeyError
@@ -56,6 +60,9 @@ func lobbyStatusError(err error) error {
 	case errors.Is(err, lobbyorch.ErrEncounterAlreadyEnded):
 		return status.Error(codes.FailedPrecondition, "encounter has already ended")
 	case errors.As(err, &disabledErr):
+		if disabledErr.Cause == nil {
+			return status.Error(codes.InvalidArgument, disabledErr.Error())
+		}
 		return status.Error(codes.InvalidArgument, disabledErr.Cause.Error())
 	}
 	return status.Errorf(codes.Internal, "lobby: %v", err)

--- a/internal/handlers/dnd5e/lobby/v1alpha1/status_internal_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/status_internal_test.go
@@ -47,6 +47,16 @@ func TestLobbyStatusError_Table(t *testing.T) {
 			name: "disabled content key carries the CAUSE, not Error()'s wrapped prefix",
 			err:  disabledErr, wantCode: codes.InvalidArgument, wantMessage: cause.Error(),
 		},
+		{
+			// nil-Cause guard: DisabledDungeonKeyError is an exported type --
+			// a future construction site could build one with Cause left
+			// nil. Calling Cause.Error() on a nil error interface panics; a
+			// handler panicking on a malformed error is worse than falling
+			// back to Error()'s own wrapped message, so that's the fallback.
+			name: "disabled content key with nil Cause falls back to Error(), never panics",
+			err:  &lobbyorch.DisabledDungeonKeyError{Key: "no-cause"}, wantCode: codes.InvalidArgument,
+			wantMessage: (&lobbyorch.DisabledDungeonKeyError{Key: "no-cause"}).Error(),
+		},
 
 		{name: "unclassified error falls through to Internal", err: errors.New("boom"), wantCode: codes.Internal, msgContains: "boom"},
 	}

--- a/internal/handlers/dnd5e/lobby/v1alpha1/status_internal_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/status_internal_test.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package lobby
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	lobbyorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/lobby"
+)
+
+// TestLobbyStatusError_Table covers every sentinel lobbyStatusError maps,
+// plus the two Task E3 additions (ErrUnknownDungeonKey, *DisabledDungeonKeyError)
+// and the default Internal fallback — one exhaustive table so adding the
+// two new cases can't perturb any existing mapping.
+func TestLobbyStatusError_Table(t *testing.T) {
+	cause := errors.New("must have at least 2 rooms, got 1")
+	disabledErr := &lobbyorch.DisabledDungeonKeyError{Key: "broken-dungeon", Cause: cause}
+
+	cases := []struct {
+		name        string
+		err         error
+		wantCode    codes.Code
+		wantMessage string // exact message when set
+		msgContains string // substring check when exact isn't meaningful
+	}{
+		{name: "lobby not found", err: lobbyorch.ErrLobbyNotFound, wantCode: codes.NotFound, wantMessage: "lobby not found"},
+		{name: "character not found", err: lobbyorch.ErrCharacterNotFound, wantCode: codes.NotFound, wantMessage: "character not found"},
+		{name: "player not in lobby", err: lobbyorch.ErrPlayerNotInLobby, wantCode: codes.PermissionDenied, wantMessage: "player is not a member of this lobby"},
+		{name: "not host", err: lobbyorch.ErrNotHost, wantCode: codes.PermissionDenied, wantMessage: "only the host can start the encounter"},
+		{name: "character ownership mismatch", err: lobbyorch.ErrCharacterOwnershipMismatch, wantCode: codes.PermissionDenied, wantMessage: "character_id does not belong to the authenticated player"},
+		{name: "lobby already started", err: lobbyorch.ErrLobbyAlreadyStarted, wantCode: codes.FailedPrecondition, wantMessage: "lobby has already started"},
+		{name: "lobby full", err: lobbyorch.ErrLobbyFull, wantCode: codes.FailedPrecondition, wantMessage: "lobby is full"},
+		{name: "not all ready", err: lobbyorch.ErrNotAllReady, wantCode: codes.FailedPrecondition, wantMessage: "not all members are ready"},
+		{name: "lobby not started", err: lobbyorch.ErrLobbyNotStarted, wantCode: codes.FailedPrecondition, wantMessage: "lobby has not started an encounter"},
+		{name: "encounter already ended", err: lobbyorch.ErrEncounterAlreadyEnded, wantCode: codes.FailedPrecondition, wantMessage: "encounter has already ended"},
+
+		// Task E3 additions.
+		{name: "unknown dungeon key", err: lobbyorch.ErrUnknownDungeonKey, wantCode: codes.NotFound, wantMessage: "unknown dungeon key"},
+		{
+			name: "disabled content key carries the CAUSE, not Error()'s wrapped prefix",
+			err:  disabledErr, wantCode: codes.InvalidArgument, wantMessage: cause.Error(),
+		},
+
+		{name: "unclassified error falls through to Internal", err: errors.New("boom"), wantCode: codes.Internal, msgContains: "boom"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lobbyStatusError(tc.err)
+			st, ok := status.FromError(got)
+			require.True(t, ok, "lobbyStatusError must always return a gRPC status error")
+			assert.Equal(t, tc.wantCode, st.Code())
+			if tc.wantMessage != "" {
+				assert.Equal(t, tc.wantMessage, st.Message())
+			}
+			if tc.msgContains != "" {
+				assert.Contains(t, st.Message(), tc.msgContains)
+			}
+		})
+	}
+}
+
+// TestLobbyStatusError_DisabledContentKey_NeverLeaksOrchestratorPrefix is a
+// dedicated regression pin (not just a table row): the client-facing
+// message must be exactly the stored validation cause, never
+// DisabledDungeonKeyError.Error()'s own "lobby orchestrator: dungeon key
+// ... is disabled:" wrapping prefix.
+func TestLobbyStatusError_DisabledContentKey_NeverLeaksOrchestratorPrefix(t *testing.T) {
+	cause := errors.New("must have at least 2 rooms, got 1")
+	err := &lobbyorch.DisabledDungeonKeyError{Key: "broken-dungeon", Cause: cause}
+
+	got := lobbyStatusError(err)
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Equal(t, cause.Error(), st.Message())
+	assert.NotContains(t, st.Message(), "lobby orchestrator", "must never leak the internal error-taxonomy prefix to the client")
+}

--- a/internal/orchestrators/lobby/dungeon_spec.go
+++ b/internal/orchestrators/lobby/dungeon_spec.go
@@ -170,7 +170,14 @@ func (e *DisabledDungeonKeyError) Unwrap() error {
 func loadContentSpecs() (map[DungeonKey]contentSpecResult, error) {
 	specs, problems, err := content.AllSpecs()
 	if err != nil {
-		return nil, fmt.Errorf("lobby orchestrator: load content specs: %w", err)
+		// No "lobby orchestrator:" prefix here (and content.AllSpecs' own
+		// wrapped error already names RPG_CONTENT_DIR) -- cmd/server/
+		// server.go's lobbyorch.New call site already wraps ANY error from
+		// New with fmt.Errorf("lobby orchestrator: %w", err), so adding it
+		// here would double it up for the one caller who actually sees
+		// this message, the same class of bug Task E3's rider fixed for
+		// validateDungeonKeyOverride.
+		return nil, fmt.Errorf("load content specs (RPG_CONTENT_DIR): %w", err)
 	}
 	for _, p := range problems {
 		slog.Warn("lobby orchestrator: content spec problem, key excluded from registry", "detail", p)

--- a/internal/orchestrators/lobby/dungeon_spec.go
+++ b/internal/orchestrators/lobby/dungeon_spec.go
@@ -223,3 +223,34 @@ func (o *Orchestrator) resolveContentDungeonSpec(key DungeonKey) (compiled dunge
 	}
 	return result.compiled, true, nil
 }
+
+// validateDungeonKeyOverride checks that override (Config.DungeonKeyOverride,
+// Task E2b's RPG_DUNGEON_KEY mechanism) resolves to a real, ENABLED
+// dungeon spec before construction succeeds. "" (unset) is always valid —
+// a no-op. A non-empty override must resolve via EITHER contentSpecs (the
+// registry loadContentSpecs just built) OR the legacy dungeonSpecs map; a
+// content key that resolves but is DISABLED (its file failed
+// dungeonspec.Load) is rejected here too — an operator pointing
+// RPG_DUNGEON_KEY at a broken key must see a construction failure
+// immediately, not a deferred failure on the first real StartEncounter
+// call.
+func validateDungeonKeyOverride(override string, contentSpecs map[DungeonKey]contentSpecResult) error {
+	if override == "" {
+		return nil
+	}
+	key := DungeonKey(override)
+	if result, ok := contentSpecs[key]; ok {
+		if result.err != nil {
+			return fmt.Errorf(
+				"lobby orchestrator: Config.DungeonKeyOverride %q resolves to a disabled content key: %w",
+				override, result.err)
+		}
+		return nil
+	}
+	if _, ok := dungeonSpecs[key]; ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"lobby orchestrator: Config.DungeonKeyOverride %q does not resolve via content or the legacy dungeonSpecs map",
+		override)
+}

--- a/internal/orchestrators/lobby/dungeon_spec.go
+++ b/internal/orchestrators/lobby/dungeon_spec.go
@@ -3,9 +3,13 @@ package lobby
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+
+	"github.com/KirkDiggler/rpg-api/internal/content"
 )
 
 // DungeonKey selects a named dungeon specification passed to the
@@ -96,4 +100,126 @@ func resolveDungeonSpec(key DungeonKey, seed int64) (DungeonKey, tkenc.DungeonPa
 		return key, tkenc.DungeonParams{}, fmt.Errorf("%w: %q", ErrUnknownDungeonKey, key)
 	}
 	return key, build(seed), nil
+}
+
+// --- Task E2: content-backed dungeon spec resolution (rpg-project#709) ---
+//
+// A content-hosted key (internal/content's embedded dungeons/*.yaml, plus
+// any RPG_CONTENT_DIR override) resolves through this parallel path
+// instead of the legacy dungeonSpecs map above — StartEncounter checks
+// resolveContentDungeonSpec FIRST and only falls through to
+// resolveDungeonSpec when the key isn't content-backed at all. The legacy
+// crypt path (dungeonSpecs, resolveDungeonSpec, seedRegionMonsters) is
+// untouched by this addition.
+
+// contentSpecResult stores either a successfully compiled content-backed
+// dungeon spec, or the load failure that key's file produced at startup.
+// A failed spec is not dropped from the registry: resolveContentDungeonSpec
+// still reports its key as FOUND (so it never silently falls through to
+// the legacy map), just disabled.
+type contentSpecResult struct {
+	compiled dungeonspec.CompiledDungeon
+	err      error
+}
+
+// DisabledDungeonKeyError means a content-backed dungeon key resolved to a
+// FILE that exists but failed rpg-toolkit's dungeonspec.Load at startup —
+// a broken content commit that slipped past CI, or a broken RPG_CONTENT_DIR
+// dev-loop override file. Cause is the exact validation error content
+// authoring needs to fix the file; lobbyStatusError (Task E3) maps this to
+// codes.InvalidArgument, carrying that message to the caller.
+type DisabledDungeonKeyError struct {
+	Key   DungeonKey
+	Cause error
+}
+
+func (e *DisabledDungeonKeyError) Error() string {
+	return fmt.Sprintf("lobby orchestrator: dungeon key %q is disabled: %v", e.Key, e.Cause)
+}
+
+func (e *DisabledDungeonKeyError) Unwrap() error {
+	return e.Cause
+}
+
+// loadContentSpecs builds the startup registry of every content-hosted
+// dungeon spec by calling content.AllSpecs() exactly ONCE (New calls this
+// once at construction and stores the result on *Orchestrator —
+// resolveContentDungeonSpec below is a plain map lookup against that
+// stored result, never a second content.AllSpecs/SpecByKey call: those
+// re-read RPG_CONTENT_DIR and re-parse every file on every call, which is
+// fine for a one-time startup pass and wrong for a per-request path).
+//
+// A spec whose header decodes but whose body fails dungeonspec.Load (a
+// schema/business-rule violation) is stored as a contentSpecResult
+// carrying that error, not dropped — see contentSpecResult's doc. Returns
+// an error only when content.AllSpecs() itself fails: RPG_CONTENT_DIR set
+// but unreadable as a directory, an operator/config mistake that must
+// fail lobbyorch.New() loudly (Task E2b's same validate-at-construction
+// posture for RPG_DUNGEON_KEY) rather than silently falling back to
+// embedded-only content.
+//
+// Logs one line per problem found while building the registry, from BOTH
+// failure sources this registry can hit: content.AllSpecs' own
+// header-level problems (a malformed/missing key: field in an
+// RPG_CONTENT_DIR file — logged here since AllSpecs only returns these as
+// data, it never logs), and a dungeonspec.Load failure for a spec whose
+// header decoded fine but whose body doesn't validate/compile. Also logs
+// one DEBUG line per RPG_CONTENT_DIR key that shadows an embedded key of
+// the same name — confirmation, for an author mid edit-restart loop, that
+// their override actually took effect.
+func loadContentSpecs() (map[DungeonKey]contentSpecResult, error) {
+	specs, problems, err := content.AllSpecs()
+	if err != nil {
+		return nil, fmt.Errorf("lobby orchestrator: load content specs: %w", err)
+	}
+	for _, p := range problems {
+		slog.Warn("lobby orchestrator: content spec problem, key excluded from registry", "detail", p)
+	}
+
+	if shadowed, oerr := content.OverriddenKeys(); oerr == nil {
+		for _, key := range shadowed {
+			slog.Debug("lobby orchestrator: content spec loaded from RPG_CONTENT_DIR override", "key", key)
+		}
+	}
+	// oerr != nil here would mean content.AllSpecs() above raced its own
+	// RPG_CONTENT_DIR read against this second one and got a different
+	// answer -- astronomically unlikely for a startup-only path reading a
+	// local directory, and this debug log is a nice-to-have, not a
+	// correctness path, so it's worth skipping quietly rather than
+	// failing construction over.
+
+	results := make(map[DungeonKey]contentSpecResult, len(specs))
+	for key, raw := range specs {
+		compiled, loadErr := dungeonspec.Load(raw)
+		if loadErr != nil {
+			slog.Warn("lobby orchestrator: content spec failed to load, key disabled", "key", key, "error", loadErr)
+			results[DungeonKey(key)] = contentSpecResult{err: loadErr}
+			continue
+		}
+		results[DungeonKey(key)] = contentSpecResult{compiled: compiled}
+	}
+	return results, nil
+}
+
+// resolveContentDungeonSpec looks up key in the pre-built content registry
+// (o.contentSpecs, built ONCE by loadContentSpecs at construction). The
+// three-value return is deliberate, not a bool: found reports whether key
+// is a content-backed key AT ALL (callers fall through to the legacy
+// dungeonSpecs map when false); when found is true, err distinguishes a
+// spec that compiled cleanly at startup (nil, compiled is ready to use)
+// from one that failed to load (a *DisabledDungeonKeyError wrapping the
+// stored cause) — the caller must fail immediately in that case, never
+// silently fall through to the legacy path for a key that DOES exist in
+// content but is broken. err is the LAST return (not the plan's own
+// example order) to satisfy this repo's error-return lint convention —
+// still three distinct signals, just Go-idiomatic positionally.
+func (o *Orchestrator) resolveContentDungeonSpec(key DungeonKey) (compiled dungeonspec.CompiledDungeon, found bool, err error) {
+	result, ok := o.contentSpecs[key]
+	if !ok {
+		return dungeonspec.CompiledDungeon{}, false, nil
+	}
+	if result.err != nil {
+		return dungeonspec.CompiledDungeon{}, true, &DisabledDungeonKeyError{Key: key, Cause: result.err}
+	}
+	return result.compiled, true, nil
 }

--- a/internal/orchestrators/lobby/dungeon_spec.go
+++ b/internal/orchestrators/lobby/dungeon_spec.go
@@ -225,15 +225,24 @@ func (o *Orchestrator) resolveContentDungeonSpec(key DungeonKey) (compiled dunge
 }
 
 // validateDungeonKeyOverride checks that override (Config.DungeonKeyOverride,
-// Task E2b's RPG_DUNGEON_KEY mechanism) resolves to a real, ENABLED
-// dungeon spec before construction succeeds. "" (unset) is always valid —
-// a no-op. A non-empty override must resolve via EITHER contentSpecs (the
-// registry loadContentSpecs just built) OR the legacy dungeonSpecs map; a
-// content key that resolves but is DISABLED (its file failed
-// dungeonspec.Load) is rejected here too — an operator pointing
-// RPG_DUNGEON_KEY at a broken key must see a construction failure
-// immediately, not a deferred failure on the first real StartEncounter
-// call.
+// populated from the RPG_DUNGEON_KEY env var — Task E2b's dev-loop
+// mechanism) resolves to a real, ENABLED dungeon spec before construction
+// succeeds. "" (unset) is always valid — a no-op. A non-empty override
+// must resolve via EITHER contentSpecs (the registry loadContentSpecs
+// just built) OR the legacy dungeonSpecs map; a content key that resolves
+// but is DISABLED (its file failed dungeonspec.Load) is rejected here
+// too — an operator pointing RPG_DUNGEON_KEY at a broken key must see a
+// construction failure immediately, not a deferred failure on the first
+// real StartEncounter call.
+//
+// Error messages name RPG_DUNGEON_KEY (the env var an operator actually
+// set), not Config.DungeonKeyOverride (the Go field name) — this is the
+// error an operator hits during the M1 manual walkthrough. They also omit
+// the "lobby orchestrator:" prefix other Config validation errors in this
+// package carry: cmd/server/server.go's lobbyorch.New call site already
+// wraps ANY error from New with fmt.Errorf("lobby orchestrator: %w", err),
+// so including it here would double it up ("lobby orchestrator: lobby
+// orchestrator: ...") for the one caller that actually sees this message.
 func validateDungeonKeyOverride(override string, contentSpecs map[DungeonKey]contentSpecResult) error {
 	if override == "" {
 		return nil
@@ -242,7 +251,7 @@ func validateDungeonKeyOverride(override string, contentSpecs map[DungeonKey]con
 	if result, ok := contentSpecs[key]; ok {
 		if result.err != nil {
 			return fmt.Errorf(
-				"lobby orchestrator: Config.DungeonKeyOverride %q resolves to a disabled content key: %w",
+				"RPG_DUNGEON_KEY %q resolves to a disabled content key: %w",
 				override, result.err)
 		}
 		return nil
@@ -251,6 +260,6 @@ func validateDungeonKeyOverride(override string, contentSpecs map[DungeonKey]con
 		return nil
 	}
 	return fmt.Errorf(
-		"lobby orchestrator: Config.DungeonKeyOverride %q does not resolve via content or the legacy dungeonSpecs map",
+		"RPG_DUNGEON_KEY %q does not resolve via content or the legacy dungeonSpecs map",
 		override)
 }

--- a/internal/orchestrators/lobby/dungeon_spec_internal_test.go
+++ b/internal/orchestrators/lobby/dungeon_spec_internal_test.go
@@ -112,7 +112,7 @@ func TestLoadContentSpecs_EmbeddedReferenceTombCompiles(t *testing.T) {
 	result, ok := specs[DungeonKey("reference-tomb")]
 	require.True(t, ok, "reference-tomb must be present in the startup registry")
 	require.NoError(t, result.err, "reference-tomb must compile cleanly — it's the M1 acceptance file")
-	require.Len(t, result.compiled.Params.Regions, 2, "entrance + tomb")
+	require.Len(t, result.compiled.Params.Regions, 3, "entrance + hall + tomb (Kirk's live-authored 3-room draft)")
 }
 
 // TestLoadContentSpecs_ContentDirUnreadable_ReturnsError proves an

--- a/internal/orchestrators/lobby/dungeon_spec_internal_test.go
+++ b/internal/orchestrators/lobby/dungeon_spec_internal_test.go
@@ -12,11 +12,14 @@ package lobby
 // obstacles included.
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
 )
 
 // TestResolveDungeonSpec_ExplicitCryptKey_MatchesToolkitConstructorVerbatim
@@ -94,4 +97,105 @@ func TestResolveDungeonSpec_UnknownKey_ReturnsErrUnknownDungeonKey(t *testing.T)
 	_, _, err := resolveDungeonSpec(DungeonKey("no-such-key"), 0)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrUnknownDungeonKey))
+}
+
+// --- Task E2: content-backed dungeon spec resolution ---
+
+// TestLoadContentSpecs_EmbeddedReferenceTombCompiles proves the M1
+// acceptance file (internal/content/dungeons/reference-tomb.yaml) is
+// present in loadContentSpecs' startup registry and compiled cleanly —
+// no RPG_CONTENT_DIR override needed, since reference-tomb ships embedded.
+func TestLoadContentSpecs_EmbeddedReferenceTombCompiles(t *testing.T) {
+	specs, err := loadContentSpecs()
+	require.NoError(t, err)
+
+	result, ok := specs[DungeonKey("reference-tomb")]
+	require.True(t, ok, "reference-tomb must be present in the startup registry")
+	require.NoError(t, result.err, "reference-tomb must compile cleanly — it's the M1 acceptance file")
+	require.Len(t, result.compiled.Params.Regions, 2, "entrance + tomb")
+}
+
+// TestLoadContentSpecs_ContentDirUnreadable_ReturnsError proves an
+// unreadable RPG_CONTENT_DIR path fails loudly here — the caller (New)
+// propagates this as a construction failure, never a panic.
+func TestLoadContentSpecs_ContentDirUnreadable_ReturnsError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("RPG_CONTENT_DIR", missing)
+
+	_, err := loadContentSpecs()
+	require.Error(t, err)
+}
+
+// TestLoadContentSpecs_BrokenOverrideFile_StoredAsDisabledNotConstructionFailure
+// proves the OTHER failure mode: a content file with a valid key: field
+// that nonetheless fails dungeonspec.Load (a schema/business-rule
+// violation — here, a single-room spec violating the >=2-rooms rule)
+// must NOT fail loadContentSpecs itself; it's stored as a disabled
+// (errored) contentSpecResult for that one key, every other key
+// unaffected — resolveContentDungeonSpec is what turns this into a
+// caller-visible DisabledDungeonKeyError, per-request, not at startup.
+func TestLoadContentSpecs_BrokenOverrideFile_StoredAsDisabledNotConstructionFailure(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "broken-dungeon.yaml"),
+		[]byte("version: 1\nkey: broken-dungeon\nname: Broken\nheight: 8\nrooms:\n  - id: only-one\n    archetype: entrance\n    width: 6\n"),
+		0o600,
+	))
+	t.Setenv("RPG_CONTENT_DIR", dir)
+
+	specs, err := loadContentSpecs()
+	require.NoError(t, err, "a schema-invalid content FILE must not fail construction")
+
+	result, ok := specs[DungeonKey("broken-dungeon")]
+	require.True(t, ok, "the key must still be present -- found, but disabled")
+	require.Error(t, result.err)
+
+	// The embedded reference-tomb must be unaffected by the other key's
+	// failure -- one broken file must never take down the whole registry.
+	tombResult, ok := specs[DungeonKey("reference-tomb")]
+	require.True(t, ok)
+	require.NoError(t, tombResult.err)
+}
+
+func TestResolveContentDungeonSpec_NotFound_ReturnsFoundFalse(t *testing.T) {
+	o := &Orchestrator{contentSpecs: map[DungeonKey]contentSpecResult{}}
+	compiled, found, err := o.resolveContentDungeonSpec(DungeonKey("no-such-key"))
+	require.False(t, found)
+	require.NoError(t, err)
+	require.Equal(t, dungeonspec.CompiledDungeon{}, compiled)
+}
+
+func TestResolveContentDungeonSpec_FoundAndValid_ReturnsCompiledNoError(t *testing.T) {
+	want := dungeonspec.CompiledDungeon{Params: tkenc.DungeonParams{Theme: "crypt"}}
+	o := &Orchestrator{contentSpecs: map[DungeonKey]contentSpecResult{
+		"reference-tomb": {compiled: want},
+	}}
+
+	compiled, found, err := o.resolveContentDungeonSpec(DungeonKey("reference-tomb"))
+	require.True(t, found)
+	require.NoError(t, err)
+	require.Equal(t, want, compiled)
+}
+
+func TestResolveContentDungeonSpec_FoundButDisabled_WrapsStoredError(t *testing.T) {
+	cause := errors.New("boom: at least 2 rooms required")
+	o := &Orchestrator{contentSpecs: map[DungeonKey]contentSpecResult{
+		"broken-dungeon": {err: cause},
+	}}
+
+	compiled, found, err := o.resolveContentDungeonSpec(DungeonKey("broken-dungeon"))
+	require.True(t, found, "a disabled key is still FOUND -- it must never fall through to the legacy map")
+	require.Error(t, err)
+	require.Equal(t, dungeonspec.CompiledDungeon{}, compiled)
+
+	var disabledErr *DisabledDungeonKeyError
+	require.True(t, errors.As(err, &disabledErr))
+	require.Equal(t, DungeonKey("broken-dungeon"), disabledErr.Key)
+	require.True(t, errors.Is(err, cause), "Unwrap must expose the stored cause")
+}
+
+func TestDisabledDungeonKeyError_ErrorMessageNamesKeyAndCause(t *testing.T) {
+	err := &DisabledDungeonKeyError{Key: "broken-dungeon", Cause: errors.New("bad spec")}
+	require.Contains(t, err.Error(), "broken-dungeon")
+	require.Contains(t, err.Error(), "bad spec")
 }

--- a/internal/orchestrators/lobby/lobby_test.go
+++ b/internal/orchestrators/lobby/lobby_test.go
@@ -172,6 +172,36 @@ func (s *LobbySuite) newOrchestratorWithContentDir(dir string) (*lobbyorch.Orche
 	})
 }
 
+// newOrchestratorWithDungeonKeyOverride returns a fresh Orchestrator
+// sharing every other suite dependency, constructed with
+// Config.DungeonKeyOverride set to key (Task E2b's RPG_DUNGEON_KEY
+// mechanism) — s.orch never has an override set, so a test exercising it
+// must build its own Orchestrator here, exactly like
+// newOrchestratorWithContentDir does for RPG_CONTENT_DIR.
+func (s *LobbySuite) newOrchestratorWithDungeonKeyOverride(key string) *lobbyorch.Orchestrator {
+	orch, err := lobbyorch.New(&lobbyorch.Config{
+		LobbyRepo:         s.lobbyRepo,
+		LobbyBroker:       s.broker,
+		CharacterRepo:     s.charRepo,
+		EncounterRepo:     s.encRepo,
+		EncounterBroker:   s.encBroker,
+		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		LobbyIDGenerator:     idgen.NewSequential("lobby"),
+		JoinRefGenerator:     idgen.NewSequential("ref"),
+		EncounterIDGenerator: idgen.NewSequential("enc"),
+		Now:                  func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+		DungeonKeyOverride:   key,
+	})
+	s.Require().NoError(err)
+	return orch
+}
+
 // seedLobby writes data directly to s.lobbyRepo, bypassing CreateLobby /
 // JoinLobby (and their character-repo lookups) so tests that exercise a
 // LATER RPC (SetReady, LeaveLobby, StartEncounter, SetConnected) can set up

--- a/internal/orchestrators/lobby/lobby_test.go
+++ b/internal/orchestrators/lobby/lobby_test.go
@@ -139,6 +139,39 @@ func (s *LobbySuite) newOrchestratorWithLobbyRepo(repo lobbyrepo.Repository) *lo
 	return orch
 }
 
+// newOrchestratorWithContentDir returns a fresh Orchestrator sharing every
+// other suite dependency, constructed with RPG_CONTENT_DIR set to dir —
+// for tests that need a deliberately broken (or deliberately augmented)
+// content override. loadContentSpecs only ever reads RPG_CONTENT_DIR
+// once, at New() time (Task E2's note #3: never per-request), so a test
+// needing a specific override must build its OWN Orchestrator here rather
+// than reuse s.orch, which was already constructed in SetupTest before
+// the test body ever runs. Returns the error too (rather than requiring
+// success) so this same helper covers both a successful construction
+// (the disabled-key test) and a construction FAILURE (an unreadable
+// RPG_CONTENT_DIR path).
+func (s *LobbySuite) newOrchestratorWithContentDir(dir string) (*lobbyorch.Orchestrator, error) {
+	s.T().Setenv("RPG_CONTENT_DIR", dir)
+	return lobbyorch.New(&lobbyorch.Config{
+		LobbyRepo:         s.lobbyRepo,
+		LobbyBroker:       s.broker,
+		CharacterRepo:     s.charRepo,
+		EncounterRepo:     s.encRepo,
+		EncounterBroker:   s.encBroker,
+		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		LobbyIDGenerator:     idgen.NewSequential("lobby"),
+		JoinRefGenerator:     idgen.NewSequential("ref"),
+		EncounterIDGenerator: idgen.NewSequential("enc"),
+		Now:                  func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+}
+
 // seedLobby writes data directly to s.lobbyRepo, bypassing CreateLobby /
 // JoinLobby (and their character-repo lookups) so tests that exercise a
 // LATER RPC (SetReady, LeaveLobby, StartEncounter, SetConnected) can set up

--- a/internal/orchestrators/lobby/orchestrator.go
+++ b/internal/orchestrators/lobby/orchestrator.go
@@ -117,6 +117,12 @@ type Orchestrator struct {
 	partyCap              int
 	now                   func() time.Time
 	locks                 *keyedMutex
+
+	// contentSpecs is the content-hosted dungeon spec registry (Task E2),
+	// built ONCE here at construction by loadContentSpecs — StartEncounter
+	// resolves against this stored map (resolveContentDungeonSpec), never
+	// by calling content.AllSpecs/SpecByKey again per request.
+	contentSpecs map[DungeonKey]contentSpecResult
 }
 
 // New constructs an Orchestrator from cfg. Returns an error (never a nil
@@ -169,6 +175,16 @@ func New(cfg *Config) (*Orchestrator, error) {
 	if now == nil {
 		now = time.Now
 	}
+
+	// Content-hosted dungeon specs (Task E2): built once here, never
+	// per-request. An unreadable RPG_CONTENT_DIR fails construction
+	// loudly rather than silently degrading to embedded-only content —
+	// see loadContentSpecs' doc.
+	contentSpecs, err := loadContentSpecs()
+	if err != nil {
+		return nil, err
+	}
+
 	return &Orchestrator{
 		lobbyRepo:             cfg.LobbyRepo,
 		lobbyBroker:           cfg.LobbyBroker,
@@ -184,6 +200,7 @@ func New(cfg *Config) (*Orchestrator, error) {
 		partyCap:              partyCap,
 		now:                   now,
 		locks:                 newKeyedMutex(),
+		contentSpecs:          contentSpecs,
 	}, nil
 }
 

--- a/internal/orchestrators/lobby/orchestrator.go
+++ b/internal/orchestrators/lobby/orchestrator.go
@@ -97,6 +97,23 @@ type Config struct {
 	// kept for parity with the v2 encounter orchestrator's Config and any
 	// future need (e.g. abandonment metrics).
 	Now func() time.Time
+
+	// DungeonKeyOverride is the RPG_DUNGEON_KEY dev-loop mechanism (Task
+	// E2b): when non-empty, StartEncounter substitutes this key ONLY when
+	// the caller supplied no DungeonKey at all — an explicit caller-
+	// supplied key always wins (no real proto surface sets one yet, so
+	// this is the only way to actually select a non-default key end to
+	// end today). Optional — "" (unset RPG_DUNGEON_KEY, every real
+	// deployment today) is a no-op, zero player-facing change.
+	//
+	// Validated here at construction, not deferred to first request: must
+	// resolve via either the content registry (and not be a DISABLED
+	// content key — a load-error key set as the override fails loudly at
+	// boot too, same posture as any other Config validation failure) or
+	// the legacy dungeonSpecs map. An override naming nothing real is a
+	// deploy-time misconfiguration, not something that should surface only
+	// on the first StartEncounter call.
+	DungeonKeyOverride string
 }
 
 // Orchestrator is the lobby load -> mutate -> persist -> publish core. One
@@ -123,6 +140,12 @@ type Orchestrator struct {
 	// resolves against this stored map (resolveContentDungeonSpec), never
 	// by calling content.AllSpecs/SpecByKey again per request.
 	contentSpecs map[DungeonKey]contentSpecResult
+
+	// dungeonKeyOverride is Config.DungeonKeyOverride, already validated
+	// to resolve (Task E2b) — "" when RPG_DUNGEON_KEY was unset at
+	// startup, in which case StartEncounter's effectiveKey substitution is
+	// a no-op.
+	dungeonKeyOverride DungeonKey
 }
 
 // New constructs an Orchestrator from cfg. Returns an error (never a nil
@@ -185,6 +208,14 @@ func New(cfg *Config) (*Orchestrator, error) {
 		return nil, err
 	}
 
+	// RPG_DUNGEON_KEY override (Task E2b): validated NOW, against the
+	// registry just built above, so a misconfigured override fails
+	// construction loudly rather than deferring to StartEncounter's first
+	// real call.
+	if err := validateDungeonKeyOverride(cfg.DungeonKeyOverride, contentSpecs); err != nil {
+		return nil, err
+	}
+
 	return &Orchestrator{
 		lobbyRepo:             cfg.LobbyRepo,
 		lobbyBroker:           cfg.LobbyBroker,
@@ -201,6 +232,7 @@ func New(cfg *Config) (*Orchestrator, error) {
 		now:                   now,
 		locks:                 newKeyedMutex(),
 		contentSpecs:          contentSpecs,
+		dungeonKeyOverride:    DungeonKey(cfg.DungeonKeyOverride),
 	}, nil
 }
 

--- a/internal/orchestrators/lobby/orchestrator_test.go
+++ b/internal/orchestrators/lobby/orchestrator_test.go
@@ -1,6 +1,7 @@
 package lobby_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,36 @@ func TestNew_NegativePartyCap_ReturnsError(t *testing.T) {
 		JoinRefGenerator:     idgen.NewSequential("ref"),
 		EncounterIDGenerator: idgen.NewSequential("enc"),
 		PartyCap:             -1,
+	})
+	require.Error(t, err)
+}
+
+// TestNew_ContentDirUnreadable_ReturnsConstructionError proves Task E2's
+// content-dir wiring end to end: an RPG_CONTENT_DIR pointing at a path
+// that can't be read must fail lobbyorch.New() loudly, not panic and not
+// silently degrade to embedded-only content — the same "operator/config
+// mistake must fail construction" posture Task E2b applies to
+// RPG_DUNGEON_KEY.
+func TestNew_ContentDirUnreadable_ReturnsConstructionError(t *testing.T) {
+	t.Setenv("RPG_CONTENT_DIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	ctrl := gomock.NewController(t)
+	_, err := lobbyorch.New(&lobbyorch.Config{
+		LobbyRepo:         lobbyrepo.NewInMemory(),
+		LobbyBroker:       lobbyorch.NewBroker(),
+		CharacterRepo:     charactermock.NewMockRepository(ctrl),
+		EncounterRepo:     encountersv2.NewInMemory(),
+		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		LobbyIDGenerator:     idgen.NewSequential("lobby"),
+		JoinRefGenerator:     idgen.NewSequential("ref"),
+		EncounterIDGenerator: idgen.NewSequential("enc"),
 	})
 	require.Error(t, err)
 }

--- a/internal/orchestrators/lobby/orchestrator_test.go
+++ b/internal/orchestrators/lobby/orchestrator_test.go
@@ -50,7 +50,12 @@ func TestNew_NegativePartyCap_ReturnsError(t *testing.T) {
 // that can't be read must fail lobbyorch.New() loudly, not panic and not
 // silently degrade to embedded-only content — the same "operator/config
 // mistake must fail construction" posture Task E2b applies to
-// RPG_DUNGEON_KEY.
+// RPG_DUNGEON_KEY. Also pins the message content (Copilot PR #710 review):
+// names RPG_CONTENT_DIR (the env var an operator actually set), and drops
+// the "lobby orchestrator:" prefix that would double up once
+// cmd/server/server.go's own lobbyorch.New call site wraps this error with
+// fmt.Errorf("lobby orchestrator: %w", err) — the same class of doubled
+// prefix Task E3's rider fixed for validateDungeonKeyOverride's errors.
 func TestNew_ContentDirUnreadable_ReturnsConstructionError(t *testing.T) {
 	t.Setenv("RPG_CONTENT_DIR", filepath.Join(t.TempDir(), "does-not-exist"))
 
@@ -73,6 +78,8 @@ func TestNew_ContentDirUnreadable_ReturnsConstructionError(t *testing.T) {
 		EncounterIDGenerator: idgen.NewSequential("enc"),
 	})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RPG_CONTENT_DIR", "message must name the env var an operator set")
+	assert.NotContains(t, err.Error(), "lobby orchestrator", "must not carry a prefix that would double up when server.go wraps it")
 }
 
 // baseTestConfig returns the required-fields-only Config every New() test

--- a/internal/orchestrators/lobby/orchestrator_test.go
+++ b/internal/orchestrators/lobby/orchestrator_test.go
@@ -1,6 +1,7 @@
 package lobby_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -71,4 +72,91 @@ func TestNew_ContentDirUnreadable_ReturnsConstructionError(t *testing.T) {
 		EncounterIDGenerator: idgen.NewSequential("enc"),
 	})
 	require.Error(t, err)
+}
+
+// baseTestConfig returns the required-fields-only Config every New() test
+// in this file builds on, customizing just the one field under test.
+func baseTestConfig(t *testing.T) *lobbyorch.Config {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	return &lobbyorch.Config{
+		LobbyRepo:         lobbyrepo.NewInMemory(),
+		LobbyBroker:       lobbyorch.NewBroker(),
+		CharacterRepo:     charactermock.NewMockRepository(ctrl),
+		EncounterRepo:     encountersv2.NewInMemory(),
+		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
+			return nil
+		},
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		LobbyIDGenerator:     idgen.NewSequential("lobby"),
+		JoinRefGenerator:     idgen.NewSequential("ref"),
+		EncounterIDGenerator: idgen.NewSequential("enc"),
+	}
+}
+
+// --- Task E2b: RPG_DUNGEON_KEY dev-loop override, validated at construction ---
+
+// TestNew_DungeonKeyOverrideMustResolve proves an override key that
+// resolves NOWHERE — not content, not the legacy dungeonSpecs map — fails
+// construction loudly, per the plan's own test sketch.
+func TestNew_DungeonKeyOverrideMustResolve(t *testing.T) {
+	cfg := baseTestConfig(t)
+	cfg.DungeonKeyOverride = "atlantis"
+	_, err := lobbyorch.New(cfg)
+	require.Error(t, err, "an override key resolving nowhere (content or legacy) must fail construction loudly")
+}
+
+// TestNew_DungeonKeyOverrideRejectsDisabledContentKey proves an override
+// pointing at a content key that itself failed dungeonspec.Load at
+// startup (contentSpecs[key].err != nil) must ALSO fail construction —
+// not silently accepted just because the key string exists in the map.
+func TestNew_DungeonKeyOverrideRejectsDisabledContentKey(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "broken-dungeon.yaml"),
+		[]byte("version: 1\nkey: broken-dungeon\nname: Broken\nheight: 8\nrooms:\n"+
+			"  - id: only-one\n    archetype: entrance\n    width: 6\n"),
+		0o600,
+	))
+	t.Setenv("RPG_CONTENT_DIR", dir)
+
+	cfg := baseTestConfig(t)
+	cfg.DungeonKeyOverride = "broken-dungeon"
+	_, err := lobbyorch.New(cfg)
+	require.Error(t, err, "an override pointing at a DISABLED content key must fail construction, not defer to first request")
+}
+
+// TestNew_DungeonKeyOverrideEmptyIsANoOp proves DungeonKeyOverride: ""
+// (today's real deployments — RPG_DUNGEON_KEY unset) constructs exactly
+// as before this task. Zero player-facing change is the whole point.
+func TestNew_DungeonKeyOverrideEmptyIsANoOp(t *testing.T) {
+	cfg := baseTestConfig(t)
+	cfg.DungeonKeyOverride = ""
+	_, err := lobbyorch.New(cfg)
+	require.NoError(t, err)
+}
+
+// TestNew_DungeonKeyOverride_ResolvesViaContentRegistry proves the
+// content-registry resolution half explicitly: reference-tomb ships
+// embedded (Task E1), so an override naming it must construct cleanly
+// with no RPG_CONTENT_DIR needed.
+func TestNew_DungeonKeyOverride_ResolvesViaContentRegistry(t *testing.T) {
+	cfg := baseTestConfig(t)
+	cfg.DungeonKeyOverride = "reference-tomb"
+	_, err := lobbyorch.New(cfg)
+	require.NoError(t, err)
+}
+
+// TestNew_DungeonKeyOverride_ResolvesViaLegacyMap proves the OTHER
+// resolution half: an override naming a legacy dungeonSpecs key (crypt)
+// must also construct cleanly.
+func TestNew_DungeonKeyOverride_ResolvesViaLegacyMap(t *testing.T) {
+	cfg := baseTestConfig(t)
+	cfg.DungeonKeyOverride = string(lobbyorch.DungeonKeyCrypt)
+	_, err := lobbyorch.New(cfg)
+	require.NoError(t, err)
 }

--- a/internal/orchestrators/lobby/orchestrator_test.go
+++ b/internal/orchestrators/lobby/orchestrator_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"
@@ -102,12 +103,19 @@ func baseTestConfig(t *testing.T) *lobbyorch.Config {
 
 // TestNew_DungeonKeyOverrideMustResolve proves an override key that
 // resolves NOWHERE — not content, not the legacy dungeonSpecs map — fails
-// construction loudly, per the plan's own test sketch.
+// construction loudly, per the plan's own test sketch. Also pins the
+// message content: names RPG_DUNGEON_KEY (the env var an operator
+// actually set), not Config.DungeonKeyOverride (the Go field), and — once
+// wrapped by cmd/server/server.go's own "lobby orchestrator: %w" at the
+// real New() call site — must never double up to "lobby orchestrator:
+// lobby orchestrator: ...".
 func TestNew_DungeonKeyOverrideMustResolve(t *testing.T) {
 	cfg := baseTestConfig(t)
 	cfg.DungeonKeyOverride = "atlantis"
 	_, err := lobbyorch.New(cfg)
 	require.Error(t, err, "an override key resolving nowhere (content or legacy) must fail construction loudly")
+	assert.Contains(t, err.Error(), "RPG_DUNGEON_KEY", "message must name the env var an operator set")
+	assert.NotContains(t, err.Error(), "lobby orchestrator", "must not carry a prefix that would double up when server.go wraps it")
 }
 
 // TestNew_DungeonKeyOverrideRejectsDisabledContentKey proves an override
@@ -128,6 +136,8 @@ func TestNew_DungeonKeyOverrideRejectsDisabledContentKey(t *testing.T) {
 	cfg.DungeonKeyOverride = "broken-dungeon"
 	_, err := lobbyorch.New(cfg)
 	require.Error(t, err, "an override pointing at a DISABLED content key must fail construction, not defer to first request")
+	assert.Contains(t, err.Error(), "RPG_DUNGEON_KEY")
+	assert.NotContains(t, err.Error(), "lobby orchestrator")
 }
 
 // TestNew_DungeonKeyOverrideEmptyIsANoOp proves DungeonKeyOverride: ""

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -106,12 +106,19 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		return nil, errors.New("lobby orchestrator: StartEncounterInput is required")
 	}
 
-	// effectiveKey is in.DungeonKey today, unchanged — Task E2b adds an
-	// RPG_DUNGEON_KEY-sourced fallback here (o.dungeonKeyOverride) for
-	// when the caller supplies no key at all; until that lands this is a
-	// plain passthrough, so every real caller's behavior is untouched by
-	// this task.
+	// effectiveKey substitutes Task E2b's RPG_DUNGEON_KEY override ONLY
+	// when the caller supplied no key at all — an explicit in.DungeonKey
+	// (once a real proto surface exists to set one) always wins.
+	// o.dungeonKeyOverride is "" when RPG_DUNGEON_KEY was unset at
+	// startup, so this is a no-op today for every real caller (zero
+	// player-facing change, per design.md) — no real handler builds
+	// in.DungeonKey from the request yet, so every real call leaves it at
+	// the zero value and gets whatever the override resolves to (or the
+	// legacy default when there's no override either).
 	effectiveKey := in.DungeonKey
+	if effectiveKey == "" {
+		effectiveKey = o.dungeonKeyOverride
+	}
 
 	// Content-backed resolution (Task E2) runs FIRST, before touching the
 	// lobby lock or building anything — same "fail loudly, zero side

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -106,17 +106,39 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		return nil, errors.New("lobby orchestrator: StartEncounterInput is required")
 	}
 
-	// Resolve the dungeon spec BEFORE touching the lobby lock or building
-	// anything — an unknown key must fail loudly with zero side effects
-	// (rpg-api#688's boundary note: rpg-api never invents geometry for a
-	// key it doesn't recognize). in.RandomSeed threads straight through to
-	// the resolved tkenc.DungeonParams.RandomSeed (rpg-api#694: the crypt
-	// key's builder calls tkenc.CryptDungeonParams(seed, ...), which sets
-	// it) — entropy-seeded when zero, same as every other InitRoom/
-	// InitDungeon caller.
-	dungeonKey, dungeonParams, specErr := resolveDungeonSpec(in.DungeonKey, in.RandomSeed)
-	if specErr != nil {
-		return nil, specErr
+	// effectiveKey is in.DungeonKey today, unchanged — Task E2b adds an
+	// RPG_DUNGEON_KEY-sourced fallback here (o.dungeonKeyOverride) for
+	// when the caller supplies no key at all; until that lands this is a
+	// plain passthrough, so every real caller's behavior is untouched by
+	// this task.
+	effectiveKey := in.DungeonKey
+
+	// Content-backed resolution (Task E2) runs FIRST, before touching the
+	// lobby lock or building anything — same "fail loudly, zero side
+	// effects" posture resolveDungeonSpec below already has. A content key
+	// that's FOUND but disabled (its file failed dungeonspec.Load at
+	// startup) must return immediately here; a key content doesn't
+	// recognize at all falls through to the legacy resolveDungeonSpec/
+	// dungeonSpecs path below, completely untouched by this branch.
+	contentCompiled, foundInContent, contentErr := o.resolveContentDungeonSpec(effectiveKey)
+	if foundInContent && contentErr != nil {
+		return nil, contentErr // *DisabledDungeonKeyError; lobbyStatusError maps it (Task E3)
+	}
+
+	// The legacy path only runs when effectiveKey isn't content-backed at
+	// all — resolveDungeonSpec ITSELF is untouched: it still applies its
+	// own hardcoded defaultDungeonKey fallback for an empty key, and
+	// effectiveKey is only empty here when the caller supplied none
+	// (today, every real caller), so today's exact fallback behavior
+	// (crypt) is unchanged for every key content doesn't claim.
+	var dungeonKey DungeonKey
+	var dungeonParams tkenc.DungeonParams
+	if !foundInContent {
+		var specErr error
+		dungeonKey, dungeonParams, specErr = resolveDungeonSpec(effectiveKey, in.RandomSeed)
+		if specErr != nil {
+			return nil, specErr
+		}
 	}
 
 	unlock := o.locks.Lock(in.LobbyID)
@@ -157,10 +179,19 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 	// the dungeon (N regions + N-1 plain doors + entrance + per-region
 	// archetype tags + opaque theme + physical set-piece obstacles) is
 	// entirely the toolkit's call — rpg-api only supplies the resolved
-	// key's toolkit-constructed params verbatim (rpg-api#688, rpg-api#694).
-	// dungeonParams.RandomSeed is already in.RandomSeed, threaded in by
-	// resolveDungeonSpec above.
-	if err := enc.InitDungeon(dungeonParams); err != nil {
+	// key's toolkit-constructed params verbatim (rpg-api#688, rpg-api#694),
+	// or (Task E2) the content-compiled params verbatim.
+	if foundInContent {
+		// compiled.Params.RandomSeed is a FIELD dungeonspec.Load leaves at
+		// its zero value (Load has no opinion on reproducibility) — the
+		// caller must set it before InitDungeon, exactly like
+		// resolveDungeonSpec already threads in.RandomSeed into the
+		// legacy path's params below.
+		contentCompiled.Params.RandomSeed = in.RandomSeed
+		if err := enc.InitDungeon(contentCompiled.Params); err != nil {
+			return nil, fmt.Errorf("init dungeon (key=%q) for encounter %q: %w", effectiveKey, encID, err)
+		}
+	} else if err := enc.InitDungeon(dungeonParams); err != nil {
 		return nil, fmt.Errorf("init dungeon (key=%q) for encounter %q: %w", dungeonKey, encID, err)
 	}
 
@@ -199,18 +230,23 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 		}
 	}
 
-	// Seed the crypt's first-swing monster composition (rpg-api#689): one
+	// Seed monsters — Task E2's content-backed branch uses the toolkit's
+	// generic Encounter.SeedMonsters against the compiled spawn plan
+	// (dungeonspec's own placed-instruction batching/atomic-combat-entry
+	// invariants); the legacy crypt branch is UNCHANGED: one
 	// deterministic-anchor minion in the entrance region, zero in the
 	// corridor, one deterministic-anchor boss in the boss region — via
 	// spawn.FixedPositions only (crypt_monster_seed.go's
 	// seedRegionMonsters/buildMonsterSeedGroups/regionMonsterAnchor), no
-	// PositionOracle search/retry. Concealment (when it happens) comes
-	// from real door/wall LoS geometry, not a placement predicate.
-	// dungeonParams is the same toolkit-constructed params InitDungeon was
-	// just given above (rpg-api#694: CryptDungeonParams' own Regions/
-	// Connectors, not an API-owned literal) — seedRegionMonsters is generic
-	// over that shape regardless of which key produced it.
-	if err := o.seedRegionMonsters(ctx, enc, encID, dungeonParams, dungeonKey); err != nil {
+	// PositionOracle search/retry. Both branches run AFTER every member has
+	// been added above (SeedMonsters' documented caller-ordering
+	// requirement; seedRegionMonsters already relies on the same thing via
+	// perception.CanSeeAt's combat-entry check).
+	if foundInContent {
+		if err := enc.SeedMonsters(contentCompiled.Spawns); err != nil {
+			return nil, fmt.Errorf("seed monsters for encounter %q: %w", encID, err)
+		}
+	} else if err := o.seedRegionMonsters(ctx, enc, encID, dungeonParams, dungeonKey); err != nil {
 		return nil, fmt.Errorf("seed monsters for encounter %q: %w", encID, err)
 	}
 

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -926,17 +926,48 @@ func (s *LobbySuite) TestStartEncounter_DungeonGeometryIndependentOfPartySize() 
 
 // --- Task E2: content-backed dungeon keys ---
 
+// placedThing is one placed monster or prop's ref, owning region, and
+// absolute cell — the comparison unit for pinning reference-tomb's exact
+// compiled layout (see TestStartEncounter_ContentBackedKey_ReferenceTomb).
+type placedThing struct {
+	ref       string
+	region    string
+	at        core.Hex
+	blocksLoS bool // only meaningful for obstacles; zero value for monsters
+}
+
+func sortPlacedThings(things []placedThing) {
+	sort.Slice(things, func(i, j int) bool {
+		if things[i].ref != things[j].ref {
+			return things[i].ref < things[j].ref
+		}
+		if things[i].at.Q != things[j].at.Q {
+			return things[i].at.Q < things[j].at.Q
+		}
+		if things[i].at.R != things[j].at.R {
+			return things[i].at.R < things[j].at.R
+		}
+		return things[i].at.S < things[j].at.S
+	})
+}
+
 // TestStartEncounter_ContentBackedKey_ReferenceTomb is the M1 acceptance
 // proof at the orchestrator level: StartEncounter("reference-tomb")
 // builds the content-hosted spec (internal/content/dungeons/
 // reference-tomb.yaml, shipped embedded — no RPG_CONTENT_DIR override
 // needed) via the SAME toolkit InitDungeon + SeedMonsters path a real
-// content-authored dungeon would use — two regions (entrance + tomb) with
-// their declared archetypes, the tomb's boss and every place: prop/monster
-// landing inside the tomb region, and the EXISTING crypt-path tests
+// content-authored dungeon would use, and the EXISTING crypt-path tests
 // (TestStartEncounter_CryptDungeon_..., TestStartEncounter_CryptMonsters_...,
-// TestStartEncounter_CryptObstacles_...) staying green completely
-// unperturbed by this branch's addition.
+// TestStartEncounter_CryptObstacles_...) stay green completely unperturbed
+// by this branch's addition.
+//
+// reference-tomb became a 3-room spec (entrance -> hall -> tomb, Kirk's
+// live-authored draft, approved in-game 2026-07-25) — every want* value
+// below was MEASURED directly off the real compiler + engine (a throwaway
+// program: dungeonspec.Load -> InitDungeon(seed 42) -> SeedMonsters,
+// reading back encData.Monsters/Space.Obstacles/Doors), never hand-derived.
+// Every position in the spec is placed (place:/boss.at), never rolled, so
+// these are seed-independent, stable absolute hexes.
 func (s *LobbySuite) TestStartEncounter_ContentBackedKey_ReferenceTomb() {
 	s.seedReadyLobby("lobby-tomb1", "alice")
 	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
@@ -951,80 +982,78 @@ func (s *LobbySuite) TestStartEncounter_ContentBackedKey_ReferenceTomb() {
 	s.Require().NoError(err)
 	s.Require().NotNil(encData.Space)
 	s.Require().Equal("crypt", encData.Space.Theme)
-	s.Require().Len(encData.Space.Regions, 2, "reference-tomb is a two-room spec: entrance + tomb")
+	s.Require().Len(encData.Space.Regions, 3, "reference-tomb is now a three-room spec: entrance -> hall -> tomb")
 
-	entrance, entranceOK := regionByArchetype(encData.Space, tkenc.ArchetypeEntrance)
+	_, entranceOK := regionByArchetype(encData.Space, tkenc.ArchetypeEntrance)
 	s.Require().True(entranceOK, "exactly one entrance-archetype region")
+	hall, hallOK := regionByArchetype(encData.Space, tkenc.ArchetypeChamber)
+	s.Require().True(hallOK, "exactly one chamber-archetype region (the hall)")
 	tomb, tombOK := regionByArchetype(encData.Space, tkenc.ArchetypeBoss)
 	s.Require().True(tombOK, "exactly one boss-archetype region (the tomb)")
-	_ = entrance
 
-	// The boss (skeleton-captain, pinned boss.at) and the placed skeleton
-	// monster must both land at their EXACT compiled cells — every
-	// position in reference-tomb.yaml is placed (place:/boss.at), never
-	// rolled, so these are seed-independent, stable absolute hexes, not
-	// just "somewhere in the tomb region."
-	wantMonsterPositions := map[string]core.Hex{
-		"dnd5e:monsters:skeleton-captain": {Q: 14, R: -12, S: -2},
-		"dnd5e:monsters:skeleton":         {Q: 11, R: -8, S: -3},
+	// The hall->tomb connector is locked (DC 12, dex) — the entrance->hall
+	// connector is not. Exactly one locked door, with the spec's exact
+	// lock parameters surviving compile -> InitDungeon -> persisted DoorData.
+	var lockedDoors int
+	for _, d := range encData.Doors {
+		if !d.Locked {
+			continue
+		}
+		lockedDoors++
+		s.Assert().Equal(12, d.LockDC)
+		s.Assert().Equal("dex", d.LockAbility)
 	}
-	gotMonsterPositions := map[string]core.Hex{}
+	s.Require().Equal(1, lockedDoors, "exactly the hall->tomb connector is locked")
+
+	// Three monster spawns: two placed skeletons in the hall, the pinned
+	// boss (skeleton-captain) in the tomb.
+	wantMonsters := []placedThing{
+		{ref: "dnd5e:monsters:skeleton", region: hall.ID, at: core.Hex{Q: 12, R: -9, S: -3}},
+		{ref: "dnd5e:monsters:skeleton", region: hall.ID, at: core.Hex{Q: 14, R: -12, S: -2}},
+		{ref: "dnd5e:monsters:skeleton-captain", region: tomb.ID, at: core.Hex{Q: 25, R: -18, S: -7}},
+	}
+	gotMonsters := make([]placedThing, 0, len(encData.Monsters))
 	for _, m := range encData.Monsters {
 		regionID, ok := encData.Space.RegionAt(m.Position)
 		s.Require().True(ok, "every seeded monster must land on a tagged region hex")
-		s.Assert().Equal(tomb.ID, regionID, "reference-tomb's monsters are both in the tomb room")
-		gotMonsterPositions[m.MonsterRef] = m.Position
+		gotMonsters = append(gotMonsters, placedThing{ref: m.MonsterRef, region: regionID, at: m.Position})
 	}
-	s.Require().Equal(wantMonsterPositions, gotMonsterPositions,
-		"the boss and the placed skeleton must land at their exact compiled cells")
+	sortPlacedThings(wantMonsters)
+	sortPlacedThings(gotMonsters)
+	s.Require().Equal(wantMonsters, gotMonsters, "every placed monster must land at its exact compiled cell, in its declared room")
 
-	// All five placed props (coffin, altar, statue-reaper, brazier x2) must
-	// land at their exact compiled cells too, with the spec's blocks_los
-	// override (coffin: false) and the toolkit's true default (the other
-	// four) both surviving compile -> InitDungeon -> persisted ObstacleData.
-	wantObstaclePositions := map[string][]core.Hex{
-		"dnd5e:props:coffin":        {{Q: 13, R: -10, S: -3}},
-		"dnd5e:props:altar":         {{Q: 16, R: -11, S: -5}},
-		"dnd5e:props:statue-reaper": {{Q: 8, R: -5, S: -3}},
-		"dnd5e:props:brazier":       {{Q: 10, R: -6, S: -4}, {Q: 10, R: -11, S: 1}},
+	// Fifteen placed props across all three rooms, with the spec's
+	// blocks_los override (coffin: false) and the toolkit's true default
+	// (every other prop) both surviving compile -> InitDungeon ->
+	// persisted ObstacleData.
+	wantObstacles := []placedThing{
+		{ref: "dnd5e:props:altar", region: tomb.ID, at: core.Hex{Q: 27, R: -17, S: -10}, blocksLoS: true},
+		{ref: "dnd5e:props:bone-pile", region: hall.ID, at: core.Hex{Q: 15, R: -14, S: -1}, blocksLoS: true},
+		{ref: "dnd5e:props:brazier", region: "entrance", at: core.Hex{Q: 1, R: -2, S: 1}, blocksLoS: true},
+		{ref: "dnd5e:props:brazier", region: "entrance", at: core.Hex{Q: 1, R: -7, S: 6}, blocksLoS: true},
+		{ref: "dnd5e:props:brazier", region: tomb.ID, at: core.Hex{Q: 21, R: -12, S: -9}, blocksLoS: true},
+		{ref: "dnd5e:props:brazier", region: tomb.ID, at: core.Hex{Q: 21, R: -17, S: -4}, blocksLoS: true},
+		{ref: "dnd5e:props:candles", region: tomb.ID, at: core.Hex{Q: 28, R: -19, S: -9}, blocksLoS: true},
+		{ref: "dnd5e:props:coffin", region: tomb.ID, at: core.Hex{Q: 24, R: -15, S: -9}, blocksLoS: false},
+		{ref: "dnd5e:props:pillar", region: hall.ID, at: core.Hex{Q: 9, R: -10, S: 1}, blocksLoS: true},
+		{ref: "dnd5e:props:pillar", region: hall.ID, at: core.Hex{Q: 9, R: -7, S: -2}, blocksLoS: true},
+		{ref: "dnd5e:props:pillar", region: hall.ID, at: core.Hex{Q: 13, R: -9, S: -4}, blocksLoS: true},
+		{ref: "dnd5e:props:pillar", region: hall.ID, at: core.Hex{Q: 13, R: -12, S: -1}, blocksLoS: true},
+		{ref: "dnd5e:props:statue-knight-hooded", region: tomb.ID, at: core.Hex{Q: 19, R: -16, S: -3}, blocksLoS: true},
+		{ref: "dnd5e:props:statue-reaper", region: tomb.ID, at: core.Hex{Q: 19, R: -11, S: -8}, blocksLoS: true},
+		{ref: "dnd5e:props:torch-ornate", region: hall.ID, at: core.Hex{Q: 11, R: -7, S: -4}, blocksLoS: true},
 	}
-	wantBlocksLoS := map[string]bool{
-		"dnd5e:props:coffin":        false,
-		"dnd5e:props:altar":         true,
-		"dnd5e:props:statue-reaper": true,
-		"dnd5e:props:brazier":       true,
-	}
-	gotObstaclePositions := map[string][]core.Hex{}
+	gotObstacles := make([]placedThing, 0, len(encData.Space.Obstacles))
 	for _, obstacle := range encData.Space.Obstacles {
 		regionID, ok := encData.Space.RegionAt(obstacle.Position)
 		s.Require().True(ok, "every placed obstacle must land on a tagged region hex")
-		s.Assert().Equal(tomb.ID, regionID, "reference-tomb's placed props are all in the tomb room")
-		s.Assert().Equal(wantBlocksLoS[obstacle.Ref], obstacle.BlocksLoS, "ref %q blocks_los", obstacle.Ref)
-		gotObstaclePositions[obstacle.Ref] = append(gotObstaclePositions[obstacle.Ref], obstacle.Position)
+		gotObstacles = append(gotObstacles, placedThing{
+			ref: obstacle.Ref, region: regionID, at: obstacle.Position, blocksLoS: obstacle.BlocksLoS,
+		})
 	}
-	for ref := range gotObstaclePositions {
-		sortHexes(gotObstaclePositions[ref])
-	}
-	for ref := range wantObstaclePositions {
-		sortHexes(wantObstaclePositions[ref])
-	}
-	s.Require().Equal(wantObstaclePositions, gotObstaclePositions,
-		"exactly the reference-tomb spec's five placed props, at their exact compiled cells")
-}
-
-// sortHexes orders hexes by (Q, R, S) for stable slice comparison — the
-// spawn/obstacle engines don't guarantee any particular iteration order
-// among same-ref instances (e.g. reference-tomb's two braziers).
-func sortHexes(hexes []core.Hex) {
-	sort.Slice(hexes, func(i, j int) bool {
-		if hexes[i].Q != hexes[j].Q {
-			return hexes[i].Q < hexes[j].Q
-		}
-		if hexes[i].R != hexes[j].R {
-			return hexes[i].R < hexes[j].R
-		}
-		return hexes[i].S < hexes[j].S
-	})
+	sortPlacedThings(wantObstacles)
+	sortPlacedThings(gotObstacles)
+	s.Require().Equal(wantObstacles, gotObstacles, "every placed prop must land at its exact compiled cell, in its declared room, with its exact blocks_los")
 }
 
 // TestStartEncounter_DisabledContentKey_ErrorsBeforeLobbyLock proves the
@@ -1154,6 +1183,14 @@ func (s *LobbySuite) TestStartEncounter_ContentBackedKey_SeedWiring() {
 // supplying NO DungeonKey at all (today's exact shape — no real proto
 // surface sets one), StartEncounter must build the content-backed
 // reference-tomb dungeon, not the legacy crypt default.
+//
+// Both specs now compile to 3 regions (reference-tomb's Kirk-authored
+// entrance/hall/tomb draft; the legacy crypt's entrance/corridor/boss), so
+// region COUNT alone can no longer distinguish them (it could when
+// reference-tomb was 2 rooms). The crypt template never emits an
+// ArchetypeChamber region (verified against tkenc's own crypt_dungeon.go:
+// entrance/corridor/boss only) — reference-tomb's "hall" is the one
+// structural signal that's actually distinguishing.
 func (s *LobbySuite) TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb() {
 	orch := s.newOrchestratorWithDungeonKeyOverride("reference-tomb")
 
@@ -1168,7 +1205,9 @@ func (s *LobbySuite) TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb(
 
 	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
 	s.Require().NoError(err)
-	s.Require().Len(encData.Space.Regions, 2, "reference-tomb (not the 3-region crypt default) must have been selected")
+	hall, hallOK := regionByArchetype(encData.Space, tkenc.ArchetypeChamber)
+	s.Require().True(hallOK, "reference-tomb (not the crypt default, which has no chamber-archetype region) must have been selected")
+	s.Assert().Equal("hall", hall.ID)
 	_, tombOK := regionByArchetype(encData.Space, tkenc.ArchetypeBoss)
 	s.Require().True(tombOK)
 }

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -1074,11 +1074,11 @@ func (s *LobbySuite) TestStartEncounter_DisabledContentKey_ErrorsBeforeLobbyLock
 // room with placed/pinned content never gets rolled interior walls, so
 // only the entrance's own random walls can prove RandomSeed wiring here.
 // entrance's width (20) is deliberately generous: verified empirically
-// that a width this small as 6 rolls IDENTICAL walls for every seed
-// 1-50 (the margin heuristic leaves too few interior candidate cells to
-// vary) — width 20 was checked to produce 47 distinct wall layouts across
-// the same 50-seed sweep, and seeds 111/222 specifically (this test's
-// values) were confirmed to differ before being hardcoded here.
+// that a width as small as 6 rolls IDENTICAL walls for every seed 1-50
+// (the margin heuristic leaves too few interior candidate cells to vary)
+// — width 20 was checked to produce 47 distinct wall layouts across the
+// same 50-seed sweep, and seeds 111/222 specifically (this test's values)
+// were confirmed to differ before being hardcoded here.
 const scatteredSeedTestYAML = `
 version: 1
 key: scattered-seed-test

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -959,39 +960,71 @@ func (s *LobbySuite) TestStartEncounter_ContentBackedKey_ReferenceTomb() {
 	_ = entrance
 
 	// The boss (skeleton-captain, pinned boss.at) and the placed skeleton
-	// monster must both be present, landing inside the tomb region.
-	var bossFound, skeletonFound bool
+	// monster must both land at their EXACT compiled cells — every
+	// position in reference-tomb.yaml is placed (place:/boss.at), never
+	// rolled, so these are seed-independent, stable absolute hexes, not
+	// just "somewhere in the tomb region."
+	wantMonsterPositions := map[string]core.Hex{
+		"dnd5e:monsters:skeleton-captain": {Q: 14, R: -12, S: -2},
+		"dnd5e:monsters:skeleton":         {Q: 11, R: -8, S: -3},
+	}
+	gotMonsterPositions := map[string]core.Hex{}
 	for _, m := range encData.Monsters {
 		regionID, ok := encData.Space.RegionAt(m.Position)
 		s.Require().True(ok, "every seeded monster must land on a tagged region hex")
 		s.Assert().Equal(tomb.ID, regionID, "reference-tomb's monsters are both in the tomb room")
-		switch m.MonsterRef {
-		case "dnd5e:monsters:skeleton-captain":
-			bossFound = true
-		case "dnd5e:monsters:skeleton":
-			skeletonFound = true
-		}
+		gotMonsterPositions[m.MonsterRef] = m.Position
 	}
-	s.Require().True(bossFound, "the pinned boss (skeleton-captain) must be seeded")
-	s.Require().True(skeletonFound, "the placed skeleton monster must be seeded")
-	s.Require().Len(encData.Monsters, 2, "exactly the boss + one placed skeleton — no rolled/count-based monsters in M1")
+	s.Require().Equal(wantMonsterPositions, gotMonsterPositions,
+		"the boss and the placed skeleton must land at their exact compiled cells")
 
 	// All five placed props (coffin, altar, statue-reaper, brazier x2) must
-	// land inside the tomb region too.
-	wantObstacleRefs := map[string]int{
-		"dnd5e:props:coffin":        1,
-		"dnd5e:props:altar":         1,
-		"dnd5e:props:statue-reaper": 1,
-		"dnd5e:props:brazier":       2,
+	// land at their exact compiled cells too, with the spec's blocks_los
+	// override (coffin: false) and the toolkit's true default (the other
+	// four) both surviving compile -> InitDungeon -> persisted ObstacleData.
+	wantObstaclePositions := map[string][]core.Hex{
+		"dnd5e:props:coffin":        {{Q: 13, R: -10, S: -3}},
+		"dnd5e:props:altar":         {{Q: 16, R: -11, S: -5}},
+		"dnd5e:props:statue-reaper": {{Q: 8, R: -5, S: -3}},
+		"dnd5e:props:brazier":       {{Q: 10, R: -6, S: -4}, {Q: 10, R: -11, S: 1}},
 	}
-	gotObstacleRefs := map[string]int{}
+	wantBlocksLoS := map[string]bool{
+		"dnd5e:props:coffin":        false,
+		"dnd5e:props:altar":         true,
+		"dnd5e:props:statue-reaper": true,
+		"dnd5e:props:brazier":       true,
+	}
+	gotObstaclePositions := map[string][]core.Hex{}
 	for _, obstacle := range encData.Space.Obstacles {
 		regionID, ok := encData.Space.RegionAt(obstacle.Position)
 		s.Require().True(ok, "every placed obstacle must land on a tagged region hex")
 		s.Assert().Equal(tomb.ID, regionID, "reference-tomb's placed props are all in the tomb room")
-		gotObstacleRefs[obstacle.Ref]++
+		s.Assert().Equal(wantBlocksLoS[obstacle.Ref], obstacle.BlocksLoS, "ref %q blocks_los", obstacle.Ref)
+		gotObstaclePositions[obstacle.Ref] = append(gotObstaclePositions[obstacle.Ref], obstacle.Position)
 	}
-	s.Require().Equal(wantObstacleRefs, gotObstacleRefs, "exactly the reference-tomb spec's five placed props")
+	for ref := range gotObstaclePositions {
+		sortHexes(gotObstaclePositions[ref])
+	}
+	for ref := range wantObstaclePositions {
+		sortHexes(wantObstaclePositions[ref])
+	}
+	s.Require().Equal(wantObstaclePositions, gotObstaclePositions,
+		"exactly the reference-tomb spec's five placed props, at their exact compiled cells")
+}
+
+// sortHexes orders hexes by (Q, R, S) for stable slice comparison — the
+// spawn/obstacle engines don't guarantee any particular iteration order
+// among same-ref instances (e.g. reference-tomb's two braziers).
+func sortHexes(hexes []core.Hex) {
+	sort.Slice(hexes, func(i, j int) bool {
+		if hexes[i].Q != hexes[j].Q {
+			return hexes[i].Q < hexes[j].Q
+		}
+		if hexes[i].R != hexes[j].R {
+			return hexes[i].R < hexes[j].R
+		}
+		return hexes[i].S < hexes[j].S
+	})
 }
 
 // TestStartEncounter_DisabledContentKey_ErrorsBeforeLobbyLock proves the
@@ -1030,4 +1063,85 @@ func (s *LobbySuite) TestStartEncounter_DisabledContentKey_ErrorsBeforeLobbyLock
 	s.Require().NoError(err)
 	s.Require().Equal(lobbyrepo.StatusWaiting, lobbyData.Status, "a disabled content key must fail before any state transition")
 	s.Require().Empty(lobbyData.EncounterID)
+}
+
+// scatteredSeedTestYAML is a content-backed spec whose ONLY seed-varying
+// geometry lives in the entrance room (pattern: scattered, no place:
+// entries — design.md's delta forbids place:/boss.at together with a
+// scattered pattern). The tomb room's pinned boss.at (M1's own
+// restriction requires a boss room to pin its boss) compiles its pattern
+// to "empty" (verified directly against the compiler, not assumed) — a
+// room with placed/pinned content never gets rolled interior walls, so
+// only the entrance's own random walls can prove RandomSeed wiring here.
+// entrance's width (20) is deliberately generous: verified empirically
+// that a width this small as 6 rolls IDENTICAL walls for every seed
+// 1-50 (the margin heuristic leaves too few interior candidate cells to
+// vary) — width 20 was checked to produce 47 distinct wall layouts across
+// the same 50-seed sweep, and seeds 111/222 specifically (this test's
+// values) were confirmed to differ before being hardcoded here.
+const scatteredSeedTestYAML = `
+version: 1
+key: scattered-seed-test
+name: Scattered Seed Test
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 20
+    pattern: scattered
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+connectors:
+  - { from: entrance, to: tomb }
+`
+
+// TestStartEncounter_ContentBackedKey_SeedWiring proves compiled.Params.
+// RandomSeed = in.RandomSeed (start_encounter.go) actually reaches
+// InitDungeon: the same seed must reproduce byte-identical scattered-
+// pattern geometry across two independent encounters, and a different
+// seed must roll different geometry — the content-backed-branch
+// equivalent of TestStartEncounter_ExplicitSeed_ReproducibleDungeonLayout
+// for the legacy crypt path.
+func (s *LobbySuite) TestStartEncounter_ContentBackedKey_SeedWiring() {
+	dir := s.T().TempDir()
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "scattered-seed-test.yaml"), []byte(scatteredSeedTestYAML), 0o600,
+	))
+	orch, err := s.newOrchestratorWithContentDir(dir)
+	s.Require().NoError(err)
+
+	s.seedReadyLobby("lobby-seed-a", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+	outA, err := orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-seed-a",
+		DungeonKey: lobbyorch.DungeonKey("scattered-seed-test"), RandomSeed: 111,
+	})
+	s.Require().NoError(err)
+	dataA, err := s.encRepo.Get(s.ctx, outA.EncounterID)
+	s.Require().NoError(err)
+
+	s.seedReadyLobby("lobby-seed-b", "bob")
+	s.expectCharacter("char-bob", "bob", "Bob", 12, 12)
+	outB, err := orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "bob", LobbyID: "lobby-seed-b",
+		DungeonKey: lobbyorch.DungeonKey("scattered-seed-test"), RandomSeed: 111,
+	})
+	s.Require().NoError(err)
+	dataB, err := s.encRepo.Get(s.ctx, outB.EncounterID)
+	s.Require().NoError(err)
+	s.Require().Equal(dataA.Space, dataB.Space, "the same seed must reproduce identical content-backed dungeon geometry")
+
+	s.seedReadyLobby("lobby-seed-c", "carol")
+	s.expectCharacter("char-carol", "carol", "Carol", 12, 12)
+	outC, err := orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "carol", LobbyID: "lobby-seed-c",
+		DungeonKey: lobbyorch.DungeonKey("scattered-seed-test"), RandomSeed: 222,
+	})
+	s.Require().NoError(err)
+	dataC, err := s.encRepo.Get(s.ctx, outC.EncounterID)
+	s.Require().NoError(err)
+	s.Require().NotEqual(dataA.Space, dataC.Space, "a different seed must roll different content-backed dungeon geometry")
 }

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -2,7 +2,10 @@ package lobby_test
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -918,4 +921,113 @@ func (s *LobbySuite) TestStartEncounter_DungeonGeometryIndependentOfPartySize() 
 		return out
 	}
 	s.Require().Equal(doorPositions(data1), doorPositions(data2), "connector door positions are geometry too")
+}
+
+// --- Task E2: content-backed dungeon keys ---
+
+// TestStartEncounter_ContentBackedKey_ReferenceTomb is the M1 acceptance
+// proof at the orchestrator level: StartEncounter("reference-tomb")
+// builds the content-hosted spec (internal/content/dungeons/
+// reference-tomb.yaml, shipped embedded — no RPG_CONTENT_DIR override
+// needed) via the SAME toolkit InitDungeon + SeedMonsters path a real
+// content-authored dungeon would use — two regions (entrance + tomb) with
+// their declared archetypes, the tomb's boss and every place: prop/monster
+// landing inside the tomb region, and the EXISTING crypt-path tests
+// (TestStartEncounter_CryptDungeon_..., TestStartEncounter_CryptMonsters_...,
+// TestStartEncounter_CryptObstacles_...) staying green completely
+// unperturbed by this branch's addition.
+func (s *LobbySuite) TestStartEncounter_ContentBackedKey_ReferenceTomb() {
+	s.seedReadyLobby("lobby-tomb1", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-tomb1",
+		DungeonKey: lobbyorch.DungeonKey("reference-tomb"), RandomSeed: 42,
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	s.Require().NotNil(encData.Space)
+	s.Require().Equal("crypt", encData.Space.Theme)
+	s.Require().Len(encData.Space.Regions, 2, "reference-tomb is a two-room spec: entrance + tomb")
+
+	entrance, entranceOK := regionByArchetype(encData.Space, tkenc.ArchetypeEntrance)
+	s.Require().True(entranceOK, "exactly one entrance-archetype region")
+	tomb, tombOK := regionByArchetype(encData.Space, tkenc.ArchetypeBoss)
+	s.Require().True(tombOK, "exactly one boss-archetype region (the tomb)")
+	_ = entrance
+
+	// The boss (skeleton-captain, pinned boss.at) and the placed skeleton
+	// monster must both be present, landing inside the tomb region.
+	var bossFound, skeletonFound bool
+	for _, m := range encData.Monsters {
+		regionID, ok := encData.Space.RegionAt(m.Position)
+		s.Require().True(ok, "every seeded monster must land on a tagged region hex")
+		s.Assert().Equal(tomb.ID, regionID, "reference-tomb's monsters are both in the tomb room")
+		switch m.MonsterRef {
+		case "dnd5e:monsters:skeleton-captain":
+			bossFound = true
+		case "dnd5e:monsters:skeleton":
+			skeletonFound = true
+		}
+	}
+	s.Require().True(bossFound, "the pinned boss (skeleton-captain) must be seeded")
+	s.Require().True(skeletonFound, "the placed skeleton monster must be seeded")
+	s.Require().Len(encData.Monsters, 2, "exactly the boss + one placed skeleton — no rolled/count-based monsters in M1")
+
+	// All five placed props (coffin, altar, statue-reaper, brazier x2) must
+	// land inside the tomb region too.
+	wantObstacleRefs := map[string]int{
+		"dnd5e:props:coffin":        1,
+		"dnd5e:props:altar":         1,
+		"dnd5e:props:statue-reaper": 1,
+		"dnd5e:props:brazier":       2,
+	}
+	gotObstacleRefs := map[string]int{}
+	for _, obstacle := range encData.Space.Obstacles {
+		regionID, ok := encData.Space.RegionAt(obstacle.Position)
+		s.Require().True(ok, "every placed obstacle must land on a tagged region hex")
+		s.Assert().Equal(tomb.ID, regionID, "reference-tomb's placed props are all in the tomb room")
+		gotObstacleRefs[obstacle.Ref]++
+	}
+	s.Require().Equal(wantObstacleRefs, gotObstacleRefs, "exactly the reference-tomb spec's five placed props")
+}
+
+// TestStartEncounter_DisabledContentKey_ErrorsBeforeLobbyLock proves the
+// "found but disabled" branch (Task E2's three-state contract): a
+// content-backed key whose file fails dungeonspec.Load at startup must
+// return a *lobbyorch.DisabledDungeonKeyError, before touching the lobby
+// lock — same zero-side-effects posture as an unknown legacy key
+// (TestStartEncounter_UnknownDungeonKey_ErrorsAndLobbyStaysWaiting above).
+// Uses a dedicated Orchestrator (newOrchestratorWithContentDir) since
+// loadContentSpecs only reads RPG_CONTENT_DIR once, at construction.
+func (s *LobbySuite) TestStartEncounter_DisabledContentKey_ErrorsBeforeLobbyLock() {
+	dir := s.T().TempDir()
+	require.NoError(s.T(), os.WriteFile(
+		filepath.Join(dir, "broken-dungeon.yaml"),
+		[]byte("version: 1\nkey: broken-dungeon\nname: Broken\nheight: 8\nrooms:\n"+
+			"  - id: only-one\n    archetype: entrance\n    width: 6\n"),
+		0o600,
+	))
+	orch, err := s.newOrchestratorWithContentDir(dir)
+	s.Require().NoError(err, "a schema-invalid content FILE must not fail construction — only an unreadable path does")
+
+	s.seedReadyLobby("lobby-broken1", "alice")
+	// No expectCharacter armed: resolving the content spec fails before
+	// StartEncounter ever reaches character-snapshot seeding.
+
+	_, err = orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-broken1",
+		DungeonKey: lobbyorch.DungeonKey("broken-dungeon"),
+	})
+	s.Require().Error(err)
+	var disabledErr *lobbyorch.DisabledDungeonKeyError
+	s.Require().True(errors.As(err, &disabledErr), "must be a *DisabledDungeonKeyError, not a generic error")
+	s.Assert().Equal(lobbyorch.DungeonKey("broken-dungeon"), disabledErr.Key)
+
+	lobbyData, err := s.lobbyRepo.Get(s.ctx, "lobby-broken1")
+	s.Require().NoError(err)
+	s.Require().Equal(lobbyrepo.StatusWaiting, lobbyData.Status, "a disabled content key must fail before any state transition")
+	s.Require().Empty(lobbyData.EncounterID)
 }

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -1145,3 +1145,52 @@ func (s *LobbySuite) TestStartEncounter_ContentBackedKey_SeedWiring() {
 	s.Require().NoError(err)
 	s.Require().NotEqual(dataA.Space, dataC.Space, "a different seed must roll different content-backed dungeon geometry")
 }
+
+// --- Task E2b: RPG_DUNGEON_KEY override selects a dungeon end to end ---
+
+// TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb is the M1
+// manual-walkthrough mechanism proven at the orchestrator level: with
+// Config.DungeonKeyOverride set to "reference-tomb" and the caller
+// supplying NO DungeonKey at all (today's exact shape — no real proto
+// surface sets one), StartEncounter must build the content-backed
+// reference-tomb dungeon, not the legacy crypt default.
+func (s *LobbySuite) TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb() {
+	orch := s.newOrchestratorWithDungeonKeyOverride("reference-tomb")
+
+	s.seedReadyLobby("lobby-override1", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+
+	out, err := orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-override1",
+		// DungeonKey deliberately left unset -- the override must fill it in.
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	s.Require().Len(encData.Space.Regions, 2, "reference-tomb (not the 3-region crypt default) must have been selected")
+	_, tombOK := regionByArchetype(encData.Space, tkenc.ArchetypeBoss)
+	s.Require().True(tombOK)
+}
+
+// TestStartEncounter_DungeonKeyOverride_ExplicitCallerKeyWins proves the
+// substitution's ONLY-when-empty guard: a caller-supplied DungeonKey
+// (crypt) must win over a configured override (reference-tomb) — the
+// override is a fallback for "no key supplied," never a hijack of an
+// explicit one.
+func (s *LobbySuite) TestStartEncounter_DungeonKeyOverride_ExplicitCallerKeyWins() {
+	orch := s.newOrchestratorWithDungeonKeyOverride("reference-tomb")
+
+	s.seedReadyLobby("lobby-override2", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+
+	out, err := orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-override2",
+		DungeonKey: lobbyorch.DungeonKeyCrypt,
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+	s.Require().Len(encData.Space.Regions, 3, "the explicit crypt key must win over the configured override")
+}


### PR DESCRIPTION
Closes #716.

`internal/content/dungeons/reference-tomb.yaml` becomes the 3-room tomb Kirk authored live via the `RPG_CONTENT_DIR` edit-restart loop and approved in the running game: entrance (2 braziers) → hall/chamber (4 pillars, a torch, a bone-pile, 2 skeletons) → tomb/boss (coffin, altar, two statues, 2 braziers, candles, the skeleton-captain), with the hall→tomb connector locked at DC 12 (dex).

Byte-identical copy of `/home/kirk/game-dev/dungeon-content/reference-tomb.yaml` — per this team's review-rigor calibration, the content itself needs no further review (approved live); only the test-pin needed to be mechanically exact.

`TestStartEncounter_ContentBackedKey_ReferenceTomb` rewritten for the new shape — 3 regions with their archetypes, the locked connector's exact DC/ability, and every placed monster/prop at its exact compiled absolute cell. All values were measured directly off the real compiler + engine (`dungeonspec.Load` → `InitDungeon(seed 42)` → `SeedMonsters`, reading back the persisted encounter data via a throwaway program), never hand-derived.

Two other tests still assumed the old 2-room shape — found via a full-suite run before committing, both fixed:
- `TestLoadContentSpecs_EmbeddedReferenceTombCompiles` — region count 2 → 3.
- `TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb` — region count alone can no longer distinguish reference-tomb from the legacy crypt default (both are now 3 regions); switched to the actually-distinguishing signal, an `ArchetypeChamber` region, which the crypt template never emits.

Note on branch/PR: PR #710 (the base M1 feature) merged before this content swap landed, so this necessarily became a fresh PR off the current `main` rather than an addition to #710 — same underlying branch (`feat/dungeonspec-content`), new PR object since #710 is closed.

Precedes the `rpg-deployment` prod-flip PR (`RPG_DUNGEON_KEY=reference-tomb`), which lands after this one deploys.

— implementer (asset-pipeline), on behalf of KirkDiggler
