### PR TITLE
feat(encounter): consume connector-column boundary walls — bump encounter to v0.44.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260723025004-0e4e2d77d73a
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.44.0
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.44.1
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.44.0 h1:qPruibDIY+NrP/iWR2Xpy+ic7xdSOXI1NakaGZFj5jE=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.44.0/go.mod h1:aYGY8a2YADbnKO4qXy38vEMMsQLhgVuHUZozR7F2GVs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.44.1 h1:d2YXObUM7tkYAITa3vIhbOeCvSmMhfXiSoueq1Oo6c4=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.44.1/go.mod h1:aYGY8a2YADbnKO4qXy38vEMMsQLhgVuHUZozR7F2GVs=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/project_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/project_test.go
@@ -1180,17 +1180,37 @@ func (s *ProjectSuite) TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolid
 			degenerateCount++
 			continue
 		}
-		// Non-degenerate: a boundary-edge perimeter segment (rpg-toolkit#834).
+		// Non-degenerate: a boundary-edge segment -- either an outer-perimeter
+		// segment (rpg-toolkit#834) or, since encounter v0.44.1
+		// (rpg-toolkit#849), a connector-column flanking segment. Both use
+		// the identical shape (Start != End, one hex step, SOLID), which is
+		// exactly why a single loop/assertion pair below covers both without
+		// needing to tell them apart.
 		perimeterEdgeCount++
 		dist := (abs32(from.GetX()-to.GetX()) + abs32(from.GetY()-to.GetY()) + abs32(from.GetZ()-to.GetZ())) / 2
-		s.Require().Equal(int32(1), dist, "perimeter-edge wall %+v must be exactly one hex step apart", w)
+		s.Require().Equal(int32(1), dist, "boundary-edge wall %+v must be exactly one hex step apart", w)
 		s.Require().Equal(encounterv2pb.WallKind_WALL_KIND_SOLID, w.GetKind(),
-			"a perimeter-edge segment (BlocksMovement+BlocksLoS both true) must project as WALL_KIND_SOLID")
+			"a boundary-edge segment (BlocksMovement+BlocksLoS both true) must project as WALL_KIND_SOLID")
 	}
-	s.Require().Positive(degenerateCount,
-		"the crypt's interior/connector walls must still project degenerate (From==To)")
-	s.Require().Positive(perimeterEdgeCount,
-		"the crypt must project at least one non-degenerate perimeter-edge wall")
+	// rpg-api#721 (encounter v0.44.0 -> v0.44.1, rpg-toolkit#849): the
+	// crypt's connector-column flanking cells (7 per connector x 2
+	// connectors = 14, per toolkit#849's own diagnosis) converted from
+	// degenerate (Start == End) "rubble box" entries to the same
+	// boundary-edge shape perimeterEdgeCount already tracked. Every crypt
+	// region uses environments.PatternEmpty (rpg-toolkit#835 -- verified
+	// directly against encounter/crypt_dungeon.go, not assumed), so the
+	// connector columns were the crypt's ONLY source of degenerate walls;
+	// with those fixed, degenerateCount is now genuinely, permanently zero
+	// for this fixture -- not a seed-dependent coincidence. Measured
+	// directly (not guessed) before pinning: degenerateCount=0,
+	// perimeterEdgeCount=182 (184 total walls - 2 door walls), for this
+	// fixture's fixed seed/dimensions.
+	s.Require().Zero(degenerateCount,
+		"toolkit#849: connector-column flanking cells no longer project degenerate; "+
+			"the crypt's PatternEmpty rooms have no other source of degenerate walls")
+	s.Require().Equal(182, perimeterEdgeCount,
+		"exact count locks in that the connector fix's 14 flanking cells (7 per connector x 2 connectors) "+
+			"joined the boundary-edge category, not just \"more than zero\"")
 
 	// doorWallsToProto output unchanged in shape: the crypt's two connector
 	// doors (entrance plain, boss locked) must still each project exactly


### PR DESCRIPTION
Closes #721.

Bumps `github.com/KirkDiggler/rpg-toolkit/encounter` v0.44.0 → v0.44.1 (rpg-toolkit#849: connector-column flanking cells now project as boundary-edge walls — the same shape the outer perimeter already used — instead of the degenerate "rubble box" entries diagnosed in rpg-toolkit#848). No api code changes needed; walls project verbatim (opaque passthrough).

**Note: merging this auto-deploys.** Once deployed, prod's door areas visibly clean up — the rubble blocks flanking every connector door disappear, replaced by proper boundary-edge wall segments.

**Test fix:** `TestProjectFor_CryptFixture_ProjectsPerimeterEdgesAsSolidAndDoorsUnchanged` asserted the crypt must still project some degenerate walls. Verified directly against `encounter/crypt_dungeon.go` (v0.44.1): every crypt region uses `PatternEmpty`, not `PatternRandom`, so connector columns were the crypt's *only* source of degenerate walls — with those fixed, the count is now genuinely and permanently zero for this fixture, not a seed coincidence. Flipped the assertion to `Zero`, and per #705's "bump + projection regression test" precedent, hard-pinned the exact new count (182) rather than a loose bound — mutation-verified (temporarily broke the expected value, confirmed the assertion actually fires, reverted).

**Verification:** full non-short suite green with race detection (`go test -count=1 -race ./...`, docker/Redis testcontainer), `golangci-lint` clean on the touched package, `gofmt`/`goimports` clean.

**One thing found, not fixed here** (out of scope — a shared test helper, doesn't currently fail): `internal/integration/lobby_start_then_move_test.go`'s `isDegenerateBlockingWall` classifier (shared with `dungeon_crypt_test.go`'s `planWalk` BFS) only recognizes a wall as a real blocker when `Start == End`. Per toolkit#849's own PR body, a connector flanking cell's blocker is now placed at `End` for its new boundary-edge shape — this classifier never checks `End` at all, so it may now silently misclassify a real connector-column blocker as walkable. Nothing currently exercises this closely enough to fail, but it's a latent gap worth its own follow-up issue.

— asset-pipeline agent, on behalf of KirkDiggler
