### PR TITLE
content: add fog-lab dungeon fixture for fog-of-war playtesting

### DIFF
--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -38,6 +38,61 @@ func (s *ContentTestSuite) TestEveryEmbeddedSpecLoads() {
 	}
 }
 
+// TestFogLabSpec_CompilesWithExpectedFixtureShape validates the fog-lab.yaml
+// fixture (rpg-project#733 follow-up: a purpose-built dungeon so fog-of-war
+// playtesting isn't fighting the procedural crypt generator) both generically
+// (TestEveryEmbeddedSpecLoads already covers "does it load at all") and
+// structurally: the specific room shape the fixture exists to guarantee. A
+// fixture that loads but silently drifts from "4 pillars, no monsters in
+// room 1; one skeleton in room 2, door unlocked" would be worse than an
+// obviously-broken one — this pins the shape, not just the load.
+func (s *ContentTestSuite) TestFogLabSpec_CompilesWithExpectedFixtureShape() {
+	raw, ok, err := content.SpecByKey("fog-lab")
+	s.Require().NoError(err)
+	s.Require().True(ok, "fog-lab must be embedded and resolve by its declared key")
+
+	compiled, err := dungeonspec.Load(raw)
+	s.Require().NoError(err, "fog-lab.yaml must compile through dungeonspec — a fixture that fails to load is worse than no fixture")
+
+	s.Require().Len(compiled.Params.Regions, 2, "exactly two rooms: the pillar room and the skeleton room")
+	room1, room2 := compiled.Params.Regions[0], compiled.Params.Regions[1]
+
+	// Room 1: four pillars, no monsters, four explicitly non-blocking props.
+	s.Assert().Empty(room1.Obstacles, "room 1 uses static place: entries, not rolled obstacles")
+	pillars, nonBlocking := 0, 0
+	for _, o := range room1.PlacedObstacles {
+		switch o.Ref {
+		case "dnd5e:props:pillar":
+			pillars++
+			s.Assert().True(o.BlocksLoS, "pillars must block line of sight (the geometry-fog test depends on this)")
+		case "dnd5e:props:candles", "dnd5e:props:bone-pile":
+			nonBlocking++
+			s.Assert().False(o.BlocksLoS, "props next to pillars must be EXPLICITLY non-blocking, not relying on any ref default")
+		}
+	}
+	s.Assert().Equal(4, pillars, "room 1 must have exactly 4 pillars")
+	s.Assert().Equal(4, nonBlocking, "room 1 must have exactly 4 non-blocking props, one per pillar")
+
+	// No monster spawns target room 1 at all — entity-fog is tested
+	// separately, in room 2, per the fixture's whole point.
+	for _, spawn := range compiled.Spawns {
+		s.Assert().NotEqual(room1.ID, spawn.RoomID, "room 1 must have zero monsters")
+	}
+
+	// Room 2: exactly one monster (the mandatory boss slot, filled by the
+	// fixture's single skeleton rather than a separate non-boss monster in a
+	// third room) and nothing else placed.
+	s.Require().Len(compiled.Spawns, 1, "fog-lab must spawn exactly one monster: the skeleton in room 2")
+	s.Assert().Equal(room2.ID, compiled.Spawns[0].RoomID)
+	s.Assert().Equal("dnd5e:monsters:skeleton", compiled.Spawns[0].MonsterRef)
+	s.Assert().Empty(room2.PlacedObstacles, "room 2 has nothing placed besides its pinned boss/skeleton")
+
+	// The connector between them must be unlocked — Kirk needs to open the
+	// door, look, and step back repeatedly without a DC check in the way.
+	s.Require().Len(compiled.Params.Connectors, 1)
+	s.Assert().False(compiled.Params.Connectors[0].Locked, "the pillars->sentry door must be unlocked")
+}
+
 func (s *ContentTestSuite) TestSpecByKey_UnknownKey() {
 	_, ok, err := content.SpecByKey("atlantis")
 	s.Require().NoError(err)

--- a/internal/content/dungeons/fog-lab.yaml
+++ b/internal/content/dungeons/fog-lab.yaml
@@ -1,0 +1,40 @@
+version: 1
+key: fog-lab
+name: Fog Lab
+theme: crypt
+height: 8
+rooms:
+  # Room 1 (spawn) — geometry-fog test surface. Four pillars (blocks_los
+  # defaults to true — unset here, same as reference-tomb) each flanked by
+  # one small, confirmed-non-blocking prop (blocks_los: false set
+  # explicitly, not relied on as a ref default): walk around a pillar and
+  # watch its neighboring prop swing in and out of shadow. No monsters in
+  # this room at all — entity-fog is tested separately, in room 2.
+  - id: pillars
+    archetype: entrance
+    width: 10
+    place:
+      - { ref: "dnd5e:props:pillar", at: [2, 2] }
+      - { ref: "dnd5e:props:pillar", at: [2, 5] }
+      - { ref: "dnd5e:props:pillar", at: [6, 2] }
+      - { ref: "dnd5e:props:pillar", at: [6, 5] }
+      - { ref: "dnd5e:props:candles", at: [3, 2], blocks_los: false }
+      - { ref: "dnd5e:props:bone-pile", at: [3, 5], blocks_los: false }
+      - { ref: "dnd5e:props:candles", at: [7, 2], blocks_los: false }
+      - { ref: "dnd5e:props:bone-pile", at: [7, 5], blocks_los: false }
+  # Room 2 — entity-fog test surface, reached through an UNLOCKED door (no
+  # `locked:` on the connector below) so it can be opened/closed repeatedly
+  # without a DC check. Schema requires exactly one boss room somewhere in
+  # the chain (dungeonspec.Validate); this fixture's single skeleton fills
+  # that mandatory slot rather than adding a third room just to hold a
+  # separate non-boss monster. Pinned one row off the shared door row
+  # (doorRow = height/2 = 4, which no placement may occupy) and close to
+  # the incoming boundary, so it's immediately visible from the doorway —
+  # open the door, see it; step back behind the wall, watch it freeze into
+  # a remembered placement.
+  - id: sentry
+    archetype: boss
+    width: 8
+    boss: { ref: "dnd5e:monsters:skeleton", at: [1, 3] }
+connectors:
+  - { from: pillars, to: sentry }

--- a/internal/orchestrators/lobby/start_encounter_test.go
+++ b/internal/orchestrators/lobby/start_encounter_test.go
@@ -1212,6 +1212,50 @@ func (s *LobbySuite) TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb(
 	s.Require().True(tombOK)
 }
 
+// TestStartEncounter_DungeonKeyOverride_SelectsFogLab is the fog-of-war
+// playtest fixture (rpg-project#733 follow-up) proven end to end the same
+// way TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb proves
+// reference-tomb: with Config.DungeonKeyOverride set to "fog-lab" and no
+// caller-supplied DungeonKey, StartEncounter must build the content-backed
+// fog-lab dungeon, not the legacy crypt default (which is what motivated
+// this fixture in the first place — the procedural crypt is uncontrollable
+// for isolating geometry-fog from entity-fog).
+//
+// fog-lab is uniquely a two-room spec (every other registered key — crypt,
+// reference-tomb — compiles to three regions), so region count alone
+// already distinguishes it; this also pins the two room ids/archetypes and
+// that exactly one monster (the skeleton filling the mandatory boss slot)
+// got seeded, proving SeedMonsters actually ran against the content-compiled
+// spawn plan, not just that InitDungeon built the right geometry.
+func (s *LobbySuite) TestStartEncounter_DungeonKeyOverride_SelectsFogLab() {
+	orch := s.newOrchestratorWithDungeonKeyOverride("fog-lab")
+
+	s.seedReadyLobby("lobby-foglab", "alice")
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+
+	out, err := orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-foglab",
+		// DungeonKey deliberately left unset -- the override must fill it in.
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, out.EncounterID)
+	s.Require().NoError(err)
+
+	s.Require().Len(encData.Space.Regions, 2, "fog-lab is a two-room spec; the crypt/reference-tomb defaults are both three")
+	pillars, pillarsOK := regionByArchetype(encData.Space, tkenc.ArchetypeEntrance)
+	s.Require().True(pillarsOK)
+	s.Assert().Equal("pillars", pillars.ID)
+	sentry, sentryOK := regionByArchetype(encData.Space, tkenc.ArchetypeBoss)
+	s.Require().True(sentryOK)
+	s.Assert().Equal("sentry", sentry.ID)
+
+	s.Require().Len(encData.Monsters, 1, "exactly one monster: the skeleton filling fog-lab's mandatory boss slot")
+	for _, m := range encData.Monsters {
+		s.Assert().Equal("dnd5e:monsters:skeleton", m.MonsterRef)
+	}
+}
+
 // TestStartEncounter_DungeonKeyOverride_ExplicitCallerKeyWins proves the
 // substitution's ONLY-when-empty guard: a caller-supplied DungeonKey
 // (crypt) must win over a configured override (reference-tomb) — the


### PR DESCRIPTION
## Summary

Kirk is playtesting fog of war locally and the live default dungeon (procedural crypt, seed-rolled) is a bad test surface — its layout is uncontrollable and mixes geometry occlusion with entity visibility in whatever the roll produces. This adds a purpose-built two-room fixture that isolates the two behaviors so they can be tested independently, no combat required for either.

## What was authored

`internal/content/dungeons/fog-lab.yaml` (`key: fog-lab`):

- **Room 1 — `pillars` (entrance archetype, width 10), where the player spawns.** Four pillars at `[2,2] [2,5] [6,2] [6,5]` (cloned from `reference-tomb.yaml`'s already-proven "hall" pillar layout — same width, same coordinates, so the spacing is known-good at normal sight range). Each pillar is flanked by one small prop one column over: `candles` at `[3,2]`/`[3,5]`... wait, exact coordinates: `candles` at `[3,2]`, `bone-pile` at `[3,5]`, `candles` at `[7,2]`, `bone-pile` at `[7,5]`. Every prop sets `blocks_los: false` **explicitly** — dungeonspec's own compile-time default for an omitted `blocks_los` is `true` (`boolOrTrue` in the toolkit's `dungeonspec/compile.go`), so relying on "the ref's default" would silently make these blocking. No monsters anywhere in this room.
- **Room 2 — `sentry` (boss archetype, width 8).** One skeleton at `[1,3]` — one row off the shared door row (`doorRow = height/2 = 4`, which no placement may occupy) and close to the incoming boundary, so it's visible immediately when the door opens. The connector (`pillars -> sentry`) carries **no `locked:`** — open/close repeatedly, no DC check.
- **Why the skeleton is the "boss":** `dungeonspec.Validate` requires *exactly one* boss-archetype room somewhere in the chain (a hard schema invariant, not something this fixture can route around). Rather than add a third room just to hold a plain (non-boss) monster, this fixture's single skeleton fills that mandatory slot. Mechanically there's no difference the player would notice — any visible hostile monster triggers combat-entry regardless of the boss/non-boss tag, so "no combat required" just means the test doesn't need Kirk to fight it, not that seeing it won't flip the encounter into turn-based mode (that's pre-existing behavior, not something introduced or defeatable here).
- Height 8 throughout (shared by both rooms, matching `reference-tomb`) — required: the boss room's primary axis (`min(width, height)`) must exceed 6, so height must be ≥7 the moment any boss room exists at all.

## YAML-key selection: no new wiring needed (correcting the stated premise)

The brief flagged this as unverified — worth stating plainly since it changed the shape of the work: **content-backed dungeon-key selection is already fully wired end to end**, from `rpg-project#709`'s Task E2/E2b (which predates this task). `internal/orchestrators/lobby/dungeon_spec.go`'s `resolveContentDungeonSpec` checks the embedded-YAML registry *first*, before ever falling through to the legacy `dungeonSpecs` map — and `start_encounter.go`'s `StartEncounter` already branches on it (`foundInContent`) for both `InitDungeon` and `SeedMonsters`. `RPG_DUNGEON_KEY` (`cmd/server/server.go`) feeds `Config.DungeonKeyOverride`, validated at construction (`validateDungeonKeyOverride`). A test already existed proving this mechanism generically (`TestStartEncounter_DungeonKeyOverride_SelectsReferenceTomb`) — nothing needed to be built here, just proven specifically for `fog-lab` (see below).

## Tests added

- `internal/content/content_test.go`: `TestFogLabSpec_CompilesWithExpectedFixtureShape` — loads `fog-lab` through `dungeonspec.Load` and pins the structural shape: exactly 4 pillars (blocking) + 4 explicitly-non-blocking props in room 1, zero monster spawns targeting room 1, exactly one skeleton spawn in room 2, unlocked connector. A fixture that loads but silently drifts from this shape would be worse than an obviously-broken one.
- `internal/orchestrators/lobby/start_encounter_test.go`: `TestStartEncounter_DungeonKeyOverride_SelectsFogLab` — proves `RPG_DUNGEON_KEY=fog-lab` (via `Config.DungeonKeyOverride`, no caller-supplied key) drives `StartEncounter` to build the fog-lab dungeon (2 regions — uniquely distinguishing vs. crypt/reference-tomb's 3) and seeds exactly one skeleton, end to end.

`reference-tomb.yaml` is untouched.

## Deployed locally

Based on `feat/remembered-transitions` (not `main` — Kirk is running that build for the fog-of-war fix in #732).

- `docker build -t rpg-api:local /home/kirk/game-dev/rpg-api/.worktrees/feat-fog-lab-dungeon` — built clean.
- `rpg-deployment` already had uncommitted local edits (`docker-compose.local-dev.yml` modified; `docker-compose.local-api-src.yml`, `envoy/envoy-lab*.yaml` untracked) — none touched. Added one new file, `docker-compose.fog-lab-env.yml`, a minimal overlay that adds only `RPG_DUNGEON_KEY=fog-lab` to the `rpg-api` service's environment.
- Dry-ran `docker compose ... config rpg-api` first to confirm the merge only *adds* the new key (all 5 existing env vars — `PORT`, `LOG_LEVEL`, `REDIS_ADDR`, `AUTH_DEV_MODE`, `DND5E_API_URL` — came through unchanged) before applying.
- `docker compose -f docker-compose.local-dev.yml -f docker-compose.local-api-src.yml -f docker-compose.fog-lab-env.yml up -d rpg-api` — recreated only the `rpg-api` container (compose warned about orphans for `rpg-api-lab`/`rpg-api-lab2`/their envoys since `--remove-orphans` was never passed; confirmed via `docker ps` afterward that both labs kept their original uptime, untouched).
- Verified post-deploy: `rpg-api` container is `healthy`, running image `rpg-api:local` (id `sha256:674251...`, the build just produced), env includes `RPG_DUNGEON_KEY=fog-lab` alongside all the original vars, and startup logs are clean (gRPC server up, Redis connected, no `RPG_DUNGEON_KEY` validation error — `validateDungeonKeyOverride` runs at construction, so a broken/unknown key would have failed the server to start entirely rather than silently).

## Verification (real output, this session)

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l internal/` — clean (no output)
- `golangci-lint run ./...` — 29 pre-existing issues, **none** in the files this PR touches (`fog-lab.yaml`, `content_test.go`, `start_encounter_test.go`) — checked explicitly
- Full unit suite: `go test ./...` — all packages `ok`
- Real Docker/Redis integration suite (testcontainers, fresh `-count=1`, container spin-up logs observed): `internal/integration` (36.7s), `internal/integration/character` (13.6s), `internal/integration/harness` (11.3s) — all `ok`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l internal/`
- [x] `golangci-lint run ./...`
- [x] Full unit suite
- [x] Real Docker/Redis integration suite
- [x] `fog-lab.yaml` validated via dedicated `dungeonspec.Load` structural test
- [x] `RPG_DUNGEON_KEY=fog-lab` proven to select this dungeon end to end
- [x] Deployed to the local `rpg-api` container with `RPG_DUNGEON_KEY=fog-lab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdG4UCKmpJCDgh9ipiqXF
