### PR TITLE
content: light fog-lab.yaml — the fixture was reading as nearly unlit

### DIFF
--- a/internal/content/content_test.go
+++ b/internal/content/content_test.go
@@ -46,6 +46,15 @@ func (s *ContentTestSuite) TestEveryEmbeddedSpecLoads() {
 // fixture that loads but silently drifts from "4 pillars, no monsters in
 // room 1; one skeleton in room 2, door unlocked" would be worse than an
 // obviously-broken one — this pins the shape, not just the load.
+//
+// Also pins the lighting follow-up (Kirk playtest finding: the fixture was
+// "essentially unlit" — 2 dim candles + 2 unlit bone-piles in room 1, ZERO
+// props in room 2 — which both looked wrong and defeated the fixture's own
+// purpose, since it's hard to judge a remembered-shadow transition when the
+// whole room is already dark): 2 braziers in room 1, 1 in room 2, every one
+// EXPLICITLY non-blocking (dungeonspec's own compile-time default for an
+// omitted blocks_los is true — see fog-lab.yaml's comments and this
+// package's earlier lesson on the same point for the flanking props).
 func (s *ContentTestSuite) TestFogLabSpec_CompilesWithExpectedFixtureShape() {
 	raw, ok, err := content.SpecByKey("fog-lab")
 	s.Require().NoError(err)
@@ -57,21 +66,27 @@ func (s *ContentTestSuite) TestFogLabSpec_CompilesWithExpectedFixtureShape() {
 	s.Require().Len(compiled.Params.Regions, 2, "exactly two rooms: the pillar room and the skeleton room")
 	room1, room2 := compiled.Params.Regions[0], compiled.Params.Regions[1]
 
-	// Room 1: four pillars, no monsters, four explicitly non-blocking props.
+	// Room 1: four pillars, no monsters, four explicitly non-blocking
+	// flanking props, and two explicitly non-blocking braziers for light.
 	s.Assert().Empty(room1.Obstacles, "room 1 uses static place: entries, not rolled obstacles")
-	pillars, nonBlocking := 0, 0
+	pillars, flankers, braziers := 0, 0, 0
 	for _, o := range room1.PlacedObstacles {
 		switch o.Ref {
 		case "dnd5e:props:pillar":
 			pillars++
 			s.Assert().True(o.BlocksLoS, "pillars must block line of sight (the geometry-fog test depends on this)")
 		case "dnd5e:props:candles", "dnd5e:props:bone-pile":
-			nonBlocking++
+			flankers++
 			s.Assert().False(o.BlocksLoS, "props next to pillars must be EXPLICITLY non-blocking, not relying on any ref default")
+		case "dnd5e:props:brazier":
+			braziers++
+			s.Assert().False(o.BlocksLoS, "light props must be EXPLICITLY non-blocking, not relying on any ref default")
 		}
 	}
 	s.Assert().Equal(4, pillars, "room 1 must have exactly 4 pillars")
-	s.Assert().Equal(4, nonBlocking, "room 1 must have exactly 4 non-blocking props, one per pillar")
+	s.Assert().Equal(4, flankers, "room 1 must have exactly 4 non-blocking flanking props, one per pillar")
+	s.Assert().Equal(2, braziers, "room 1 must have exactly 2 braziers lighting the pillar layout")
+	s.Assert().Len(room1.PlacedObstacles, pillars+flankers+braziers, "no unexpected extra props in room 1")
 
 	// No monster spawns target room 1 at all — entity-fog is tested
 	// separately, in room 2, per the fixture's whole point.
@@ -81,11 +96,14 @@ func (s *ContentTestSuite) TestFogLabSpec_CompilesWithExpectedFixtureShape() {
 
 	// Room 2: exactly one monster (the mandatory boss slot, filled by the
 	// fixture's single skeleton rather than a separate non-boss monster in a
-	// third room) and nothing else placed.
+	// third room) and exactly one non-blocking brazier so the skeleton isn't
+	// sitting in a pitch-dark room.
 	s.Require().Len(compiled.Spawns, 1, "fog-lab must spawn exactly one monster: the skeleton in room 2")
 	s.Assert().Equal(room2.ID, compiled.Spawns[0].RoomID)
 	s.Assert().Equal("dnd5e:monsters:skeleton", compiled.Spawns[0].MonsterRef)
-	s.Assert().Empty(room2.PlacedObstacles, "room 2 has nothing placed besides its pinned boss/skeleton")
+	s.Require().Len(room2.PlacedObstacles, 1, "room 2 has exactly one placed prop: its light source")
+	s.Assert().Equal("dnd5e:props:brazier", room2.PlacedObstacles[0].Ref)
+	s.Assert().False(room2.PlacedObstacles[0].BlocksLoS, "room 2's light prop must be EXPLICITLY non-blocking")
 
 	// The connector between them must be unlocked — Kirk needs to open the
 	// door, look, and step back repeatedly without a DC check in the way.

--- a/internal/content/dungeons/fog-lab.yaml
+++ b/internal/content/dungeons/fog-lab.yaml
@@ -10,6 +10,15 @@ rooms:
   # explicitly, not relied on as a ref default): walk around a pillar and
   # watch its neighboring prop swing in and out of shadow. No monsters in
   # this room at all — entity-fog is tested separately, in room 2.
+  #
+  # Two braziers at col 4 (between the two pillar columns, 2 and 6) light
+  # the room warmly without sitting directly beside any one pillar/prop
+  # pair — sitting a light source between the pillars rather than flush
+  # against one gives each pillar a discernible lit side and a shadowed
+  # side instead of flattening the contrast the geometry-fog test depends
+  # on. The original 4 pillars and their 4 flanking props are UNCHANGED —
+  # that layout is the test surface itself (Kirk confirmed the shadows read
+  # well on it) — this only adds light, never moves anything.
   - id: pillars
     archetype: entrance
     width: 10
@@ -22,6 +31,8 @@ rooms:
       - { ref: "dnd5e:props:bone-pile", at: [3, 5], blocks_los: false }
       - { ref: "dnd5e:props:candles", at: [7, 2], blocks_los: false }
       - { ref: "dnd5e:props:bone-pile", at: [7, 5], blocks_los: false }
+      - { ref: "dnd5e:props:brazier", at: [4, 1], blocks_los: false }
+      - { ref: "dnd5e:props:brazier", at: [4, 6], blocks_los: false }
   # Room 2 — entity-fog test surface, reached through an UNLOCKED door (no
   # `locked:` on the connector below) so it can be opened/closed repeatedly
   # without a DC check. Schema requires exactly one boss room somewhere in
@@ -32,9 +43,15 @@ rooms:
   # the incoming boundary, so it's immediately visible from the doorway —
   # open the door, see it; step back behind the wall, watch it freeze into
   # a remembered placement.
+  #
+  # One brazier right beside the skeleton so the room isn't pitch dark —
+  # without it the "open the door and see it" test was defeated outright,
+  # not just dim.
   - id: sentry
     archetype: boss
     width: 8
     boss: { ref: "dnd5e:monsters:skeleton", at: [1, 3] }
+    place:
+      - { ref: "dnd5e:props:brazier", at: [2, 3], blocks_los: false }
 connectors:
   - { from: pillars, to: sentry }


### PR DESCRIPTION
## Summary

Playtest finding from Kirk: "the lighting overall is way off" on the fog-lab dungeon (#733) — and he's right. My brief for that fixture asked for "small non-sight-blocking props" beside the pillars but never said "keep the room lit," so this is a brief gap, not an implementation error in #733.

Before this change: room 1 (`pillars`) had only 2 dim (green-pooling) candle clusters and 2 unlit bone-piles; room 2 (`sentry`) had **zero** props besides the boss skeleton. Compared with `reference-tomb.yaml` (braziers in every room, plus a torch-ornate), fog-lab read as close to unlit — which both looked wrong and undermined the fixture's own purpose: hard to judge whether a prop has gone into remembered-shadow when the whole room is already dark.

## What changed

`internal/content/dungeons/fog-lab.yaml`:

- **Room 1**: two braziers at `[4,1]` and `[4,6]` — column 4, between the pillar columns (2 and 6), not flush against any single pillar/prop pair. Sitting between rather than beside gives each pillar a discernible lit side and a shadowed side instead of flattening the contrast the geometry-fog test depends on. **The original 4 pillars and their 4 flanking props are unchanged** — that layout is the test surface itself, already confirmed to read well; this only adds light, never moves anything.
- **Room 2**: one brazier at `[2,3]`, right beside the skeleton (`[1,3]`) — without it, "open the door and see it" was defeated outright by the room being pitch dark, not just dim.
- Every added brazier sets `blocks_los: false` **explicitly** — same lesson as #733: `dungeonspec/compile.go`'s `boolOrTrue` defaults an omitted `blocks_los` to `true`, which would silently turn a light source into a sight-blocker.

`internal/content/content_test.go`: `TestFogLabSpec_CompilesWithExpectedFixtureShape` updated to pin the new prop counts (2 braziers in room 1, 1 in room 2, all explicitly non-blocking) alongside everything it already pinned (4 pillars, 4 non-blocking flankers, zero monsters in room 1, exactly one skeleton in room 2, unlocked connector).

## Deployed locally

Rebuilt `rpg-api:local` from this worktree (normal `Dockerfile` — no toolkit override active; confirmed via `scripts/toolkit-local-override.sh status` and `git diff go.mod go.sum` being empty before building) and redeployed **only** the primary `rpg-api` container with the same `docker-compose.fog-lab-env.yml` overlay from #733/#735 (no new deployment-repo changes). Verified post-deploy:

- `rpg-api`: healthy, image `rpg-api:local` (`sha256:e46616363dbf...` — a genuinely new digest, since `fog-lab.yaml` is `go:embed`-ed into the binary and this change edits its content), env has `RPG_DUNGEON_KEY=fog-lab`.
- `rpg-api-lab` (27h uptime) / `rpg-api-lab2` (14h uptime): confirmed untouched.

## Verification (real output, this session)

- `go build ./...` / `go vet ./...` / `gofmt -l internal/` — all clean
- `golangci-lint run ./...` — 29 pre-existing issues, none in this PR's 2 touched files
- Full unit suite: `go test ./...` — all packages `ok`
- Real Docker/Redis integration suite (testcontainers, fresh `-count=1`): `internal/integration` (36.5s), `internal/integration/character` (13.3s), `internal/integration/harness` (11.0s) — all `ok`

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l internal/`, `golangci-lint run ./...`
- [x] Full unit suite + real Docker/Redis integration suite
- [x] `TestFogLabSpec_CompilesWithExpectedFixtureShape` updated and passing
- [x] Primary `rpg-api` rebuilt, redeployed, healthy, `RPG_DUNGEON_KEY=fog-lab` confirmed
- [x] `rpg-api-lab` / `rpg-api-lab2` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdG4UCKmpJCDgh9ipiqXF
