### PR TITLE
feat(encounter): real CharacterResolver against the character store

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -207,6 +207,11 @@ func runServer(_ *cobra.Command, _ []string) error {
 	encV2Handler, err := encounterhandlerv2.New(&encounterhandlerv2.HandlerConfig{
 		Broker: encV2Broker,
 		Repo:   encV2Repo,
+		// rpg-api#516: real ability-modifier / tool-proficiency-bonus
+		// resolution for SubmitCheck, replacing the zero-modifier stub.
+		CharacterResolverConfig: &encounterhandlerv2.Dnd5eCharacterResolverConfig{
+			CharacterRepo: charRepo,
+		},
 		CombatResolverConfig: &encounterhandlerv2.Dnd5eCombatResolverConfig{
 			CharacterRepo: charRepo,
 		},
@@ -226,17 +231,17 @@ func runServer(_ *cobra.Command, _ []string) error {
 	lobbyBroker := lobbyorch.NewBroker()
 	lobbyRepo := lobbyrepo.NewRedis(redisClient, lobbyTTL)
 	lobbyOrch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:             lobbyRepo,
-		LobbyBroker:           lobbyBroker,
-		CharacterRepo:         charRepo,
-		EncounterRepo:         encV2Repo,
-		EncounterBroker:       encV2Broker,
-		CharacterResolver:     encounterhandlerv2.StubCharacterResolver{},
-		BuildCombatResolver:   lobbyhandler.BuildCombatResolver(encounterhandlerv2.Dnd5eCombatResolverConfig{CharacterRepo: charRepo}),
-		BuildMovementResolver: lobbyhandler.BuildMovementResolver(encounterhandlerv2.Dnd5eMovementResolverConfig{CharacterRepo: charRepo}),
-		LobbyIDGenerator:      idgen.NewUUID("lobby"),
-		JoinRefGenerator:      idgen.NewUUID("join"),
-		EncounterIDGenerator:  idgen.NewUUID(""),
+		LobbyRepo:              lobbyRepo,
+		LobbyBroker:            lobbyBroker,
+		CharacterRepo:          charRepo,
+		EncounterRepo:          encV2Repo,
+		EncounterBroker:        encV2Broker,
+		BuildCharacterResolver: lobbyhandler.BuildCharacterResolver(encounterhandlerv2.Dnd5eCharacterResolverConfig{CharacterRepo: charRepo}),
+		BuildCombatResolver:    lobbyhandler.BuildCombatResolver(encounterhandlerv2.Dnd5eCombatResolverConfig{CharacterRepo: charRepo}),
+		BuildMovementResolver:  lobbyhandler.BuildMovementResolver(encounterhandlerv2.Dnd5eMovementResolverConfig{CharacterRepo: charRepo}),
+		LobbyIDGenerator:       idgen.NewUUID("lobby"),
+		JoinRefGenerator:       idgen.NewUUID("join"),
+		EncounterIDGenerator:   idgen.NewUUID(""),
 		// RPG_DUNGEON_KEY (Task E2b): the M1 manual-walkthrough mechanism --
 		// unset in every real deployment today (zero player-facing change),
 		// validated at construction below (a misconfigured value fails

--- a/internal/handlers/dnd5e/lobby/v1alpha1/handler.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/handler.go
@@ -76,3 +76,15 @@ func BuildMovementResolver(cfg encounterhandlerv2.Dnd5eMovementResolverConfig) l
 		return encounterhandlerv2.NewDnd5eMovementResolverForData(cfg, data)
 	}
 }
+
+// BuildCharacterResolver is BuildCombatResolver's character-resolver
+// counterpart (rpg-api#516): it adapts encounterhandlerv2's
+// Dnd5eCharacterResolver construction into the lobbyorch.CharacterResolverBuilder
+// shape, so StartEncounter's freshly constructed encounter resolves real
+// ability/tool-proficiency modifiers the same way the encounter service
+// itself does — never a duplicate implementation.
+func BuildCharacterResolver(cfg encounterhandlerv2.Dnd5eCharacterResolverConfig) lobbyorch.CharacterResolverBuilder {
+	return func(data *tkenc.Data) tkenc.CharacterResolver {
+		return encounterhandlerv2.NewDnd5eCharacterResolverForData(cfg, data)
+	}
+}

--- a/internal/handlers/dnd5e/lobby/v1alpha1/handler_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/handler_test.go
@@ -51,12 +51,12 @@ func (s *HandlerSuite) SetupTest() {
 	s.broker = lobbyorch.NewBroker()
 
 	orch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         s.lobbyRepo,
-		LobbyBroker:       s.broker,
-		CharacterRepo:     s.charRepo,
-		EncounterRepo:     encountersv2.NewInMemory(),
-		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              s.lobbyRepo,
+		LobbyBroker:            s.broker,
+		CharacterRepo:          s.charRepo,
+		EncounterRepo:          encountersv2.NewInMemory(),
+		EncounterBroker:        tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},

--- a/internal/handlers/dnd5e/v2/encounter/character_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/character_resolver.go
@@ -135,6 +135,16 @@ func (r *Dnd5eCharacterResolver) AbilityModifier(playerID core.PlayerID, ability
 // never derived from level here (that derivation, if ever needed, is a
 // toolkit rule, not rpg-api's).
 //
+// tool arrives here as door.LockTool verbatim (rpg-toolkit's AttemptUnlock
+// sets PendingPrompt.Tool = door.LockTool; SubmitCheck passes prompt.Tool
+// straight through to this method) — a full toolkit ref such as
+// "dnd5e:item:thieves-tools" (rpg-toolkit/encounter/data.go's LockTool doc),
+// not the bare id tkcharacter.Data.ToolProficiencies stores
+// (proficiencies.ToolThieves == "thieves-tools"). toolRefID normalizes tool
+// to its bare id before comparing; a tool that isn't ref-shaped (splitRef
+// returns nil) is compared as-is, since nothing in the interface guarantees
+// the ref form.
+//
 // Returns ok=false for an unseated player, a player with no bound character,
 // or a character-store miss — the same "unknown" cases AbilityModifier uses.
 func (r *Dnd5eCharacterResolver) ToolProficiencyBonus(playerID core.PlayerID, tool string) (int, bool) {
@@ -143,12 +153,28 @@ func (r *Dnd5eCharacterResolver) ToolProficiencyBonus(playerID core.PlayerID, to
 		return 0, false
 	}
 
+	toolID := toolRefID(tool)
 	for _, prof := range charData.ToolProficiencies {
-		if string(prof) == tool {
+		if string(prof) == toolID {
 			return charData.ProficiencyBonus, true
 		}
 	}
 	return 0, true
+}
+
+// toolRefID extracts the bare id segment from a toolkit ref
+// ("module:type:id" -> "id", e.g. "dnd5e:item:thieves-tools" ->
+// "thieves-tools"), reusing this package's existing splitRef helper
+// (translate.go) so ref-parsing semantics stay consistent with the rest of
+// the handler package (projection, event translation, prompt translation
+// all already use it). A ref that doesn't parse to exactly module:type:id
+// (splitRef's documented nil return) is returned unmodified, so a bare id
+// passed directly still compares correctly.
+func toolRefID(ref string) string {
+	if parts := splitRef(ref); parts != nil {
+		return parts[2]
+	}
+	return ref
 }
 
 // characterData resolves playerID to the character store's Data for the

--- a/internal/handlers/dnd5e/v2/encounter/character_resolver.go
+++ b/internal/handlers/dnd5e/v2/encounter/character_resolver.go
@@ -1,24 +1,25 @@
 package encounter
 
 import (
+	"context"
 	"strings"
 
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	tkcharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
 
 // CharacterResolver bridges the toolkit's encounter.CharacterResolver to
 // rpg-api's character store so SubmitCheck can total a roll with the player's
 // ability modifier (and tool-proficiency bonus, if any).
 //
-// Wave 2.9 ships a stub implementation (StubCharacterResolver) that reports
-// every modifier as zero. This unblocks the SubmitCheck wire flow without
-// coupling the encounter handler to the character orchestrator yet — sourcing
-// real ability modifiers requires a player→character lookup that does not
-// exist on the encounter today (PlayerData.EntityID currently mirrors PlayerID
-// rather than referencing a character).
-//
-// Tracking issue for real lookups: see rpg-api follow-up filed alongside #514.
+// Wave 2.9 shipped a stub implementation (StubCharacterResolver) that reports
+// every modifier as zero, to unblock the SubmitCheck wire flow without
+// coupling the encounter handler to the character store yet. rpg-api#516
+// replaces it in production with Dnd5eCharacterResolver (below) — the stub
+// remains the zero-modifier default for tests and the integration harness.
 //
 // The interface alias here exists so the rest of the handler package can
 // reference a single name regardless of which implementation is wired.
@@ -26,12 +27,14 @@ type CharacterResolver = tkenc.CharacterResolver
 
 // StubCharacterResolver returns (0, true) for every modifier and proficiency
 // query. It satisfies tkenc.CharacterResolver so SubmitCheck can resolve
-// rolls (total = roll + 0 + 0) until the real character store bridge ships.
+// rolls (total = roll + 0 + 0) deterministically — the default for tests and
+// the integration harness (internal/integration/harness/harness.go), which
+// want stable wire-shape totals rather than real character data.
 //
 // "ok=true" is intentional: the toolkit treats ok=false as "unknown player,
-// modifier is zero anyway" — but the orchestrator wants the reported total
-// to be deterministic during wire-shape verification, so we say "yes I know
-// this player, the modifier is zero" until real data flows.
+// modifier is zero anyway" — but callers of this stub want the reported total
+// to be deterministic, so it says "yes I know this player, the modifier is
+// zero" unconditionally.
 type StubCharacterResolver struct{}
 
 // AbilityModifier always returns 0, true. Ability is normalized to upper-case
@@ -47,4 +50,126 @@ func (StubCharacterResolver) AbilityModifier(_ core.PlayerID, ability string) (i
 // untouched.
 func (StubCharacterResolver) ToolProficiencyBonus(_ core.PlayerID, _ string) (int, bool) {
 	return 0, true
+}
+
+// Dnd5eCharacterResolverConfig holds the dependencies needed to construct a
+// Dnd5eCharacterResolver.
+type Dnd5eCharacterResolverConfig struct {
+	// CharacterRepo provides character lookup by ID. Required for real
+	// ability/tool-proficiency resolution; a nil repo degrades every lookup
+	// to ok=false (the toolkit treats that as a zero modifier — see
+	// tkenc.CharacterResolver's doc), matching how callers without a wired
+	// character store behave today.
+	CharacterRepo characterrepo.Repository
+}
+
+// Dnd5eCharacterResolver implements tkenc.CharacterResolver against the
+// dnd5e rulebook's stored character data.
+//
+// # Why this is built per-request (NewDnd5eCharacterResolverForData), not once
+//
+// The toolkit's CharacterResolver interface hands AbilityModifier /
+// ToolProficiencyBonus only a core.PlayerID — no encounter ID, no EntityID
+// (encounter/prompts.go's CharacterResolver doc). A player can own more than
+// one character (character repo's ListByPlayerID), so PlayerID alone cannot
+// unambiguously name "the" character; the only reliable mapping is the
+// specific encounter's own data.Players[playerID].EntityID — exactly the
+// field start_encounter.go already populates with the real character ID
+// (EntityID: core.EntityID(m.CharacterID)), not a mirror of PlayerID as an
+// earlier doc comment on this file assumed. Reading that mapping requires
+// the loaded *tkenc.Data, so the resolver is constructed fresh per request
+// from it, exactly like Dnd5eCombatResolver / Dnd5eMovementResolver
+// (NewDnd5eCombatResolverForData / NewDnd5eMovementResolverForData) — do not
+// share one instance across requests/encounters.
+type Dnd5eCharacterResolver struct {
+	cfg  Dnd5eCharacterResolverConfig
+	data *tkenc.Data
+}
+
+// NewDnd5eCharacterResolverForData constructs a resolver bound to the given
+// encounter data. data supplies the PlayerID -> EntityID (character ID)
+// mapping for this encounter; nil data (e.g. the lobby orchestrator's
+// StartEncounter, which builds resolvers before any player is seated) is
+// handled by every lookup returning ok=false.
+func NewDnd5eCharacterResolverForData(cfg Dnd5eCharacterResolverConfig, data *tkenc.Data) *Dnd5eCharacterResolver {
+	return &Dnd5eCharacterResolver{cfg: cfg, data: data}
+}
+
+// AbilityModifier implements tkenc.CharacterResolver. It resolves playerID to
+// its bound character (via data.Players[playerID].EntityID) and returns the
+// toolkit's own shared.AbilityScores.Modifier for the named ability — this
+// package never computes (score-10)/2 itself (rpg-api CLAUDE.md "Code Smell:
+// Game Logic in the API"; the modifier formula is rpg-toolkit's rule, not
+// rpg-api's).
+//
+// ability is matched case-insensitively: the toolkit's own DoorData.LockAbility
+// doc documents 3-letter upper-case codes ("DEX") while rpg-api's crypt door
+// construction stores lower-case ("dex") — both conventions appear in this
+// codebase, so the ability string is lower-cased before the toolkit's
+// abilities.GetByID lookup (whose canonical keys are lower-case: abilities.DEX
+// == "dex").
+//
+// Returns ok=false — treated as a zero modifier by the toolkit's SubmitCheck
+// (prompts.go) — for an unseated player, a player with no bound character, a
+// character-store miss, or an unrecognized ability string. These are all
+// "unknown" in the sense the interface documents, never a fabricated zero.
+func (r *Dnd5eCharacterResolver) AbilityModifier(playerID core.PlayerID, ability string) (int, bool) {
+	charData, ok := r.characterData(playerID)
+	if !ok {
+		return 0, false
+	}
+
+	abilityID, err := abilities.GetByID(strings.ToLower(ability))
+	if err != nil {
+		return 0, false
+	}
+
+	return charData.AbilityScores.Modifier(abilityID), true
+}
+
+// ToolProficiencyBonus implements tkenc.CharacterResolver. It resolves
+// playerID to its bound character and reports the character's stored
+// ProficiencyBonus when the character is proficient with tool, else a known
+// zero (ok=true — a real character who simply lacks the proficiency, not an
+// unknown answer). Proficiency bonus is a stored field on tkcharacter.Data,
+// never derived from level here (that derivation, if ever needed, is a
+// toolkit rule, not rpg-api's).
+//
+// Returns ok=false for an unseated player, a player with no bound character,
+// or a character-store miss — the same "unknown" cases AbilityModifier uses.
+func (r *Dnd5eCharacterResolver) ToolProficiencyBonus(playerID core.PlayerID, tool string) (int, bool) {
+	charData, ok := r.characterData(playerID)
+	if !ok {
+		return 0, false
+	}
+
+	for _, prof := range charData.ToolProficiencies {
+		if string(prof) == tool {
+			return charData.ProficiencyBonus, true
+		}
+	}
+	return 0, true
+}
+
+// characterData resolves playerID to the character store's Data for the
+// encounter-bound character (data.Players[playerID].EntityID). Every failure
+// mode — no repo wired, no data wired, player not seated, no bound
+// character, or a character-store miss/error — returns ok=false, which both
+// exported methods above translate into the toolkit's documented "unknown,
+// treat as zero" contract rather than a panic or a fabricated value.
+func (r *Dnd5eCharacterResolver) characterData(playerID core.PlayerID) (*tkcharacter.Data, bool) {
+	if r.cfg.CharacterRepo == nil || r.data == nil {
+		return nil, false
+	}
+
+	pd, ok := r.data.Players[playerID]
+	if !ok || pd.EntityID == "" {
+		return nil, false
+	}
+
+	out, err := r.cfg.CharacterRepo.Get(context.Background(), characterrepo.GetInput{ID: string(pd.EntityID)})
+	if err != nil || out == nil || out.Character == nil || out.Character.Data == nil {
+		return nil, false
+	}
+	return out.Character.Data, true
 }

--- a/internal/handlers/dnd5e/v2/encounter/character_resolver_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/character_resolver_test.go
@@ -306,6 +306,27 @@ func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_NilToolProfic
 	s.Equal(0, bonus)
 }
 
+// TestToolProficiencyBonus_EmptyTool_ReturnsKnownZero: SubmitCheck only
+// calls ToolProficiencyBonus when prompt.Tool != "" (rpg-toolkit's
+// prompts.go), but the resolver itself must not depend on that caller
+// discipline — an empty tool string should degrade to "known character,
+// not proficient with ”" (ok=true, 0), not panic or falsely match some
+// proficiency.
+func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_EmptyTool_ReturnsKnownZero() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	bonus, ok := resolver.ToolProficiencyBonus("alice", "")
+	s.True(ok)
+	s.Equal(0, bonus)
+}
+
 // TestToolProficiencyBonus_UnknownPlayer_ReturnsFalse mirrors
 // TestAbilityModifier_UnknownPlayer_ReturnsFalse for the tool-bonus method.
 func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_UnknownPlayer_ReturnsFalse() {

--- a/internal/handlers/dnd5e/v2/encounter/character_resolver_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/character_resolver_test.go
@@ -235,6 +235,35 @@ func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_Proficient_Re
 	s.Equal(2, bonus)
 }
 
+// TestToolProficiencyBonus_Proficient_RefFormTool_ReturnsProficiencyBonus is
+// the production shape: SubmitCheck never hands the resolver a bare
+// proficiencies.Tool id — it passes door.LockTool verbatim
+// (rpg-toolkit/encounter/prompts.go's AttemptUnlock sets
+// PendingPrompt.Tool = door.LockTool, and SubmitCheck calls
+// resolver.ToolProficiencyBonus(playerID, prompt.Tool) unmodified), and
+// LockTool is documented as a full toolkit ref: "LockTool is a toolkit ref
+// (e.g. \"dnd5e:item:thieves-tools\")" (rpg-toolkit/encounter/data.go).
+// Comparing that ref directly against tkcharacter.Data.ToolProficiencies'
+// bare ids (proficiencies.ToolThieves == "thieves-tools") would never
+// match, silently reporting a proficient character as not proficient — a
+// confident-wrong ok=true,0, not the honest "unknown" the interface
+// documents. This is the test the tool-ref/bare-id mismatch bug slipped
+// past when only bare-id inputs were exercised.
+func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_Proficient_RefFormTool_ReturnsProficiencyBonus() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	bonus, ok := resolver.ToolProficiencyBonus("alice", "dnd5e:item:thieves-tools")
+	s.True(ok)
+	s.Equal(2, bonus)
+}
+
 // TestToolProficiencyBonus_NotProficient_ReturnsKnownZero: a known character
 // who simply isn't proficient with the requested tool is a real, known
 // answer (bonus is zero) — ok=true, distinct from an unknown player/

--- a/internal/handlers/dnd5e/v2/encounter/character_resolver_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/character_resolver_test.go
@@ -1,0 +1,291 @@
+package encounter_test
+
+// character_resolver_test.go — rpg-api#516: unit tests for
+// Dnd5eCharacterResolver, the real CharacterResolver implementation that
+// replaces StubCharacterResolver in production.
+//
+// The toolkit's tkenc.CharacterResolver interface hands the resolver only a
+// core.PlayerID (no encounterID, no EntityID) — see prompts.go's doc. The
+// resolver bridges that to a character by reading the bound encounter's own
+// PlayerData.EntityID (data.Players[playerID].EntityID), exactly the field
+// rpg-api#516's stated blocker claimed didn't carry a real character
+// reference. Wave 2.9's start_encounter.go already sets
+// EntityID: core.EntityID(m.CharacterID) — the blocker was stale by the time
+// this shipped. Because the toolkit interface only carries a PlayerID (not
+// the loaded encounter's Data), the resolver must be constructed per-request
+// from that Data (NewDnd5eCharacterResolverForData), mirroring the existing
+// Dnd5eCombatResolver / Dnd5eMovementResolver per-request builder pattern —
+// a resolver built once at server-startup could never see a specific
+// encounter's Players map.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	"github.com/KirkDiggler/rpg-api/internal/apierr"
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	v2encounter "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/v2/encounter"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	charactermock "github.com/KirkDiggler/rpg-api/internal/repositories/character/mock"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	tkcharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// Dnd5eCharacterResolverTestSuite exercises AbilityModifier and
+// ToolProficiencyBonus against a mocked character store.
+type Dnd5eCharacterResolverTestSuite struct {
+	suite.Suite
+	ctrl         *gomock.Controller
+	mockCharRepo *charactermock.MockRepository
+}
+
+func TestDnd5eCharacterResolverTestSuite(t *testing.T) {
+	suite.Run(t, new(Dnd5eCharacterResolverTestSuite))
+}
+
+func (s *Dnd5eCharacterResolverTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockCharRepo = charactermock.NewMockRepository(s.ctrl)
+}
+
+func (s *Dnd5eCharacterResolverTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// aliceData is Alice the Rogue from the live rpg-dnd5e-web#589 evidence:
+// dex 16 (+3 modifier), proficiency_bonus 2, proficient with thieves' tools.
+func aliceData() *tkcharacter.Data {
+	return &tkcharacter.Data{
+		ID:               "char-alice",
+		PlayerID:         "alice",
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 10,
+			abilities.DEX: 16,
+			abilities.CON: 12,
+			abilities.INT: 10,
+			abilities.WIS: 10,
+			abilities.CHA: 8,
+		},
+		ToolProficiencies: []proficiencies.Tool{proficiencies.ToolThieves},
+	}
+}
+
+// encDataWithAlice builds a minimal tkenc.Data seating "alice" bound to
+// "char-alice" — the same PlayerID -> EntityID shape start_encounter.go
+// produces via tkenc.PlayerInput{PlayerID, EntityID: core.EntityID(CharacterID)}.
+func encDataWithAlice() *tkenc.Data {
+	return &tkenc.Data{
+		Players: map[encountercore.PlayerID]*tkenc.PlayerData{
+			"alice": {ID: "alice", EntityID: "char-alice"},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AbilityModifier
+// ---------------------------------------------------------------------------
+
+// TestAbilityModifier_KnownCharacter_ReturnsRealModifier is the done-bar
+// scenario from the issue: Alice's dex 16 must resolve to +3 (the toolkit's
+// own shared.AbilityScores.Modifier((16-10)/2)), not the stub's hardcoded 0.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_KnownCharacter_ReturnsRealModifier() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	mod, ok := resolver.AbilityModifier("alice", "dex")
+	s.True(ok)
+	s.Equal(3, mod)
+}
+
+// TestAbilityModifier_UppercaseAbility_NormalizesToLowercase proves the
+// resolver handles the "DEX" convention (rpg-toolkit encounter/data.go's
+// documented 3-letter-code doc comment) as well as the lowercase "dex" the
+// crypt boss door actually stores (dungeon_spec.go / start_encounter_test.go
+// s.Require().Equal("dex", bossDoor.LockAbility)) — both conventions appear
+// in this codebase.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_UppercaseAbility_NormalizesToLowercase() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	mod, ok := resolver.AbilityModifier("alice", "DEX")
+	s.True(ok)
+	s.Equal(3, mod)
+}
+
+// TestAbilityModifier_UnknownPlayer_ReturnsFalse: a player not seated on
+// this encounter's Data.Players has no bound character. ok=false, which the
+// toolkit's SubmitCheck treats as a zero modifier (prompts.go's documented
+// "unknowns are zero" contract) rather than erroring.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_UnknownPlayer_ReturnsFalse() {
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	mod, ok := resolver.AbilityModifier("mallory", "dex")
+	s.False(ok)
+	s.Equal(0, mod)
+}
+
+// TestAbilityModifier_CharacterStoreMiss_ReturnsFalse: the player is seated
+// (PlayerData.EntityID is set) but the character store has no record for
+// that ID (e.g. deleted mid-session). Must degrade to ok=false, not panic
+// or fabricate a zero-as-known answer.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_CharacterStoreMiss_ReturnsFalse() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(nil, apierr.NotFound("character not found"))
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	mod, ok := resolver.AbilityModifier("alice", "dex")
+	s.False(ok)
+	s.Equal(0, mod)
+}
+
+// TestAbilityModifier_UnrecognizedAbility_ReturnsFalse: a garbage ability
+// string (never emitted by the toolkit today, but the interface takes a
+// bare string) must not panic map indexing into shared.AbilityScores.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_UnrecognizedAbility_ReturnsFalse() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	mod, ok := resolver.AbilityModifier("alice", "nonsense")
+	s.False(ok)
+	s.Equal(0, mod)
+}
+
+// TestAbilityModifier_NilData_ReturnsFalse: a resolver built with nil data
+// (mirrors the lobby orchestrator's StartEncounter call site, which builds
+// resolvers before any player exists) must degrade safely rather than
+// nil-deref data.Players.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_NilData_ReturnsFalse() {
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		nil,
+	)
+
+	mod, ok := resolver.AbilityModifier("alice", "dex")
+	s.False(ok)
+	s.Equal(0, mod)
+}
+
+// TestAbilityModifier_NilCharacterRepo_ReturnsFalse: no character store
+// wired (e.g. a handler test fixture) degrades safely instead of panicking
+// on a nil CharacterRepo.Get call.
+func (s *Dnd5eCharacterResolverTestSuite) TestAbilityModifier_NilCharacterRepo_ReturnsFalse() {
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{},
+		encDataWithAlice(),
+	)
+
+	mod, ok := resolver.AbilityModifier("alice", "dex")
+	s.False(ok)
+	s.Equal(0, mod)
+}
+
+// ---------------------------------------------------------------------------
+// ToolProficiencyBonus
+// ---------------------------------------------------------------------------
+
+// TestToolProficiencyBonus_Proficient_ReturnsProficiencyBonus: Alice is
+// proficient with thieves' tools, so the bonus is her stored
+// ProficiencyBonus (2) — never computed from level in rpg-api (that's a
+// stored field on tkcharacter.Data, not game math this package performs).
+func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_Proficient_ReturnsProficiencyBonus() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	bonus, ok := resolver.ToolProficiencyBonus("alice", string(proficiencies.ToolThieves))
+	s.True(ok)
+	s.Equal(2, bonus)
+}
+
+// TestToolProficiencyBonus_NotProficient_ReturnsKnownZero: a known character
+// who simply isn't proficient with the requested tool is a real, known
+// answer (bonus is zero) — ok=true, distinct from an unknown player/
+// character (ok=false). Matches the crypt boss door today, which sets no
+// LockTool at all (start_encounter_test.go: s.Require().Empty(bossDoor.LockTool)),
+// so this path — proficiencies present but not matching — is the honest
+// "no bonus" case, not a stub artifact.
+func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_NotProficient_ReturnsKnownZero() {
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: aliceData()}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	bonus, ok := resolver.ToolProficiencyBonus("alice", string(proficiencies.ToolAlchemist))
+	s.True(ok)
+	s.Equal(0, bonus)
+}
+
+// TestToolProficiencyBonus_NilToolProficiencies_ReturnsKnownZero: seeded
+// characters carry tool_proficiencies == null (the issue's own note); a nil
+// slice must range cleanly to "not proficient", not panic.
+func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_NilToolProficiencies_ReturnsKnownZero() {
+	data := aliceData()
+	data.ToolProficiencies = nil
+	s.mockCharRepo.EXPECT().
+		Get(gomock.Any(), characterrepo.GetInput{ID: "char-alice"}).
+		Return(&characterrepo.GetOutput{Character: &entities.Character{Data: data}}, nil)
+
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	bonus, ok := resolver.ToolProficiencyBonus("alice", string(proficiencies.ToolThieves))
+	s.True(ok)
+	s.Equal(0, bonus)
+}
+
+// TestToolProficiencyBonus_UnknownPlayer_ReturnsFalse mirrors
+// TestAbilityModifier_UnknownPlayer_ReturnsFalse for the tool-bonus method.
+func (s *Dnd5eCharacterResolverTestSuite) TestToolProficiencyBonus_UnknownPlayer_ReturnsFalse() {
+	resolver := v2encounter.NewDnd5eCharacterResolverForData(
+		v2encounter.Dnd5eCharacterResolverConfig{CharacterRepo: s.mockCharRepo},
+		encDataWithAlice(),
+	)
+
+	bonus, ok := resolver.ToolProficiencyBonus("mallory", string(proficiencies.ToolThieves))
+	s.False(ok)
+	s.Equal(0, bonus)
+}

--- a/internal/handlers/dnd5e/v2/encounter/handler.go
+++ b/internal/handlers/dnd5e/v2/encounter/handler.go
@@ -22,13 +22,14 @@ import (
 
 // HandlerConfig configures a v2 encounter Handler.
 type HandlerConfig struct {
-	Broker                 *encounter.Broker
-	Repo                   encountersv2.Repository
-	Resolver               CharacterResolver            // optional; defaults to StubCharacterResolver
-	CombatResolver         CombatResolver               // optional; overrides CombatResolverConfig when set
-	CombatResolverConfig   *Dnd5eCombatResolverConfig   // optional; used to build Dnd5eCombatResolver per-request
-	MovementResolverConfig *Dnd5eMovementResolverConfig // optional; used to build Dnd5eMovementResolver per-request (Wave 2.11e #539)
-	Now                    func() time.Time             // optional; defaults to time.Now
+	Broker                  *encounter.Broker
+	Repo                    encountersv2.Repository
+	Resolver                CharacterResolver             // optional; fixed override (tests) — wins over CharacterResolverConfig
+	CharacterResolverConfig *Dnd5eCharacterResolverConfig // optional; builds Dnd5eCharacterResolver per-request (rpg-api#516)
+	CombatResolver          CombatResolver                // optional; overrides CombatResolverConfig when set
+	CombatResolverConfig    *Dnd5eCombatResolverConfig    // optional; used to build Dnd5eCombatResolver per-request
+	MovementResolverConfig  *Dnd5eMovementResolverConfig  // optional; used to build Dnd5eMovementResolver per-request (Wave 2.11e #539)
+	Now                     func() time.Time              // optional; defaults to time.Now
 
 	// Roller overrides the dice.Roller every orchestrator LoadFromData wires
 	// via tkenc.WithRoller (rpg-api#659's Config.Roller seam, threaded here).
@@ -50,9 +51,15 @@ type HandlerConfig struct {
 // returns codes.Unimplemented via the embedded server.
 type Handler struct {
 	encounterv2pb.UnimplementedEncounterServiceServer
-	broker   *encounter.Broker
-	encRepo  encountersv2.Repository
-	resolver CharacterResolver
+	broker  *encounter.Broker
+	encRepo encountersv2.Repository
+	// resolver is non-nil when a fixed CharacterResolver override is wired
+	// (tests). When nil, buildCharacterResolver builds a per-request
+	// Dnd5eCharacterResolver if characterResolverConfig has a CharacterRepo,
+	// else falls back to StubCharacterResolver — mirroring combatResolver's
+	// override-vs-builder precedence just below.
+	resolver                CharacterResolver
+	characterResolverConfig Dnd5eCharacterResolverConfig
 	// combatResolver is non-nil when a fixed resolver is wired (e.g. tests that
 	// use StandInCombatResolver for deterministic outcomes). When nil,
 	// buildCombatResolver creates a per-request Dnd5eCombatResolver.
@@ -83,13 +90,14 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 	if now == nil {
 		now = time.Now
 	}
-	resolver := cfg.Resolver
-	if resolver == nil {
-		// Wave 2.9 default: zero-modifier stub. SubmitCheck can resolve rolls
-		// (total = roll + 0 + 0) without an explicit character lookup. Replace
-		// with a real bridge to the character store once player→character
-		// resolution lands on the encounter (follow-up to #514).
-		resolver = StubCharacterResolver{}
+	// CharacterResolverConfig present → buildCharacterResolver constructs a
+	// real Dnd5eCharacterResolver per request (rpg-api#516). Left unset
+	// (zero value, CharacterRepo nil) by tests and the integration harness,
+	// which get StubCharacterResolver's deterministic zero modifiers instead
+	// — see buildCharacterResolver's doc.
+	characterResolverConfig := Dnd5eCharacterResolverConfig{}
+	if cfg.CharacterResolverConfig != nil {
+		characterResolverConfig = *cfg.CharacterResolverConfig
 	}
 
 	// combatResolver selection:
@@ -115,13 +123,14 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 	}
 
 	h := &Handler{
-		broker:                 cfg.Broker,
-		encRepo:                cfg.Repo,
-		resolver:               resolver,
-		combatResolver:         cfg.CombatResolver, // nil unless caller provides a fixed resolver
-		combatResolverConfig:   combatResolverConfig,
-		movementResolverConfig: movementResolverConfig,
-		now:                    now,
+		broker:                  cfg.Broker,
+		encRepo:                 cfg.Repo,
+		resolver:                cfg.Resolver, // nil unless caller provides a fixed resolver override
+		characterResolverConfig: characterResolverConfig,
+		combatResolver:          cfg.CombatResolver, // nil unless caller provides a fixed resolver
+		combatResolverConfig:    combatResolverConfig,
+		movementResolverConfig:  movementResolverConfig,
+		now:                     now,
 	}
 
 	// v2 encounter orchestrator (#582). The handler supplies its existing
@@ -135,10 +144,10 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 	// (hydrate_players.go, reaction_resume.go).
 	charRepo := combatResolverConfig.CharacterRepo
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:              cfg.Broker,
-		EncounterRepo:       cfg.Repo,
-		Resolver:            resolver,
-		BuildCombatResolver: h.buildCombatResolver,
+		Broker:                 cfg.Broker,
+		EncounterRepo:          cfg.Repo,
+		BuildCharacterResolver: h.buildCharacterResolver,
+		BuildCombatResolver:    h.buildCombatResolver,
 		BuildMovementResolver: func(data *encounter.Data) encounter.MovementResolver {
 			return h.buildMovementResolver(data)
 		},
@@ -168,6 +177,29 @@ func New(cfg *HandlerConfig) (*Handler, error) {
 	h.orch = orch
 
 	return h, nil
+}
+
+// buildCharacterResolver returns the character resolver for a given request.
+// If a fixed resolver override was configured (tests), it is returned
+// directly, regardless of data. Otherwise, when a character repo is
+// configured (CharacterResolverConfig.CharacterRepo — the production path,
+// wired at cmd/server/server.go), a fresh Dnd5eCharacterResolver is
+// constructed bound to this request's encounter data: it needs
+// data.Players[playerID].EntityID to resolve a player to their character,
+// which the toolkit's CharacterResolver interface has no way to carry
+// itself (rpg-api#516). With no repo configured (tests, the integration
+// harness — internal/integration/harness/harness.go), falls back to
+// StubCharacterResolver, the zero-modifier default this handler has always
+// shipped, so wire-shape tests that assert deterministic totals keep doing
+// so unless they opt in.
+func (h *Handler) buildCharacterResolver(data *encounter.Data) CharacterResolver {
+	if h.resolver != nil {
+		return h.resolver
+	}
+	if h.characterResolverConfig.CharacterRepo == nil {
+		return StubCharacterResolver{}
+	}
+	return NewDnd5eCharacterResolverForData(h.characterResolverConfig, data)
 }
 
 // buildCombatResolver returns the combat resolver for a given request.

--- a/internal/integration/harness/harness.go
+++ b/internal/integration/harness/harness.go
@@ -327,12 +327,23 @@ func (ts *TestServer) wireServices(cfg *Config) error {
 	ts.LobbyBroker = lobbyorch.NewBroker()
 	ts.LobbyRepo = lobbyrepo.NewInMemory()
 	lobbyOrch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:             ts.LobbyRepo,
-		LobbyBroker:           ts.LobbyBroker,
-		CharacterRepo:         charRepo,
-		EncounterRepo:         ts.EncRepoV2,
-		EncounterBroker:       ts.BrokerV2,
-		CharacterResolver:     encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:       ts.LobbyRepo,
+		LobbyBroker:     ts.LobbyBroker,
+		CharacterRepo:   charRepo,
+		EncounterRepo:   ts.EncRepoV2,
+		EncounterBroker: ts.BrokerV2,
+		// Deterministic zero-modifier stub (not the real Dnd5eCharacterResolver):
+		// harness integration tests seed encounters directly and assert
+		// wire-shape totals like "roll + 0" — see e.g.
+		// TestInteract_LockedDoor_FailedRoll_NoEvents's "DC 30 // unbeatable
+		// with d20 + zero modifiers". BuildCharacterResolver here ignores data
+		// and always returns the stub, mirroring how encounterhandlerv2's own
+		// New() defaults to it when no CharacterResolverConfig is supplied
+		// (see the v2 encounter handler wiring a few lines above, which sets
+		// none — rpg-api#516).
+		BuildCharacterResolver: func(*tkenc.Data) tkenc.CharacterResolver {
+			return encounterhandlerv2.StubCharacterResolver{}
+		},
 		BuildCombatResolver:   lobbyhandler.BuildCombatResolver(encounterhandlerv2.Dnd5eCombatResolverConfig{CharacterRepo: charRepo}),
 		BuildMovementResolver: lobbyhandler.BuildMovementResolver(encounterhandlerv2.Dnd5eMovementResolverConfig{CharacterRepo: charRepo}),
 		LobbyIDGenerator:      idgen.NewUUID("lobby"),

--- a/internal/integration/lobby_crypt_monster_seed_test.go
+++ b/internal/integration/lobby_crypt_monster_seed_test.go
@@ -71,12 +71,12 @@ func (s *CryptMonsterSeedRedisSuite) SetupTest() {
 	s.encRepo = encountersv2.NewRedis(s.srv.RedisClient(), cryptMonsterSeedTestTTL)
 
 	orch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         s.lobbyRepo,
-		LobbyBroker:       lobbyorch.NewBroker(),
-		CharacterRepo:     s.srv.CharacterRepo, // real Redis-backed, from the harness
-		EncounterRepo:     s.encRepo,
-		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              s.lobbyRepo,
+		LobbyBroker:            lobbyorch.NewBroker(),
+		CharacterRepo:          s.srv.CharacterRepo, // real Redis-backed, from the harness
+		EncounterRepo:          s.encRepo,
+		EncounterBroker:        tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},

--- a/internal/orchestrators/encounter/v2/activate_feature_test.go
+++ b/internal/orchestrators/encounter/v2/activate_feature_test.go
@@ -56,9 +56,9 @@ func (s *ActivateFeatureSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// ActivateFeature does not invoke the combat / movement resolvers (the
 		// verb self-loads the actor), but the orchestrator requires the builders
 		// to be present.

--- a/internal/orchestrators/encounter/v2/drive_npc_test.go
+++ b/internal/orchestrators/encounter/v2/drive_npc_test.go
@@ -53,9 +53,9 @@ func (s *DriveStalledNPCTurnSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// Stand-in combat resolver, same choice as EndTurnSuite: no DataJSON is
 		// seeded on the goblins, so NPCAct takes the scripted single-phase path —
 		// isolating the load -> drive -> persist contract from rulebook combat

--- a/internal/orchestrators/encounter/v2/end_turn_npc_pause_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_npc_pause_test.go
@@ -94,9 +94,9 @@ func (s *EndTurnNPCPauseSuite) SetupTest() {
 	s.marshalCalls = 0
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
 			return fakePhasedResolver{reactorEntityID: npEntityWiz}
 		},

--- a/internal/orchestrators/encounter/v2/end_turn_pause_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_pause_test.go
@@ -61,7 +61,9 @@ func (s *EndTurnPauseSuite) newOrch(rr ReactionResume) *Orchestrator {
 	o, err := New(&Config{
 		Broker:        s.broker,
 		EncounterRepo: encountersv2.NewInMemory(),
-		Resolver:      pauseStubCharResolver{},
+		BuildCharacterResolver: func(_ *tkenc.Data) CharacterResolver {
+			return pauseStubCharResolver{}
+		},
 		BuildCombatResolver: func(_ *tkenc.Data) CombatResolver {
 			return nil
 		},

--- a/internal/orchestrators/encounter/v2/end_turn_test.go
+++ b/internal/orchestrators/encounter/v2/end_turn_test.go
@@ -62,9 +62,9 @@ func (s *EndTurnSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// Stand-in combat resolver: the NPC dispatch loop's scripted goblin
 		// attack runs through this (single-phase ResolveAttack), advancing
 		// initiative deterministically without a rulebook. No DataJSON is seeded

--- a/internal/orchestrators/encounter/v2/interact_test.go
+++ b/internal/orchestrators/encounter/v2/interact_test.go
@@ -29,9 +29,9 @@ func (s *InteractSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// No combat / movement resolver behavior is exercised by the door verbs,
 		// but the orchestrator requires the builders to be present. Return the
 		// toolkit zero-value interfaces (nil) — Interact never invokes them.
@@ -48,12 +48,23 @@ func (s *InteractSuite) SetupTest() {
 }
 
 // stubCharacterResolver satisfies tkenc.CharacterResolver with zero modifiers;
-// the door verbs never call it, but Config.Resolver is required.
+// the door verbs never call it, but Config.BuildCharacterResolver is required.
 type stubCharacterResolver struct{}
 
 func (stubCharacterResolver) AbilityModifier(_ core.PlayerID, _ string) (int, bool) { return 0, true }
 func (stubCharacterResolver) ToolProficiencyBonus(_ core.PlayerID, _ string) (int, bool) {
 	return 0, true
+}
+
+// constCharacterResolver adapts a fixed tkenc.CharacterResolver into an
+// encounterorch.CharacterResolverBuilder that ignores data and always
+// returns the same resolver — the test-double equivalent of production's
+// per-request Dnd5eCharacterResolver builder (rpg-api#516). Shared by every
+// *_test.go file in this package that just needs
+// Config.BuildCharacterResolver satisfied without exercising real
+// character-store resolution.
+func constCharacterResolver(r tkenc.CharacterResolver) encounterorch.CharacterResolverBuilder {
+	return func(_ *tkenc.Data) tkenc.CharacterResolver { return r }
 }
 
 // seedUnlockedDoor persists an encounter with player-A adjacent to an unlocked

--- a/internal/orchestrators/encounter/v2/load.go
+++ b/internal/orchestrators/encounter/v2/load.go
@@ -118,7 +118,7 @@ func (o *Orchestrator) load(ctx context.Context, in loadInput) (*tkenc.Encounter
 	// SetMode -> rollInitiative path sets Config.Roller, which conditionally
 	// appends WithRoller here to override just that call's roller.
 	opts := []tkenc.Option{
-		tkenc.WithCharacterResolver(o.resolver),
+		tkenc.WithCharacterResolver(o.buildCharacterResolver(data)),
 		tkenc.WithCombatResolver(o.buildCombatResolver(data)),
 		tkenc.WithMovementResolver(o.buildMovementResolver(data)),
 	}

--- a/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
@@ -83,9 +83,9 @@ func (s *MoveEntityNPCFirstSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// Stand-in combat resolver, same choice as DriveStalledNPCTurnSuite: no
 		// DataJSON is seeded on the goblin, so NPCAct takes the scripted
 		// single-phase path — this test asserts WHETHER/WHEN the goblin's turn

--- a/internal/orchestrators/encounter/v2/move_entity_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_test.go
@@ -48,9 +48,9 @@ func (s *MoveEntitySuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
 			return nil
 		},

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -53,6 +53,18 @@ type CombatResolverBuilder func(data *tkenc.Data) CombatResolver
 // never imports the dnd5e rulebook movement adapter.
 type MovementResolverBuilder func(data *tkenc.Data) tkenc.MovementResolver
 
+// CharacterResolverBuilder builds a per-request CharacterResolver from the
+// encounter data (rpg-api#516). Same rationale as CombatResolverBuilder: the
+// toolkit's CharacterResolver interface hands AbilityModifier /
+// ToolProficiencyBonus only a PlayerID, with no way to see which encounter
+// (or which of a player's possibly-several characters) is in play — the
+// concrete Dnd5eCharacterResolver needs the loaded *tkenc.Data to read
+// data.Players[playerID].EntityID, so a fresh resolver is built per request
+// exactly like the combat/movement resolvers. When a fixed resolver override
+// is present (tests, the StubCharacterResolver default), the builder returns
+// it directly regardless of data.
+type CharacterResolverBuilder func(data *tkenc.Data) CharacterResolver
+
 // CharacterDataCascade attaches/persists the transient PlayerData.DataJSON for
 // the #689 hydration cascade on combat-capable verbs. The orchestrator calls
 // AttachCharacterData (before LoadFromData) and PersistCharacterData (after
@@ -133,9 +145,14 @@ type Config struct {
 	// EncounterRepo persists encounter snapshots. Required.
 	EncounterRepo encountersv2.Repository
 
-	// Resolver bridges the toolkit's CharacterResolver to the character store
-	// for skill-check totals. Required (the handler supplies a stub default).
-	Resolver CharacterResolver
+	// BuildCharacterResolver builds the per-request CharacterResolver bridging
+	// the toolkit's CharacterResolver to the character store for skill-check
+	// totals. Required (the handler supplies a builder that defaults to
+	// StubCharacterResolver). Built per-request, like BuildCombatResolver
+	// below, because the toolkit interface only carries a PlayerID — the
+	// concrete resolver needs this request's *tkenc.Data to map that PlayerID
+	// to a character (rpg-api#516).
+	BuildCharacterResolver CharacterResolverBuilder
 
 	// BuildCombatResolver builds the per-request combat resolver. Required.
 	BuildCombatResolver CombatResolverBuilder
@@ -180,9 +197,9 @@ type Orchestrator struct {
 	encRepo encountersv2.Repository
 	// now is wired now but unused by the door verbs (Interact); reserved for the
 	// projection / snapshot read path carved in later steps of #582.
-	resolver              CharacterResolver
-	buildCombatResolver   CombatResolverBuilder
-	buildMovementResolver MovementResolverBuilder
+	buildCharacterResolver CharacterResolverBuilder
+	buildCombatResolver    CombatResolverBuilder
+	buildMovementResolver  MovementResolverBuilder
 	// characterData carries the #689 hydration cascade (attach/persist of
 	// transient PlayerData.DataJSON) for combat-capable verbs. The injected funcs
 	// hold the character store handler-side, so the orchestrator needs no direct
@@ -211,8 +228,8 @@ func New(cfg *Config) (*Orchestrator, error) {
 	if cfg.EncounterRepo == nil {
 		return nil, errors.New("encounter orchestrator: Config.EncounterRepo is required")
 	}
-	if cfg.Resolver == nil {
-		return nil, errors.New("encounter orchestrator: Config.Resolver is required")
+	if cfg.BuildCharacterResolver == nil {
+		return nil, errors.New("encounter orchestrator: Config.BuildCharacterResolver is required")
 	}
 	if cfg.BuildCombatResolver == nil {
 		return nil, errors.New("encounter orchestrator: Config.BuildCombatResolver is required")
@@ -225,15 +242,15 @@ func New(cfg *Config) (*Orchestrator, error) {
 		now = time.Now
 	}
 	return &Orchestrator{
-		broker:                cfg.Broker,
-		encRepo:               cfg.EncounterRepo,
-		resolver:              cfg.Resolver,
-		buildCombatResolver:   cfg.BuildCombatResolver,
-		buildMovementResolver: cfg.BuildMovementResolver,
-		characterData:         cfg.CharacterData,
-		reactionResume:        cfg.ReactionResume,
-		now:                   now,
-		roller:                cfg.Roller,
-		npcDriveLocks:         newKeyedMutex(),
+		broker:                 cfg.Broker,
+		encRepo:                cfg.EncounterRepo,
+		buildCharacterResolver: cfg.BuildCharacterResolver,
+		buildCombatResolver:    cfg.BuildCombatResolver,
+		buildMovementResolver:  cfg.BuildMovementResolver,
+		characterData:          cfg.CharacterData,
+		reactionResume:         cfg.ReactionResume,
+		now:                    now,
+		roller:                 cfg.Roller,
+		npcDriveLocks:          newKeyedMutex(),
 	}, nil
 }

--- a/internal/orchestrators/encounter/v2/set_reaction_ready_test.go
+++ b/internal/orchestrators/encounter/v2/set_reaction_ready_test.go
@@ -32,9 +32,9 @@ func (s *SetReactionReadySuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// The readiness toggle never invokes the combat / movement resolvers, but
 		// the orchestrator requires the builders to be present.
 		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {

--- a/internal/orchestrators/encounter/v2/submit_check_test.go
+++ b/internal/orchestrators/encounter/v2/submit_check_test.go
@@ -28,9 +28,9 @@ func (s *SubmitCheckSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
 			return nil
 		},
@@ -227,9 +227,9 @@ func (s *SubmitCheckSuite) TestSubmitReactionCheck_MissingFuncs_Error() {
 	// An orchestrator without the ReactionResume funcs must refuse the reaction
 	// branch up front rather than nil-panic.
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
 			return nil
 		},

--- a/internal/orchestrators/encounter/v2/take_action_test.go
+++ b/internal/orchestrators/encounter/v2/take_action_test.go
@@ -70,9 +70,9 @@ func (s *TakeActionSuite) SetupTest() {
 	s.repo = encountersv2.NewInMemory()
 
 	orch, err := encounterorch.New(&encounterorch.Config{
-		Broker:        s.broker,
-		EncounterRepo: s.repo,
-		Resolver:      stubCharacterResolver{},
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
 		// Stand-in combat resolver: fixed 7-damage hit, non-phased so the inline
 		// resolution branch runs (no reaction prompts in these unit tests).
 		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {

--- a/internal/orchestrators/lobby/abandon_encounter.go
+++ b/internal/orchestrators/lobby/abandon_encounter.go
@@ -85,7 +85,7 @@ func (o *Orchestrator) AbandonEncounter(ctx context.Context, in *AbandonEncounte
 	}
 
 	enc, err := tkenc.LoadFromData(ctx, encData, o.encounterBroker,
-		tkenc.WithCharacterResolver(o.characterResolver),
+		tkenc.WithCharacterResolver(o.buildCharacterResolver(encData)),
 		tkenc.WithCombatResolver(o.buildCombatResolver(encData)),
 		tkenc.WithMovementResolver(o.buildMovementResolver(encData)),
 	)

--- a/internal/orchestrators/lobby/lobby_test.go
+++ b/internal/orchestrators/lobby/lobby_test.go
@@ -48,12 +48,12 @@ func (s *LobbySuite) SetupTest() {
 	s.encRepo = encountersv2.NewInMemory()
 
 	orch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         s.lobbyRepo,
-		LobbyBroker:       s.broker,
-		CharacterRepo:     s.charRepo,
-		EncounterRepo:     s.encRepo,
-		EncounterBroker:   s.encBroker,
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              s.lobbyRepo,
+		LobbyBroker:            s.broker,
+		CharacterRepo:          s.charRepo,
+		EncounterRepo:          s.encRepo,
+		EncounterBroker:        s.encBroker,
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},
@@ -118,12 +118,12 @@ func (s *LobbySuite) expectCharacterNotFound(characterID string) {
 // (e.g. a wrapped repo that forces one method to fail).
 func (s *LobbySuite) newOrchestratorWithLobbyRepo(repo lobbyrepo.Repository) *lobbyorch.Orchestrator {
 	orch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         repo,
-		LobbyBroker:       s.broker,
-		CharacterRepo:     s.charRepo,
-		EncounterRepo:     s.encRepo,
-		EncounterBroker:   s.encBroker,
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              repo,
+		LobbyBroker:            s.broker,
+		CharacterRepo:          s.charRepo,
+		EncounterRepo:          s.encRepo,
+		EncounterBroker:        s.encBroker,
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},
@@ -153,12 +153,12 @@ func (s *LobbySuite) newOrchestratorWithLobbyRepo(repo lobbyrepo.Repository) *lo
 func (s *LobbySuite) newOrchestratorWithContentDir(dir string) (*lobbyorch.Orchestrator, error) {
 	s.T().Setenv("RPG_CONTENT_DIR", dir)
 	return lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         s.lobbyRepo,
-		LobbyBroker:       s.broker,
-		CharacterRepo:     s.charRepo,
-		EncounterRepo:     s.encRepo,
-		EncounterBroker:   s.encBroker,
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              s.lobbyRepo,
+		LobbyBroker:            s.broker,
+		CharacterRepo:          s.charRepo,
+		EncounterRepo:          s.encRepo,
+		EncounterBroker:        s.encBroker,
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},
@@ -180,12 +180,12 @@ func (s *LobbySuite) newOrchestratorWithContentDir(dir string) (*lobbyorch.Orche
 // newOrchestratorWithContentDir does for RPG_CONTENT_DIR.
 func (s *LobbySuite) newOrchestratorWithDungeonKeyOverride(key string) *lobbyorch.Orchestrator {
 	orch, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         s.lobbyRepo,
-		LobbyBroker:       s.broker,
-		CharacterRepo:     s.charRepo,
-		EncounterRepo:     s.encRepo,
-		EncounterBroker:   s.encBroker,
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              s.lobbyRepo,
+		LobbyBroker:            s.broker,
+		CharacterRepo:          s.charRepo,
+		EncounterRepo:          s.encRepo,
+		EncounterBroker:        s.encBroker,
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},

--- a/internal/orchestrators/lobby/orchestrator.go
+++ b/internal/orchestrators/lobby/orchestrator.go
@@ -37,6 +37,14 @@ type CombatResolverBuilder func(data *tkenc.Data) tkenc.CombatResolver
 // rationale as CombatResolverBuilder.
 type MovementResolverBuilder func(data *tkenc.Data) tkenc.MovementResolver
 
+// CharacterResolverBuilder builds a per-request CharacterResolver bridging
+// the toolkit's CharacterResolver to the character store (rpg-api#516). Same
+// rationale as CombatResolverBuilder — the toolkit interface only carries a
+// PlayerID, so a real implementation needs the loaded *tkenc.Data to map
+// that PlayerID to a character; mirrors
+// internal/orchestrators/encounter/v2.CharacterResolverBuilder.
+type CharacterResolverBuilder func(data *tkenc.Data) tkenc.CharacterResolver
+
 // defaultPartyCap is the Dungeon Night shape (lobby-surface.md "Party cap").
 const defaultPartyCap = 4
 
@@ -64,11 +72,12 @@ type Config struct {
 	// streams. Required.
 	EncounterBroker *tkenc.Broker
 
-	// CharacterResolver bridges the toolkit's CharacterResolver to the
-	// character store, wired onto every StartEncounter-constructed encounter.
-	// Required (the handler supplies a stub default, mirroring the encounter
-	// handler's own default).
-	CharacterResolver tkenc.CharacterResolver
+	// BuildCharacterResolver builds the per-encounter CharacterResolver
+	// bridging the toolkit's CharacterResolver to the character store, wired
+	// onto every StartEncounter-constructed encounter. Required (the handler
+	// supplies a builder that defaults to StubCharacterResolver, mirroring
+	// the encounter handler's own default).
+	BuildCharacterResolver CharacterResolverBuilder
 
 	// BuildCombatResolver builds the per-encounter combat resolver at
 	// StartEncounter. Required.
@@ -120,20 +129,20 @@ type Config struct {
 // method per LobbyService RPC (plus the internal SetConnected used by
 // StreamLobby's subscribe/disconnect lifecycle).
 type Orchestrator struct {
-	lobbyRepo             lobbyrepo.Repository
-	lobbyBroker           *Broker
-	characterRepo         characterrepo.Repository
-	encounterRepo         encountersv2.Repository
-	encounterBroker       *tkenc.Broker
-	characterResolver     tkenc.CharacterResolver
-	buildCombatResolver   CombatResolverBuilder
-	buildMovementResolver MovementResolverBuilder
-	lobbyIDGen            idgen.Generator
-	joinRefGen            idgen.Generator
-	encounterIDGen        idgen.Generator
-	partyCap              int
-	now                   func() time.Time
-	locks                 *keyedMutex
+	lobbyRepo              lobbyrepo.Repository
+	lobbyBroker            *Broker
+	characterRepo          characterrepo.Repository
+	encounterRepo          encountersv2.Repository
+	encounterBroker        *tkenc.Broker
+	buildCharacterResolver CharacterResolverBuilder
+	buildCombatResolver    CombatResolverBuilder
+	buildMovementResolver  MovementResolverBuilder
+	lobbyIDGen             idgen.Generator
+	joinRefGen             idgen.Generator
+	encounterIDGen         idgen.Generator
+	partyCap               int
+	now                    func() time.Time
+	locks                  *keyedMutex
 
 	// contentSpecs is the content-hosted dungeon spec registry (Task E2),
 	// built ONCE here at construction by loadContentSpecs — StartEncounter
@@ -169,8 +178,8 @@ func New(cfg *Config) (*Orchestrator, error) {
 	if cfg.EncounterBroker == nil {
 		return nil, errors.New("lobby orchestrator: Config.EncounterBroker is required")
 	}
-	if cfg.CharacterResolver == nil {
-		return nil, errors.New("lobby orchestrator: Config.CharacterResolver is required")
+	if cfg.BuildCharacterResolver == nil {
+		return nil, errors.New("lobby orchestrator: Config.BuildCharacterResolver is required")
 	}
 	if cfg.BuildCombatResolver == nil {
 		return nil, errors.New("lobby orchestrator: Config.BuildCombatResolver is required")
@@ -217,22 +226,22 @@ func New(cfg *Config) (*Orchestrator, error) {
 	}
 
 	return &Orchestrator{
-		lobbyRepo:             cfg.LobbyRepo,
-		lobbyBroker:           cfg.LobbyBroker,
-		characterRepo:         cfg.CharacterRepo,
-		encounterRepo:         cfg.EncounterRepo,
-		encounterBroker:       cfg.EncounterBroker,
-		characterResolver:     cfg.CharacterResolver,
-		buildCombatResolver:   cfg.BuildCombatResolver,
-		buildMovementResolver: cfg.BuildMovementResolver,
-		lobbyIDGen:            cfg.LobbyIDGenerator,
-		joinRefGen:            cfg.JoinRefGenerator,
-		encounterIDGen:        cfg.EncounterIDGenerator,
-		partyCap:              partyCap,
-		now:                   now,
-		locks:                 newKeyedMutex(),
-		contentSpecs:          contentSpecs,
-		dungeonKeyOverride:    DungeonKey(cfg.DungeonKeyOverride),
+		lobbyRepo:              cfg.LobbyRepo,
+		lobbyBroker:            cfg.LobbyBroker,
+		characterRepo:          cfg.CharacterRepo,
+		encounterRepo:          cfg.EncounterRepo,
+		encounterBroker:        cfg.EncounterBroker,
+		buildCharacterResolver: cfg.BuildCharacterResolver,
+		buildCombatResolver:    cfg.BuildCombatResolver,
+		buildMovementResolver:  cfg.BuildMovementResolver,
+		lobbyIDGen:             cfg.LobbyIDGenerator,
+		joinRefGen:             cfg.JoinRefGenerator,
+		encounterIDGen:         cfg.EncounterIDGenerator,
+		partyCap:               partyCap,
+		now:                    now,
+		locks:                  newKeyedMutex(),
+		contentSpecs:           contentSpecs,
+		dungeonKeyOverride:     DungeonKey(cfg.DungeonKeyOverride),
 	}, nil
 }
 

--- a/internal/orchestrators/lobby/orchestrator_test.go
+++ b/internal/orchestrators/lobby/orchestrator_test.go
@@ -25,12 +25,12 @@ import (
 func TestNew_NegativePartyCap_ReturnsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	_, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         lobbyrepo.NewInMemory(),
-		LobbyBroker:       lobbyorch.NewBroker(),
-		CharacterRepo:     charactermock.NewMockRepository(ctrl),
-		EncounterRepo:     encountersv2.NewInMemory(),
-		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              lobbyrepo.NewInMemory(),
+		LobbyBroker:            lobbyorch.NewBroker(),
+		CharacterRepo:          charactermock.NewMockRepository(ctrl),
+		EncounterRepo:          encountersv2.NewInMemory(),
+		EncounterBroker:        tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},
@@ -61,12 +61,12 @@ func TestNew_ContentDirUnreadable_ReturnsConstructionError(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	_, err := lobbyorch.New(&lobbyorch.Config{
-		LobbyRepo:         lobbyrepo.NewInMemory(),
-		LobbyBroker:       lobbyorch.NewBroker(),
-		CharacterRepo:     charactermock.NewMockRepository(ctrl),
-		EncounterRepo:     encountersv2.NewInMemory(),
-		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              lobbyrepo.NewInMemory(),
+		LobbyBroker:            lobbyorch.NewBroker(),
+		CharacterRepo:          charactermock.NewMockRepository(ctrl),
+		EncounterRepo:          encountersv2.NewInMemory(),
+		EncounterBroker:        tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},
@@ -88,12 +88,12 @@ func baseTestConfig(t *testing.T) *lobbyorch.Config {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	return &lobbyorch.Config{
-		LobbyRepo:         lobbyrepo.NewInMemory(),
-		LobbyBroker:       lobbyorch.NewBroker(),
-		CharacterRepo:     charactermock.NewMockRepository(ctrl),
-		EncounterRepo:     encountersv2.NewInMemory(),
-		EncounterBroker:   tkenc.NewBroker(tkenc.NewInMemoryTransport()),
-		CharacterResolver: encounterhandlerv2.StubCharacterResolver{},
+		LobbyRepo:              lobbyrepo.NewInMemory(),
+		LobbyBroker:            lobbyorch.NewBroker(),
+		CharacterRepo:          charactermock.NewMockRepository(ctrl),
+		EncounterRepo:          encountersv2.NewInMemory(),
+		EncounterBroker:        tkenc.NewBroker(tkenc.NewInMemoryTransport()),
+		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {
 			return nil
 		},

--- a/internal/orchestrators/lobby/start_encounter.go
+++ b/internal/orchestrators/lobby/start_encounter.go
@@ -173,7 +173,7 @@ func (o *Orchestrator) StartEncounter(ctx context.Context, in *StartEncounterInp
 
 	encID := core.EncounterID(o.encounterIDGen.Generate())
 	enc := tkenc.New(ctx, encID, o.encounterBroker,
-		tkenc.WithCharacterResolver(o.characterResolver),
+		tkenc.WithCharacterResolver(o.buildCharacterResolver(nil)),
 		tkenc.WithCombatResolver(o.buildCombatResolver(nil)),
 		tkenc.WithMovementResolver(o.buildMovementResolver(nil)),
 	)


### PR DESCRIPTION
## Summary

Replaces `StubCharacterResolver` (which returned `(0, true)` for every ability-modifier and tool-proficiency query) with `Dnd5eCharacterResolver`, a real implementation backed by the character store. Every SubmitCheck total in production was previously computed as if the acting character had no ability scores — verified live against a crypt encounter (Alice, DEX 16/+3, proficiency bonus 2): `rolled 1, total 1` / `rolled 20, total 20`, `total == roll` in both cases.

## Was the stated blocker real?

**Stale.** The stub's doc comment claimed real lookups were blocked because `PlayerData.EntityID` mirrored `PlayerID` rather than referencing a character. Traced `start_encounter.go:219` — it already does `EntityID: core.EntityID(m.CharacterID)`, a real character id. That part of the blocker was already fixed.

The actual gap was plumbing, not data: the toolkit's `tkenc.CharacterResolver` interface hands `AbilityModifier`/`ToolProficiencyBonus` only a bare `core.PlayerID` — no encounter id, no `EntityID`. Since a player can own more than one character (`character` repo's `ListByPlayerID`), a resolver built once at server-startup can never unambiguously map `PlayerID -> character` on its own; it needs the *specific encounter's* `data.Players[playerID].EntityID`. This repo had already solved the identical problem for combat and movement (`Dnd5eCombatResolver`/`Dnd5eMovementResolver`, built per-request via `NewDnd5eCombatResolverForData(cfg, data)`), so the fix here mirrors that pattern: `CharacterResolver` is promoted from a static `Config` field to a per-request `CharacterResolverBuilder` in both the v2 encounter orchestrator and the lobby orchestrator (`StartEncounter`/`AbandonEncounter`).

## Implementation

- `internal/handlers/dnd5e/v2/encounter/character_resolver.go`: `Dnd5eCharacterResolver` + `Dnd5eCharacterResolverConfig` + `NewDnd5eCharacterResolverForData`. `AbilityModifier` calls the toolkit's own `shared.AbilityScores.Modifier` — never computes `(score-10)/2` in rpg-api (per this repo's "Code Smell: Game Logic in the API" rule). `ToolProficiencyBonus` reads the character's stored `ProficiencyBonus` verbatim — never derived from level here either, since it's already a stored field on `tkcharacter.Data`.
- Ability strings are lower-cased before the toolkit's `abilities.GetByID` lookup — both `"DEX"` (the toolkit's own doc convention) and `"dex"` (what the crypt boss door actually stores, per `start_encounter_test.go`) appear in this codebase.
- Unknown player / no bound character / character-store miss / unrecognized ability all resolve `ok=false`, which the toolkit's `SubmitCheck` treats as a zero modifier rather than an error (documented contract in `encounter/prompts.go`).
- `StubCharacterResolver` is unchanged and remains the default for the integration harness (`internal/integration/harness/harness.go`) and existing unit tests, wired via `BuildCharacterResolver` builders that ignore `data` — deterministic wire-shape tests are unaffected. Only `cmd/server/server.go`'s production wiring opts into the real resolver via the new `CharacterResolverConfig`.
- `internal/handlers/dnd5e/lobby/v1alpha1/handler.go` gets a `BuildCharacterResolver` export mirroring `BuildCombatResolver`, for `StartEncounter`'s freshly constructed encounters.

## Test plan

- [x] New unit suite `internal/handlers/dnd5e/v2/encounter/character_resolver_test.go` (testify suite + gomock): known character returns the real modifier (dex 16 -> +3), uppercase/lowercase ability convention, unknown player, character-store miss, unrecognized ability, nil data, nil repo, tool proficiency present/absent/nil-slice, unknown player for tool bonus.
- [x] `go test ./...` — full repo, all green (including `internal/integration`, real Redis).
- [x] `go vet ./...`, `gofmt`, scoped `golangci-lint run` on every touched package — 0 issues (repo-wide `make lint`/`make ci-check` still reports pre-existing debt unrelated to this change — see note below).
- [x] Live verification against the running dev stack (rebuilt `rpg-api:local` from this branch): seeded a locked door (DC 12, ability `dex`) for player `alice` bound to `char-alice` (DEX 16, +3) and called the real `Interact`/`SubmitCheck` RPCs over grpcurl.
  - `roll=9` -> `{"success": true, "total": 12}` (9 + 3 = 12; previously this would have failed as `total: 9`).
  - `roll=8` -> `{"total": 11}`, no success (8 + 3 = 11 < 12) — confirms the modifier is really being added, not a fluke.

## Found but not fixed

`scripts/ci-checks.sh`'s mock-regeneration check (`go generate ./... && git diff --quiet || git checkout -- .`) unconditionally discards **all** uncommitted tracked-file changes whenever `go generate` produces any diff — not just the mock files it's checking. It nuked this PR's entire working-tree diff mid-session (recovered from context, no data lost, but a real landmine for the next contributor with uncommitted work at the wrong moment). Also: `make lint`/`make ci-check` currently reports ~29 pre-existing lint issues repo-wide, none in files this PR touches (confirmed via `git diff origin/main` and scoped `golangci-lint run` on just the changed packages, which is clean). Neither is in scope here; flagging both for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BewLGfsex9kW23pd1NVEea