### PR TITLE
ci: run tests and image builds on the dev branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,9 @@ name: Build Docker Image
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test and Coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Kirk is introducing a long-lived integration branch named `dev` in both rpg-api and rpg-dnd5e-web (replacing web's `development`). This adds `dev` to the push/pull_request branch filters in `test.yml` and `docker.yml` so it gets the same CI treatment as `main`. The `dev` branch itself is created separately by Kirk — this PR is CI wiring only.

- `test.yml`: `branches: [ main ]` → `branches: [ main, dev ]` (push + pull_request)
- `docker.yml`: `branches: [ main ]` → `branches: [ main, dev ]` (push + pull_request)

**Production safety gates are unchanged:**
- `type=raw,value=latest,enable={{is_default_branch}}` — the `latest` image tag still only moves on the default branch, so a `dev` push cannot move it.
- The "Trigger deployment" step still requires `github.ref == 'refs/heads/main'` — a `dev` push cannot fire the rpg-deployment workflow.

Net effect: a `dev` push builds and pushes `ghcr.io/kirkdiggler/rpg-api:dev` (via the existing `type=ref,event=branch` tag), which is the image the local dev stack will pull. No prod impact.

Closes #742

## Test plan
- [x] Diff reviewed: only the 4 branch-filter lines changed across both workflow files
- [x] Confirmed the two safety-gate lines in `docker.yml` are untouched
- [ ] CI runs green on this PR (targets `main`, so filters aren't exercised here — verified by inspection instead)

— asset-pipeline agent, on behalf of KirkDiggler