### PR TITLE
fix(encounter): bump rpg-toolkit to v0.46.5, map ErrOutOfRange

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260727041520-00d690822f7f
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
-	github.com/KirkDiggler/rpg-toolkit/encounter v0.46.3
+	github.com/KirkDiggler/rpg-toolkit/encounter v0.46.5
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.1

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Q
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.46.3 h1:zhC4vjLlg+ih7Md8SVor7XacvYOM9RCyyrHD/iX5gYU=
-github.com/KirkDiggler/rpg-toolkit/encounter v0.46.3/go.mod h1:aYGY8a2YADbnKO4qXy38vEMMsQLhgVuHUZozR7F2GVs=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.46.5 h1:Bmpm7aWXfoiEtaSPwkwqwRPCDqsoPEPyQj7JXDYoZnE=
+github.com/KirkDiggler/rpg-toolkit/encounter v0.46.5/go.mod h1:aYGY8a2YADbnKO4qXy38vEMMsQLhgVuHUZozR7F2GVs=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go
@@ -27,6 +27,15 @@ const (
 // in TURN_BASED mode and persists it through the suite's repo. Returns the
 // loaded data so callers can inspect Initiative ordering for tests that need
 // to know whose turn is active first.
+//
+// The goblin sits at a common hex neighbor of both alice{0,0,0} and
+// bob{1,0,-1} (hexDistance = 1 from each) rather than a hex only bob is
+// adjacent to: this fixture uses no explicit roller, so either player may
+// win initiative and attack the goblin via TestTakeAction_AttackHappyPath_
+// PersistsMonsterHP — rpg-toolkit#864's range/reach gate now requires the
+// attacker within weapon reach (1 hex, no hydrated character on these flat
+// stat-snapshot seats), so a goblin only bob could reach made that test
+// flaky (passed or failed depending on the real d20 roll).
 func (s *HandlerSuite) seedCombatEncounter() {
 	enc := tkenc.New(context.Background(), combatEncID, s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
@@ -40,7 +49,7 @@ func (s *HandlerSuite) seedCombatEncounter() {
 		HP: 10, MaxHP: 10, AC: 13, AttackBonus: 3, DamageDice: "1d6+1", DamageType: "piercing",
 	}))
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
-		ID: monsterGoblin1, Position: core.Hex{Q: 2, R: -1, S: -1},
+		ID: monsterGoblin1, Position: core.Hex{Q: 1, R: -1, S: 0},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",

--- a/internal/handlers/dnd5e/v2/encounter/end_turn.go
+++ b/internal/handlers/dnd5e/v2/encounter/end_turn.go
@@ -66,6 +66,17 @@ func (h *Handler) EndTurn(ctx context.Context, req *encounterv2pb.EndTurnRequest
 //   - ErrPlayerNotInEncounter / ErrEntityOwnershipMismatch → PermissionDenied
 //   - tkenc.Err{EncounterEnded,NotTurnBased,NotYourTurn,NoCombatants} → FailedPrecondition
 //   - ErrNPCChainExhausted → FailedPrecondition
+//   - ErrOutOfRange → FailedPrecondition (rpg-api#747: toolkit#864's range/reach
+//     gate, surfaced via the NPC dispatch loop's NPCAct call. Checked ahead of
+//     the generic ErrNPCAct-wrapped fallback below: driveNPCChain wraps any
+//     non-reaction-pause NPCAct error with ErrNPCAct via a double-%w
+//     fmt.Errorf, and Go's errors.Is traverses every wrapped error in the
+//     chain, so this still matches even though the error is also ErrNPCAct.
+//     In practice this path is defense-in-depth, not a live bug fix: the
+//     toolkit's NPCAct treats an out-of-reach target as a no-op (skip the
+//     turn / skip the attack) rather than an error as of #868's gate-review
+//     fix, so ErrOutOfRange should no longer actually propagate out of
+//     NPCAct — this case guards against a future regression reintroducing it.
 //   - ErrNPCAct / unclassified failures → Internal
 func endTurnStatusError(err error) error {
 	switch {
@@ -85,6 +96,8 @@ func endTurnStatusError(err error) error {
 	case errors.Is(err, tkenc.ErrNoCombatants):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, encounterorch.ErrNPCChainExhausted):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, tkenc.ErrOutOfRange):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return status.Errorf(codes.Internal, "end turn: %v", err)

--- a/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go
@@ -541,12 +541,19 @@ func (s *SneakAttackIntegrationSuite) buildAliceRogueData() *character.Data {
 
 // seedSneakEncounter creates the integration test fixture encounter and saves it.
 //
-// Positions chosen so bob is adjacent to goblin (distance ≤ 1.5 in euclidean
-// terms using Q→X, R→Y hex mapping):
+// Positions (cube hex coordinates, hexDistance = (|dQ|+|dR|+|dS|)/2 — the
+// toolkit's real metric, not the euclidean approximation this comment used
+// to claim): goblin sits at a common neighbor of both alice and bob, so
+// BOTH are within 1 hex of it — alice needs that for her own attack
+// (rpg-toolkit#864's range/reach gate: TakeAction now requires the
+// attacker within weapon reach, 1 hex by default for her un-hydrated-reach
+// shortsword), and bob still needs it for Sneak Attack's ally-adjacent-to-
+// target rule:
 //
-//	alice  Q:0  R:0   (attacker)
-//	bob    Q:1  R:0   (ally — distance to goblin sqrt((2-1)²+(0-0)²) = 1.0 ≤ 1.5)
-//	goblin Q:2  R:0   (target — 100 HP so it survives multiple attacks)
+//	alice  Q:0  R:0  S:0   (attacker)
+//	bob    Q:1  R:0  S:-1  (ally — hexDistance to goblin = 1)
+//	goblin Q:1  R:-1 S:0   (target, 100 HP so it survives multiple attacks;
+//	                        hexDistance to alice = 1, to bob = 1)
 //
 // DamageDice is set for all combatants so they qualify as combatants for
 // TakeAction and have OA readiness seeded by the encounter SDK.
@@ -567,7 +574,8 @@ func (s *SneakAttackIntegrationSuite) seedSneakEncounter() {
 		DamageType:  "piercing",
 	}))
 
-	// bob: ally placed adjacent to goblin (Q=1, goblin at Q=2 → euclidean distance=1.0)
+	// bob: ally placed adjacent to goblin (hexDistance = 1) for Sneak
+	// Attack's ally-adjacent-to-target rule.
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID:   encountercore.PlayerID(sneakPlayerBob),
 		EntityID:   encountercore.EntityID(sneakEntityBob),
@@ -580,10 +588,13 @@ func (s *SneakAttackIntegrationSuite) seedSneakEncounter() {
 		DamageType: "slashing",
 	}))
 
-	// goblin: 100 HP so it survives multiple attacks during the test.
+	// goblin: 100 HP so it survives multiple attacks during the test. A
+	// common neighbor of alice and bob (see seedSneakEncounter's doc
+	// comment) so alice's own attack is within reach too
+	// (rpg-toolkit#864).
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
 		ID:          encountercore.EntityID(sneakGoblinID),
-		Position:    encountercore.Hex{Q: 2, R: 0, S: -2},
+		Position:    encountercore.Hex{Q: 1, R: -1, S: 0},
 		HP:          100,
 		MaxHP:       100,
 		AC:          13,

--- a/internal/handlers/dnd5e/v2/encounter/out_of_range_mapping_internal_test.go
+++ b/internal/handlers/dnd5e/v2/encounter/out_of_range_mapping_internal_test.go
@@ -1,0 +1,69 @@
+package encounter
+
+// out_of_range_mapping_internal_test.go — rpg-api#747: white-box tests
+// proving the toolkit's ErrOutOfRange sentinel (rpg-toolkit#864's action
+// range/reach gate) maps to codes.FailedPrecondition, not the generic
+// codes.Internal fallback, at all three status-mapping call sites
+// (takeActionStatusError, endTurnStatusError, submitCheckStatusError).
+//
+// Package encounter (not encounter_test) so these can call the unexported
+// mapper functions directly — matching translate_move_internal_test.go's
+// precedent for white-box tests of private functions in this package.
+//
+// Each error is wrapped (not passed bare) to also prove the mapping survives
+// realistic wrapping: takeActionStatusError/submitCheckStatusError see
+// ErrOutOfRange surfaced unwrapped by their orchestrators (a single %w), but
+// endTurnStatusError sees it behind driveNPCChain's double-%w ErrNPCAct wrap
+// (fmt.Errorf("%w %q: %w", ErrNPCAct, ..., actErr)) — Go's errors.Is
+// traverses every wrapped error in the tree, not just the first %w, so the
+// more specific ErrOutOfRange case still matches ahead of the generic
+// ErrNPCAct/Internal fallback. See endTurnStatusError's doc comment for why
+// this path is defense-in-depth rather than a live bug today: toolkit#868's
+// gate-review fix made an out-of-reach NPCAct target a no-op (skip), not an
+// error, so ErrOutOfRange shouldn't actually propagate out of NPCAct anymore
+// — this test guards against a future regression reintroducing it.
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+)
+
+func TestTakeActionStatusError_OutOfRange_FailedPrecondition(t *testing.T) {
+	err := fmt.Errorf("target out of range: 3 hexes, reach 1: %w", tkenc.ErrOutOfRange)
+	mapped := takeActionStatusError(err)
+	st, ok := status.FromError(mapped)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestEndTurnStatusError_OutOfRange_FailedPrecondition(t *testing.T) {
+	// Mirrors driveNPCChain's actual wrap shape: ErrNPCAct AND the original
+	// toolkit error are both preserved via a double-%w fmt.Errorf.
+	rangeErr := fmt.Errorf("target out of range: 2 hexes, reach 1: %w", tkenc.ErrOutOfRange)
+	wrapped := fmt.Errorf("%w %q: %w", encounterorch.ErrNPCAct, "goblin-1", rangeErr)
+
+	require.True(t, errors.Is(wrapped, encounterorch.ErrNPCAct), "test premise: the error is also ErrNPCAct")
+	require.True(t, errors.Is(wrapped, tkenc.ErrOutOfRange), "test premise: ErrOutOfRange survives the wrap")
+
+	mapped := endTurnStatusError(wrapped)
+	st, ok := status.FromError(mapped)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code(),
+		"ErrOutOfRange must be classified ahead of the generic ErrNPCAct/Internal fallback")
+}
+
+func TestSubmitCheckStatusError_OutOfRange_FailedPrecondition(t *testing.T) {
+	err := fmt.Errorf("door %q: target out of range: 4 hexes, reach 1: %w", "door-1", tkenc.ErrOutOfRange)
+	mapped := submitCheckStatusError(err)
+	st, ok := status.FromError(mapped)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}

--- a/internal/handlers/dnd5e/v2/encounter/submit_check.go
+++ b/internal/handlers/dnd5e/v2/encounter/submit_check.go
@@ -101,6 +101,10 @@ func (h *Handler) SubmitCheck(ctx context.Context, req *encounterv2pb.SubmitChec
 //   - ErrNoPendingPrompt / ErrPromptKindMismatch → FailedPrecondition
 //   - ErrInvalidRoll → InvalidArgument (range disagreement vs the handler bound)
 //   - ErrUnsupportedPromptAction → Unimplemented
+//   - ErrOutOfRange → FailedPrecondition (rpg-api#747: toolkit#864's gate-review
+//     blocker 2 — the actor walked out of reach between AttemptUnlock and
+//     SubmitCheck, so the successful check's dispatch was refused; state-
+//     dependent, not the system-shaped ErrSubmitCheckDispatch bucket below)
 //   - ErrNoCharacterResolver / ErrSubmitCheckDispatch / load+save failures →
 //     Internal
 func submitCheckStatusError(err error) error {
@@ -126,6 +130,8 @@ func submitCheckStatusError(err error) error {
 	case errors.Is(err, encounter.ErrUnsupportedPromptAction):
 		return status.Errorf(codes.Unimplemented,
 			"prompt action not supported in this server version: %v", err)
+	case errors.Is(err, encounter.ErrOutOfRange):
+		return status.Errorf(codes.FailedPrecondition, "target out of reach: %v", err)
 	case errors.Is(err, encounter.ErrNoCharacterResolver):
 		// The handler always wires a resolver (StubCharacterResolver default).
 		// Reaching this means the orchestrator rebuilt the encounter without the

--- a/internal/handlers/dnd5e/v2/encounter/take_action.go
+++ b/internal/handlers/dnd5e/v2/encounter/take_action.go
@@ -134,6 +134,9 @@ func translateActionTarget(target *encounterv2pb.ActionTarget, actorEntityID str
 //     ErrUnknownTarget / ErrNoCombatants → FailedPrecondition (state-dependent;
 //     the toolkit overloads ErrUnknownTarget to also mean missing-monster, so it
 //     maps to FailedPrecondition rather than InvalidArgument)
+//   - ErrOutOfRange → FailedPrecondition (rpg-api#747: toolkit#864's range/reach
+//     gate — target out of the actor's reach/range is a state-dependent refusal,
+//     the same class as the other combat gates above, not a request defect)
 //   - load / save / unclassified failures → Internal
 func takeActionStatusError(err error) error {
 	switch {
@@ -159,7 +162,12 @@ func takeActionStatusError(err error) error {
 		errors.Is(err, tkenc.ErrActionUnaffordable),
 		// ErrActionDeferred: a ref the build surfaces in the menu but does not
 		// resolve yet (e.g. move in Beat 1). State/scope-dependent refusal.
-		errors.Is(err, tkenc.ErrActionDeferred):
+		errors.Is(err, tkenc.ErrActionDeferred),
+		// ErrOutOfRange (rpg-api#747): the target is farther than the attack's
+		// reach/range. Without this case it falls through to the generic
+		// Internal below, which surfaces as an opaque error instead of the
+		// actionable "target out of reach" message.
+		errors.Is(err, tkenc.ErrOutOfRange):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return status.Errorf(codes.Internal, "take action: %v", err)

--- a/internal/integration/dungeon_crypt_test.go
+++ b/internal/integration/dungeon_crypt_test.go
@@ -28,7 +28,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"sort"
 	"testing"
 	"time"
 
@@ -373,10 +372,43 @@ func isHexNeighbor(from, to core.Hex) bool {
 	return false
 }
 
+// walkAdjacentToDoor moves alice to a hex adjacent to doorID before any
+// Interact call (rpg-toolkit#864: OpenDoor/AttemptUnlock now require
+// adjacency). Tries each of the door's 6 neighbors via moveAlongPath until
+// one is reachable — the "wrong side" neighbors (across the still-closed
+// door, potentially in an unexplored/unconnected region) are expected to
+// fail planWalk's BFS; the near-side neighbor succeeds. A no-op if alice is
+// already there (moveAlongPath returns immediately when from == target).
+func (s *DungeonCryptSuite) walkAdjacentToDoor(encounterID, characterID, doorID string) {
+	data, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
+	s.Require().NoError(err)
+	door, ok := data.Doors[core.EntityID(doorID)]
+	s.Require().True(ok, "door %q must exist in the encounter", doorID)
+
+	var walkErr error
+	for _, neighbor := range perception.HexNeighbors(door.Position) {
+		if walkErr = s.moveAlongPath(encounterID, characterID, neighbor, 10); walkErr == nil {
+			return
+		}
+	}
+	s.Require().NoError(walkErr, "no reachable approach hex adjacent to door %q", doorID)
+}
+
 // openCryptDoor uses the existing Interact -> SubmitCheck path when the
 // toolkit-owned crypt connector is locked. It supplies only the d20 roll; the
 // toolkit owns the configured DC, ability, tool, and success side effect.
+//
+// rpg-toolkit#864: Interact (OpenDoor/AttemptUnlock) now requires the actor
+// to be adjacent to the door, so this walks alice there first via
+// walkAdjacentToDoor — she was previously interacting from wherever she
+// happened to be (sometimes her spawn point, hexes away), which is exactly
+// the unvalidated-range shortcut #864 closes. This does not affect any of
+// this suite's sightline/reveal assertions: walking to be ADJACENT to a
+// still-closed door does not grant a sightline PAST it (that still requires
+// the door to open AND a further Move forming line of sight), which is what
+// every "must not reveal" assertion in this file actually depends on.
 func (s *DungeonCryptSuite) openCryptDoor(encounterID, characterID, doorID string) {
+	s.walkAdjacentToDoor(encounterID, characterID, doorID)
 	resp, err := s.srv.EncounterClientV2.Interact(s.authCtx("alice"), &encounterv2pb.InteractRequest{
 		EncounterId: encounterID, TargetEntityId: doorID,
 	})
@@ -442,21 +474,57 @@ func (s *DungeonCryptSuite) TestStartEncounter_SpawnsAtEntrance_ProjectsCanonica
 // production crypt reuses the established unlock flow. The API supplies only
 // the d20 roll; all lock configuration and resolution remain toolkit-owned.
 //
-// The wire-projection half of this test changed under rpg-api-protos#197:
-// this test never moves alice — it Interacts with the boss door directly by
-// id from her entrance spawn, two closed connector doors away. Before this
-// contract, the door's locked state projected onto the wire unconditionally
-// (the same "every viewer's snapshot carries every door regardless of
-// RevealedHexes" leak TestStartEncounter_SpawnsAtEntrance_
-// ProjectsCanonicalCryptDoors's boss-door assertion closes). Now it must NOT
-// appear at all — Interact can resolve a check against a door alice has
-// never seen (that's a server-authoritative mechanic, unaffected by this
-// contract), but the WIRE must not let her observe its lock state remotely.
-// Persisted state (verified directly via EncRepoV2.Get below) is the
-// authoritative proof the failed/successful checks actually did the right
-// thing; the wire assertions only prove they didn't leak.
+// The wire-projection half of this test changed under rpg-api-protos#197,
+// and again under rpg-toolkit#864 (see the KNOWN LIMITATION note on the test
+// itself): originally this test never moved alice at all — it Interacted
+// with the boss door directly by id from her entrance spawn, two closed
+// connector doors away, proving that a door's locked state doesn't leak onto
+// the wire "unconditionally" (the "every viewer's snapshot carries every
+// door regardless of RevealedHexes" leak TestStartEncounter_
+// SpawnsAtEntrance_ProjectsCanonicalCryptDoors's boss-door assertion closes).
+// #864 requires Interact/AttemptUnlock to be adjacency-gated, and adjacency
+// to a door reveals it — so "Interact with a door alice has never seen" is
+// no longer reachable; alice must walk to the door (through the now-open
+// entrance connector) before interacting. Persisted state (verified directly
+// via EncRepoV2.Get below) remains the authoritative proof the failed/
+// successful checks did the right thing; the remaining wire assertion (at
+// spawn, before any movement) is the part of the original wire-leak proof
+// that's still meaningful post-#864.
+// KNOWN LIMITATION (rpg-toolkit#864 rebase, flagged for coordinator review —
+// not resolved unilaterally by this fork): this test's wire-projection half
+// used to prove a door alice had NEVER SEEN could still be Interact-ed
+// (server-authoritative check, no leak onto the wire). rpg-toolkit#864 now
+// requires adjacency for Interact/AttemptUnlock, and adjacency to a door
+// necessarily reveals that door's own hex (confirmed empirically: standing
+// next to the still-locked boss door DOES put its Wall/edge on the wire) —
+// so "attempt a check against a door you've never seen" is no longer a
+// reachable scenario at all, and the original "must not leak even after a
+// failed/successful check attempt" assertions are now testing something
+// that can't happen. This rewrite keeps a genuine wire-leak proof (the boss
+// door is invisible from spawn, before any movement) and keeps the fully
+// unaffected persisted-state assertions (Locked/Open via EncRepoV2.Get), but
+// drops the two "still doesn't leak after interacting" assertions rather
+// than leave them silently vacuous. If the pre-#864 wire-leak-while-
+// unseen contract still matters, closing that gap needs a design call, not
+// a mechanical test fix — flagging rather than deciding.
 func (s *DungeonCryptSuite) TestBossLock_FailedThenSuccessfulCheck_ProjectsPersistedDoorState() {
 	encounterID, characterID, _ := s.startCryptDungeon("boss-lock", "alice")
+
+	// Baseline: from spawn, before any movement, the boss door must not be
+	// on the wire at all — this is the wire-leak proof that's still valid
+	// under #864 (genuinely unseen, not merely "un-interacted-with").
+	spawnProjection, err := s.srv.EncounterClientV2.GetEncounter(s.authCtx("alice"), &encounterv2pb.GetEncounterRequest{EncounterId: encounterID})
+	s.Require().NoError(err)
+	s.Require().Nil(doorEdgeByID(spawnProjection.GetEncounter().GetSpace().GetHexes(), cryptBossDoorID),
+		"the boss door must not project onto the wire from spawn, before alice has ever seen it")
+
+	// rpg-toolkit#864: AttemptUnlock now requires adjacency. The entrance
+	// connector (unlocked, per TestStartEncounter's own assertion) is a
+	// genuine physical blocker between alice's spawn and the boss door —
+	// walkAdjacentToDoor's BFS cannot route through a still-closed door —
+	// so it must be opened first.
+	s.openCryptDoor(encounterID, characterID, cryptEntranceDoorID)
+	s.walkAdjacentToDoor(encounterID, characterID, cryptBossDoorID)
 
 	prompt, err := s.srv.EncounterClientV2.Interact(s.authCtx("alice"), &encounterv2pb.InteractRequest{
 		EncounterId: encounterID, TargetEntityId: cryptBossDoorID,
@@ -478,11 +546,6 @@ func (s *DungeonCryptSuite) TestBossLock_FailedThenSuccessfulCheck_ProjectsPersi
 	s.Require().True(afterFailure.Doors[core.EntityID(cryptBossDoorID)].Locked)
 	s.Require().False(afterFailure.Doors[core.EntityID(cryptBossDoorID)].Open)
 
-	failedProjection, err := s.srv.EncounterClientV2.GetEncounter(s.authCtx("alice"), &encounterv2pb.GetEncounterRequest{EncounterId: encounterID})
-	s.Require().NoError(err)
-	s.Require().Nil(doorEdgeByID(failedProjection.GetEncounter().GetSpace().GetHexes(), cryptBossDoorID),
-		"the still-unseen boss door's locked state must not leak onto the wire, even after a failed check attempt on it")
-
 	_, err = s.srv.EncounterClientV2.Interact(s.authCtx("alice"), &encounterv2pb.InteractRequest{
 		EncounterId: encounterID, TargetEntityId: cryptBossDoorID,
 	})
@@ -497,16 +560,6 @@ func (s *DungeonCryptSuite) TestBossLock_FailedThenSuccessfulCheck_ProjectsPersi
 	s.Require().NoError(err)
 	s.Require().False(afterSuccess.Doors[core.EntityID(cryptBossDoorID)].Locked)
 	s.Require().True(afterSuccess.Doors[core.EntityID(cryptBossDoorID)].Open)
-
-	// Still must not leak: opening the door alone doesn't reveal it, matching
-	// gate fact (4) proved for the boss monster in
-	// TestBossMonster_NoEntityAppeared_UntilBothDoorsOpenAndSightlinesForm —
-	// alice hasn't moved an inch this whole test, so she has no sightline to
-	// the boss door regardless of its now-open state.
-	succeededProjection, err := s.srv.EncounterClientV2.GetEncounter(s.authCtx("alice"), &encounterv2pb.GetEncounterRequest{EncounterId: encounterID})
-	s.Require().NoError(err)
-	s.Require().Nil(doorEdgeByID(succeededProjection.GetEncounter().GetSpace().GetHexes(), cryptBossDoorID),
-		"the now-open boss door still must not leak onto the wire — opening a door doesn't reveal it, sight does")
 }
 
 // TestEntranceSighting_StartsPocketScopedCombat is gate fact (3): a Move
@@ -582,11 +635,6 @@ func (s *DungeonCryptSuite) TestBossMonster_NoEntityAppeared_UntilBothDoorsOpenA
 	bossMonster := bossIDs[0]
 
 	s.Require().Len(encData.Doors, 2, "the crypt spec's 3-region chain has exactly 2 connector doors")
-	doorIDs := make([]string, 0, 2)
-	for id := range encData.Doors {
-		doorIDs = append(doorIDs, string(id))
-	}
-	sort.Strings(doorIDs)
 
 	stream, err := s.srv.EncounterClientV2.StreamEncounter(s.authCtx("alice"),
 		&encounterv2pb.StreamEncounterRequest{EncounterId: encounterID})
@@ -620,17 +668,25 @@ func (s *DungeonCryptSuite) TestBossMonster_NoEntityAppeared_UntilBothDoorsOpenA
 	replay := drainAvailable(events, 500*time.Millisecond)
 	s.Require().False(sawBossMonster(replay), "boss-region monster must not appear in the connect-time replay")
 
-	// Open the first connector door. This alone must NOT reveal the boss
+	// Open the entrance connector first. This alone must NOT reveal the boss
 	// — it is still one closed door and a whole corridor away.
-	s.openCryptDoor(encounterID, characterID, doorIDs[0])
+	//
+	// rpg-toolkit#864: must be opened in PHYSICAL traversal order now
+	// (entrance, then boss) rather than the old alphabetically-sorted
+	// doorIDs[0]/doorIDs[1] — walkAdjacentToDoor's BFS (inside
+	// openCryptDoor) cannot route through a still-closed door, and the
+	// alphabetical sort happened to put the boss door first. Neither
+	// assertion below cares WHICH door is "first", only that opening one
+	// (then both) doesn't leak the boss — unaffected by the reordering.
+	s.openCryptDoor(encounterID, characterID, cryptEntranceDoorID)
 	afterFirstDoor := drainAvailable(events, 500*time.Millisecond)
 	s.Require().False(sawBossMonster(afterFirstDoor),
 		"opening one connector door alone must not reveal the boss-region monster")
 
-	// Open the second connector door too. Both doors open STILL must not
+	// Open the boss connector too. Both doors open STILL must not
 	// reveal the boss by itself — only the doorway's own progressive
 	// reveal (Slice 1), not a whole-region one; a sightline must still form.
-	s.openCryptDoor(encounterID, characterID, doorIDs[1])
+	s.openCryptDoor(encounterID, characterID, cryptBossDoorID)
 	afterSecondDoor := drainAvailable(events, 500*time.Millisecond)
 	s.Require().False(sawBossMonster(afterSecondDoor),
 		"opening both connector doors alone must not reveal the boss-region monster — a sightline must still form")
@@ -680,15 +736,12 @@ func (s *DungeonCryptSuite) TestStaticObstacles_ProjectOnlyWhenRevealedAndRemain
 	events := s.streamEvents(stream)
 	_ = drainAvailable(events, 500*time.Millisecond)
 
-	doorIDs := make([]string, 0, len(encData.Doors))
-	for id := range encData.Doors {
-		doorIDs = append(doorIDs, string(id))
-	}
-	sort.Strings(doorIDs)
-	s.Require().Len(doorIDs, 2)
-	s.openCryptDoor(encounterID, characterID, doorIDs[0])
+	s.Require().Len(encData.Doors, 2)
+	// rpg-toolkit#864: physical traversal order (entrance, then boss), not
+	// an alphabetical sort — see TestBossMonster_...'s identical note.
+	s.openCryptDoor(encounterID, characterID, cryptEntranceDoorID)
 	_ = drainAvailable(events, 500*time.Millisecond)
-	s.openCryptDoor(encounterID, characterID, doorIDs[1])
+	s.openCryptDoor(encounterID, characterID, cryptBossDoorID)
 	_ = drainAvailable(events, 500*time.Millisecond)
 
 	current, err := s.srv.EncRepoV2.Get(s.ctx, encounterID)
@@ -846,14 +899,11 @@ func (s *DungeonCryptSuite) TestSpaceZonesAndHexZoneId_ProjectRegionsOnTheWire()
 	_ = drainAvailable(events, 500*time.Millisecond) // drain connect-time replay
 
 	s.Require().Len(encData.Doors, 2, "the crypt spec's 3-region chain has exactly 2 connector doors")
-	doorIDs := make([]string, 0, 2)
-	for id := range encData.Doors {
-		doorIDs = append(doorIDs, string(id))
-	}
-	sort.Strings(doorIDs)
-	s.openCryptDoor(encounterID, characterID, doorIDs[0])
+	// rpg-toolkit#864: physical traversal order (entrance, then boss), not
+	// an alphabetical sort — see TestBossMonster_...'s identical note.
+	s.openCryptDoor(encounterID, characterID, cryptEntranceDoorID)
 	_ = drainAvailable(events, 500*time.Millisecond)
-	s.openCryptDoor(encounterID, characterID, doorIDs[1])
+	s.openCryptDoor(encounterID, characterID, cryptBossDoorID)
 	_ = drainAvailable(events, 500*time.Millisecond)
 
 	bossMonster := bossIDs[0]

--- a/internal/integration/encounter_v2_test.go
+++ b/internal/integration/encounter_v2_test.go
@@ -898,11 +898,15 @@ func (s *EncounterV2IntegrationSuite) TestStreamEncounter_LiveEventsDoNotDuplica
 // same shape that the toolkit-level test proved.
 func (s *EncounterV2IntegrationSuite) TestInteract_OpenDoor_TwoPlayers() {
 	enc := tkenc.New(context.Background(), "enc-door-1", s.srv.BrokerV2)
-	// SightRange:10 ensures both alice and bob can perceive a door at
-	// distance 4 (per ProjectDoorOpen's visibility check).
+	// rpg-toolkit#864: OpenDoor now requires adjacency, so alice (who
+	// Interacts below) starts adjacent to the door. Bob stays at his
+	// original distance-4 position — SightRange:10 still ensures HE can
+	// perceive the door-open event as a distant viewer (per ProjectDoorOpen's
+	// visibility check), which is this fixture's actual point: a door-open
+	// projects to every in-range viewer, not just the one who opened it.
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: "alice", EntityID: "char-alice",
-		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		Position: core.Hex{Q: 3, R: 0, S: -3}, SightRange: 10,
 	}))
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: "bob", EntityID: "char-bob",
@@ -1024,12 +1028,13 @@ func (s *EncounterV2IntegrationSuite) TestInteract_LockedDoor_PromptAndResolve_T
 	encID := "enc-locked-1"
 
 	// Seed: alice + bob in mutual LoS; one locked door at distance 4 from
-	// both (matches the unlocked-door test fixture so projection logic is
-	// the same).
+	// bob (matches the unlocked-door test fixture so projection logic is
+	// the same). rpg-toolkit#864: AttemptUnlock now requires adjacency, so
+	// alice (who Interacts below) starts adjacent to the door instead.
 	enc := tkenc.New(context.Background(), core.EncounterID(encID), s.srv.BrokerV2)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: "alice", EntityID: "char-alice",
-		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		Position: core.Hex{Q: 3, R: 0, S: -3}, SightRange: 10,
 	}))
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: "bob", EntityID: "char-bob",
@@ -1144,10 +1149,13 @@ func (s *EncounterV2IntegrationSuite) TestInteract_LockedDoor_PromptAndResolve_T
 func (s *EncounterV2IntegrationSuite) TestInteract_LockedDoor_FailedRoll_NoEvents() {
 	encID := "enc-locked-fail"
 
+	// rpg-toolkit#864: AttemptUnlock now requires adjacency, so alice (who
+	// Interacts below) starts adjacent to the door; bob stays distant
+	// (unused by this test's assertions beyond existing as a second member).
 	enc := tkenc.New(context.Background(), core.EncounterID(encID), s.srv.BrokerV2)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: "alice", EntityID: "char-alice",
-		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+		Position: core.Hex{Q: 3, R: 0, S: -3}, SightRange: 10,
 	}))
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: "bob", EntityID: "char-bob",
@@ -1249,8 +1257,11 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_TakeActionAndEndTurn_NPCDi
 	// lethality (Wave 2.10's death suite covers that with killGoblinFixture);
 	// bumping HP keeps the attack/endturn/npc-dispatch loop the actual
 	// subject under test. Closes #520.
+	// rpg-toolkit#864: repositioned to a hex within melee reach (1) of BOTH
+	// alice and bob (a shared neighbor of their two positions) — whichever
+	// one initiative makes active must be able to attack it.
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
-		ID: "goblin-1", Position: core.Hex{Q: 2, R: -1, S: -1},
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 30, MaxHP: 30, AC: 15, Speed: 6,
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
@@ -1481,8 +1492,11 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_KillLastHostile_FiresDeath
 		"alice", "char-alice", core.Hex{Q: 0, R: 0, S: 0})))
 	s.Require().NoError(enc.AddPlayer(killGoblinFixturePlayerInput(
 		"bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0})))
+	// rpg-toolkit#864: repositioned to a hex within melee reach (1) of BOTH
+	// alice and bob (a shared neighbor of their two positions) — whichever
+	// one initiative makes active must be able to attack it.
 	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
-		"goblin-1", core.Hex{Q: 2, R: -1, S: -1})))
+		"goblin-1", core.Hex{Q: 1, R: 0, S: -1})))
 	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice/bob
 	// (sight range 10, no room) already see the goblin(s) just added, so the
 	// encounter self-transitions to TURN_BASED here. An explicit SetMode
@@ -1691,10 +1705,14 @@ func (s *EncounterV2IntegrationSuite) TestCombatSlice_KillOneOfTwoHostiles_NoEnc
 		"alice", "char-alice", core.Hex{Q: 0, R: 0, S: 0})))
 	s.Require().NoError(enc.AddPlayer(killGoblinFixturePlayerInput(
 		"bob", "char-bob", core.Hex{Q: 1, R: -1, S: 0})))
+	// rpg-toolkit#864: both goblins repositioned to the two hexes within
+	// melee reach (1) of BOTH alice and bob (the shared neighbors of their
+	// two positions) — whichever player initiative makes active must be
+	// able to attack whichever goblin is targeted.
 	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
-		"goblin-1", core.Hex{Q: 2, R: -1, S: -1})))
+		"goblin-1", core.Hex{Q: 1, R: 0, S: -1})))
 	s.Require().NoError(enc.AddMonster(killGoblinFixtureMonsterInput(
-		"goblin-2", core.Hex{Q: 3, R: -2, S: -1})))
+		"goblin-2", core.Hex{Q: 0, R: -1, S: 1})))
 	// AddMonster inline-checks combat entry (rpg-toolkit#759): alice/bob
 	// (sight range 10, no room) already see the goblin(s) just added, so the
 	// encounter self-transitions to TURN_BASED here. An explicit SetMode

--- a/internal/integration/lobby_v1alpha1_test.go
+++ b/internal/integration/lobby_v1alpha1_test.go
@@ -24,6 +24,7 @@ import (
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	core "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
 
@@ -290,6 +291,16 @@ func (s *LobbyV1alpha1IntegrationSuite) TestPartyAssembles_FourPlayers_ThenComba
 	}
 	s.Require().NotEmpty(activePlayer, "an active player must be found before TakeAction")
 
+	// rpg-toolkit#864: TakeAction's melee attack now requires the attacker to
+	// be within weapon reach (1 hex, default) of the target — devcombat.Inject
+	// places the goblin at any unoccupied IN-SIGHT position (findVisiblePosition),
+	// not necessarily adjacent to whichever player initiative happens to make
+	// active. Walk the active player to a hex adjacent to the goblin first
+	// (direct toolkit manipulation, matching advanceUntilPlayerActive's own
+	// setup style — this is scaffolding for the #634 assertion below, not
+	// itself under test).
+	s.walkAdjacentToGoblin(data, core.PlayerID(activePlayer), injectOut.GoblinID)
+
 	// The headline #634 proof: TakeAction against the lobby-created,
 	// characterData.Attach-hydrated player must NOT return ErrNonCombatant.
 	// Pre-#634, isPlayerCombatant rejected EVERY lobby-created player because
@@ -339,6 +350,44 @@ func (s *LobbyV1alpha1IntegrationSuite) advanceUntilPlayerActive(data *tkenc.Dat
 		data = enc.ToData()
 	}
 	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, data))
+}
+
+// walkAdjacentToGoblin moves playerID to a hex adjacent to goblinID's
+// CURRENT position via direct toolkit Move + persist (rpg-toolkit#864:
+// TakeAction's melee attack now requires the attacker within weapon reach
+// of the target). Reads the goblin's position fresh from data rather than
+// devcombat.InjectOutput.Position: advanceUntilPlayerActive may have cycled
+// one or more of the goblin's own NPCAct turns first, and its own AI can
+// move it via moveTowardEnemy — using the stale injection-time position
+// intermittently walked the player adjacent to where the goblin USED to be.
+// Reuses dungeon_crypt_test.go's planWalk (same package) to route around
+// the lobby-started room's walls; tries each of the goblin's 6 neighbors
+// until one is reachable. A no-op if the player is already adjacent.
+func (s *LobbyV1alpha1IntegrationSuite) walkAdjacentToGoblin(data *tkenc.Data, playerID core.PlayerID, goblinID core.EntityID) {
+	pd, ok := data.Players[playerID]
+	s.Require().True(ok, "player %q must exist in the encounter", playerID)
+	from := pd.View.Position
+
+	goblin, ok := data.Monsters[goblinID]
+	s.Require().True(ok, "goblin %q must exist in the encounter", goblinID)
+	goblinPos := goblin.Position
+
+	var path []core.Hex
+	var planErr error
+	for _, neighbor := range perception.HexNeighbors(goblinPos) {
+		if neighbor == from {
+			return // already adjacent
+		}
+		if path, planErr = planWalk(data.Space, data.Doors, from, neighbor); planErr == nil {
+			break
+		}
+	}
+	s.Require().NoError(planErr, "no reachable hex adjacent to the injected goblin at %+v", goblinPos)
+
+	enc, err := tkenc.LoadFromData(s.ctx, data, s.srv.BrokerV2, tkenc.WithCombatResolver(testStandInResolver{}))
+	s.Require().NoError(err)
+	s.Require().NoError(enc.Move(playerID, path))
+	s.Require().NoError(s.srv.EncRepoV2.Save(s.ctx, enc.ToData()))
 }
 
 // TestPartyAssembles_FourPlayers_ThenCombatEntry_NPCFirstInitiative_StreamDrivesNPCTurn

--- a/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
@@ -15,23 +15,45 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
-// MoveEntity NPC-first combat-entry regression (rpg-api#659): a sighted Move
-// that flips FREE_ROAM -> TURN_BASED with a monster winning initiative must
-// drive that monster's turn ITSELF — it must not depend on a later
-// StreamEncounter/GetEncounter connect providing the #636 self-heal kick
-// (DriveStalledNPCTurn) to un-stall it. Before the fix, MoveEntity persisted
-// right after enc.Move() without checking whether the mode transition it just
-// triggered left an NPC active, so the encounter would sit there until some
-// client (re)connected — exactly the issue's repro ("goblin wins initiative,
-// don't refresh, watch it hang").
+// MoveEntity NPC-first combat-entry regression (rpg-api#659): when the active
+// actor in a TURN_BASED encounter is an NPC, MoveEntity must drive that NPC's
+// turn ITSELF — it must not depend on a later StreamEncounter/GetEncounter
+// connect providing the #636 self-heal kick (DriveStalledNPCTurn) to un-stall
+// it. Before the fix, MoveEntity persisted right after enc.Move() without
+// checking whether the encounter's active actor was an NPC, so the encounter
+// would sit there until some client (re)connected — exactly the issue's
+// repro ("goblin wins initiative, don't refresh, watch it hang").
 //
-// This exercises the REAL trigger path the toolkit uses for combat entry
-// (Move -> checkCombatEntry -> SetMode -> rollInitiative), not a hand-seeded
-// post-roll Initiative/ActiveIdx (which would bypass the very code path this
-// bug lives in). A forced-constant dice.Roller (Config.Roller, rpg-api#659)
-// makes every rollInitiative d20 call tie, so the sort's ascending-id
-// tiebreak deterministically puts the goblin first on every run — no retries,
-// no flake.
+// rpg-toolkit#864/#867 rebase note: the ORIGINAL version of this test
+// constructed the goblin-wins-initiative state via a Move that itself
+// triggered checkCombatEntry (zoe walking into the goblin's sight range).
+// rpg-toolkit#867 forces the entity whose OWN action triggers a
+// FreeRoam->TurnBased transition into initiative slot 0 regardless of its
+// roll — so a player's Move can no longer produce "the monster won
+// initiative" outcome; the trigger (the mover) is always first by design now.
+// That vector is gone for good, not flaky — #867 is an explicit
+// creative-director ruling (toolkit#865), not a bug.
+//
+// The #659 regression this test guards against is still very much
+// reachable, just via a DIFFERENT combat-entry vector #867 deliberately
+// leaves untouched: AddMonster (a monster becoming visible/added has no
+// acting player to privilege into slot 0, so it stays plain roll order,
+// ascending-id tiebreak, exactly as before #867). This test's setup now
+// constructs the stalled state directly via an AddMonster-triggered entry
+// (the goblin is added already within the player's sight range, so
+// AddMonster's own inline checkCombatEntry call fires immediately,
+// unattributed, and the goblin wins the tie) — then exercises MoveEntity
+// with an ORDINARY subsequent move (one that doesn't itself need to trigger
+// anything, since combat is already active) to prove MoveEntity's post-Move
+// check still drives whatever NPC currently holds the active slot, not just
+// one a Move JUST revealed. This preserves the original bug's shape (a
+// stalled NPC-first turn, un-stalled without a reconnect) through the one
+// vector #867 didn't close off.
+//
+// A forced-constant dice.Roller (Config.Roller, rpg-api#659) makes every
+// rollInitiative d20 call tie, so the sort's ascending-id tiebreak
+// deterministically puts the goblin first on every run — no retries, no
+// flake.
 
 const (
 	mfEncID     = "enc-move-npc-first"
@@ -113,12 +135,18 @@ func (s *MoveEntityNPCFirstSuite) SetupTest() {
 	s.orch = orch
 }
 
-// seedFreeRoamOutOfSight persists a FREE_ROAM encounter with zoe far enough
-// from the goblin (hex distance 20 > sight range 10) that combat has NOT yet
-// started at seed time — the encounter only flips to TURN_BASED once zoe's
-// own Move closes the distance below her sight range, exercising
-// checkCombatEntry for real rather than asserting against hand-seeded state.
-func (s *MoveEntityNPCFirstSuite) seedFreeRoamOutOfSight() {
+// seedTurnBasedGoblinFirstStalled persists a TURN_BASED encounter where the
+// goblin already won initiative and nothing has driven its turn yet — the
+// exact stalled state rpg-api#659 guards against, constructed via an
+// AddMonster-triggered combat entry (see this file's doc comment for why:
+// rpg-toolkit#867 makes a Move-triggered "monster wins initiative" outcome
+// impossible by design, but AddMonster-triggered entry stays plain roll
+// order/ascending-id tiebreak, unaffected by #867's trigger-attribution
+// rule). The goblin is added ALREADY within zoe's sight range, so
+// AddMonster's own inline checkCombatEntry call fires immediately as part of
+// this seed step, with no acting player to attribute — the goblin's
+// constant-rolled tie is broken by ascending id, and it wins.
+func (s *MoveEntityNPCFirstSuite) seedTurnBasedGoblinFirstStalled() {
 	enc := tkenc.New(s.ctx, core.EncounterID(mfEncID), s.broker)
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID:   mfPlayerZoe,
@@ -135,9 +163,12 @@ func (s *MoveEntityNPCFirstSuite) seedFreeRoamOutOfSight() {
 		MaxHP: 50,
 		AC:    14,
 	}))
+	// Within sight range (hex distance 5 <= sightRange 10) — AddMonster's own
+	// inline combat-entry check (no trigger entity, per rpg-toolkit#867's doc
+	// comment on AddMonster) fires here, at seed time, plain roll order.
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
 		ID:          mfGoblinID,
-		Position:    core.Hex{Q: 20, R: 0, S: -20},
+		Position:    core.Hex{Q: 5, R: 0, S: -5},
 		HP:          7,
 		MaxHP:       7,
 		AC:          15,
@@ -153,35 +184,44 @@ func (s *MoveEntityNPCFirstSuite) seedFreeRoamOutOfSight() {
 // --- the headline fix ---
 
 func (s *MoveEntityNPCFirstSuite) TestMoveEntity_NPCFirstCombatEntry_DrivesGoblinTurnWithoutReconnect() {
-	s.seedFreeRoamOutOfSight()
+	s.seedTurnBasedGoblinFirstStalled()
 
-	// Move zoe to within sight range (hex distance 9 <= sightRange 10) of the
-	// goblin. This is the exact repro shape from rpg-api#659: a sighted Move
-	// that itself triggers combat entry, with the monster winning initiative.
+	preLoad, getErr := s.repo.Get(s.ctx, mfEncID)
+	s.Require().NoError(getErr)
+	s.Require().Equal(core.ModeTurnBased, preLoad.Mode,
+		"test premise: AddMonster's inline combat-entry check must have already flipped to TURN_BASED")
+	s.Require().NotEmpty(preLoad.Initiative, "initiative must have rolled")
+	s.Require().Equal(core.EntityID(mfGoblinID), preLoad.Initiative[0],
+		"sanity check on the test setup: the constant roller's tiebreak must have put the goblin first")
+	s.Require().Equal(core.EntityID(mfGoblinID), preLoad.Initiative[preLoad.ActiveIdx],
+		"test premise: the goblin's turn is stalled — nothing has driven it yet")
+
+	// zoe takes an ORDINARY move — nothing about this move needs to reveal or
+	// trigger anything new (combat is already active from the seed step).
+	// Move has no turn-order gate of its own (unlike TakeAction/EndTurn), and
+	// zoe carries no hydrated character/economy in this fixture, so this
+	// succeeds regardless of whose turn it nominally is. The point being
+	// proven: MoveEntity's post-Move check (o.driveNPCChain, keyed on
+	// whatever enc.ActiveActor() is AFTER Move, not on whether THIS Move
+	// caused a transition) drives the already-stalled goblin turn.
 	out, err := s.orch.MoveEntity(s.ctx, &encounterorch.MoveEntityInput{
 		EncounterID: mfEncID,
 		PlayerID:    mfPlayerZoe,
 		EntityID:    mfEntityZoe,
 		Path: []core.Hex{
-			{Q: 0, R: 0, S: 0},
-			{Q: 11, R: 0, S: -11},
+			{Q: 1, R: 0, S: -1},
 		},
 	})
-	s.Require().NoError(err, "the sighted move that triggers combat entry must succeed")
+	s.Require().NoError(err, "the ordinary move must succeed")
 	s.Require().NotNil(out)
-
-	loaded, getErr := s.repo.Get(s.ctx, mfEncID)
-	s.Require().NoError(getErr)
-	s.Require().Equal(core.ModeTurnBased, loaded.Mode, "the move must have triggered combat entry")
-	s.Require().NotEmpty(loaded.Initiative, "initiative must have rolled")
-	s.Require().Equal(core.EntityID(mfGoblinID), loaded.Initiative[0],
-		"sanity check on the test setup: the constant roller's tiebreak must have put the goblin first")
 
 	// The headline assertion: MoveEntity alone — no DriveStalledNPCTurn call,
 	// no StreamEncounter/GetEncounter connect anywhere in this test — must have
 	// already driven the goblin's turn to completion and advanced the active
 	// actor to zoe. Before the #659 fix, the active actor would still be the
 	// goblin here, stalled forever until some client reconnected.
+	loaded, getErr := s.repo.Get(s.ctx, mfEncID)
+	s.Require().NoError(getErr)
 	s.Equal(core.EntityID(mfEntityZoe), loaded.Initiative[loaded.ActiveIdx],
 		"MoveEntity itself must drive the goblin's turn — the active actor must already be the player, with zero reconnects")
 }

--- a/internal/orchestrators/encounter/v2/submit_check.go
+++ b/internal/orchestrators/encounter/v2/submit_check.go
@@ -54,7 +54,8 @@ var (
 	// orchestrator joins them with this sentinel so the handler maps them to
 	// codes.Internal without string matching. The recognized toolkit sentinels
 	// (ErrNoPendingPrompt / ErrPromptKindMismatch / ErrInvalidRoll /
-	// ErrUnsupportedPromptAction / ErrNoCharacterResolver) pass through unwrapped.
+	// ErrUnsupportedPromptAction / ErrNoCharacterResolver / ErrOutOfRange) pass
+	// through unwrapped.
 	ErrSubmitCheckDispatch = errors.New("submit check dispatch failed")
 )
 
@@ -104,13 +105,23 @@ func (o *Orchestrator) SubmitCheck(ctx context.Context, in *SubmitCheckInput) (*
 // effect failed" cases — which the toolkit returns as plain fmt.Errorf — are
 // joined with ErrSubmitCheckDispatch so the handler maps them to Internal
 // without string matching.
+//
+// ErrOutOfRange (rpg-api#747, toolkit#864's gate-review blocker 2): dispatching
+// a successful skill check's TriggeredAction re-checks reach before opening the
+// door — a player who walked away between AttemptUnlock and SubmitCheck fails
+// here, wrapping ErrOutOfRange. Recognized like the other toolkit sentinels
+// (not folded into the generic ErrSubmitCheckDispatch bucket) so the handler
+// can map it to FailedPrecondition instead of Internal — this is a
+// state-dependent refusal (the actor moved), not a system-shaped dispatch
+// failure.
 func wrapSubmitCheckErr(err error) error {
 	switch {
 	case errors.Is(err, tkenc.ErrNoPendingPrompt),
 		errors.Is(err, tkenc.ErrPromptKindMismatch),
 		errors.Is(err, tkenc.ErrInvalidRoll),
 		errors.Is(err, tkenc.ErrUnsupportedPromptAction),
-		errors.Is(err, tkenc.ErrNoCharacterResolver):
+		errors.Is(err, tkenc.ErrNoCharacterResolver),
+		errors.Is(err, tkenc.ErrOutOfRange):
 		return err
 	}
 	return fmt.Errorf("%w: %w", ErrSubmitCheckDispatch, err)


### PR DESCRIPTION
Fixes #747.

## What this PR does

1. **Bumps `rpg-toolkit/encounter` v0.46.3 → v0.46.5**, bringing in toolkit#867 (combat-trigger-first initiative ordering, fixes toolkit#865) and toolkit#868 (action range/reach gate, fixes toolkit#864).
2. **Maps the new `ErrOutOfRange` sentinel to `codes.FailedPrecondition`** at all three call sites that can see it: `take_action.go`, `end_turn.go`, and `submit_check.go` (handler + orchestrator layers) — closing this issue.
3. **Fixes test fallout from the bump** — both the range gate and the trigger-first ordering changed real, previously-passing behavior in a handful of existing rpg-api fixtures. Full breakdown below.

## Full delta (toolkit v0.44.1 → v0.46.5)

The version jump isn't just our two fixes — it carries about a week of other encounter-module work. For visibility into everything landing in `dev` with this bump:

- **#868** `fix(encounter): gate action resolution on range/reach` — the flagship fix this issue exists to support. Doors/attacks now validate hex distance against reach/range; previously unvalidated.
- **#867** `fix(encounter): force combat-entry trigger into initiative slot 0` — the entity whose own action (Move, or walking through a just-opened door) triggers a FreeRoam→TurnBased transition is now always placed first in initiative, regardless of its own roll. AddMonster/SeedMonsters-triggered entries are unaffected (plain roll order — no acting player to attribute). **This PR's own test fallout includes a case caused by this change**, not just the range gate — see "rpg-api#659 regression test re-pointed" below.
- **#863** `fix(encounter): MoveEvent carries the mover's own post-move knowledge`
- **#861** `fix(encounter): stop recording a mover on every hex a viewer saw them cross`
- **#860** `fix(encounter): confine viewer memory to hexes that belong to the space`
  — these three are a single fix chain for the per-viewer hex-knowledge/fog-of-war system introduced in #857 (below): a viewer's stored "what have I seen" memory was recording hexes outside the room's own bounds and over-recording a moving entity's trail. **Genuine behavior change to what gets sent to clients as remembered/visible hexes** — the one part of this delta besides #867/#868 that isn't purely additive. Landed 2026-07-26–27; the 2026-07-30 QA walk that found #864/#865/#866 ran against a build that already included this chain, so it's had at least one real playtest pass, but it hasn't had a *dedicated* dev-walk the way #864/#865 are getting now — worth keeping an eye on if anything fog-of-war-shaped comes up.
- **#857** `feat(encounter): persist per-viewer hex knowledge as observations, not bare coordinates` — the fog-of-war redesign the #860/#861/#863 chain above fixes follow-on bugs in.
- **#855** `feat(encounter): extend crypt prop vocabulary with 9 wave-1 promotion refs` — new named obstacle refs (rug, wall-banner, candle-stand, etc.) for asset promotion. Additive vocabulary, no logic change.

## The mapping fix (rpg-api#747)

- `internal/handlers/dnd5e/v2/encounter/take_action.go` (`takeActionStatusError`): added `tkenc.ErrOutOfRange` to the existing state-dependent `FailedPrecondition` case group (alongside `ErrNotTurnBased`, `ErrNonCombatant`, etc.) — the orchestrator already surfaces toolkit sentinels unwrapped here, so no orchestrator-layer change was needed.
- `internal/handlers/dnd5e/v2/encounter/end_turn.go` (`endTurnStatusError`): added a `tkenc.ErrOutOfRange` case → `FailedPrecondition`. Worth noting: `driveNPCChain` (the orchestrator's NPC dispatch loop) wraps any non-reaction-pause `NPCAct` error behind `ErrNPCAct` via a double-`%w` `fmt.Errorf`, and Go's `errors.Is` traverses every wrapped error in the chain — so this case still matches even though the same error also satisfies `errors.Is(err, ErrNPCAct)`. In practice this path is **defense-in-depth, not a live bug fix**: toolkit#868's gate-review found that an out-of-reach `NPCAct` target used to hard-error and permanently wedge the encounter (the turn could never advance since `driveNPCChain` only calls `EndTurn` after a *successful* `NPCAct`), so the toolkit fix made out-of-reach a no-op (skip the turn / skip the attack) rather than an error. `ErrOutOfRange` shouldn't actually propagate out of `NPCAct` anymore — this mapping guards against a future regression reintroducing it, per #747's original ask to cover this call site regardless.
- `internal/orchestrators/encounter/v2/submit_check.go` (`wrapSubmitCheckErr`) + `internal/handlers/dnd5e/v2/encounter/submit_check.go` (`submitCheckStatusError`): added `ErrOutOfRange` to the recognized-sentinel list (passed through unwrapped by the orchestrator) and a `FailedPrecondition` case in the handler. This call site wasn't named in the original #747 issue text — it surfaced from toolkit#868's gate-review **blocker 2** (a free-unlock bypass: `dispatchPromptAction` used to clear a door's `Locked` flag before calling the now-fallible `OpenDoor`, with no reach re-check at `SubmitCheck` time — fixed toolkit-side by re-checking reach before committing `Locked = false`). Without this mapping, a player who walks away mid-unlock-attempt would see `codes.Internal` instead of the actionable "you're out of reach" refusal.

TDD: `internal/handlers/dnd5e/v2/encounter/out_of_range_mapping_internal_test.go` (new, white-box, `package encounter`) — one test per call site, each constructing a wrapped `ErrOutOfRange` (the `end_turn.go` one mirrors `driveNPCChain`'s actual double-`%w` wrap shape) and asserting `codes.FailedPrecondition`. Verified RED→GREEN: stashed the three mapping diffs, confirmed all three tests fail with `codes.Internal` (0xd) instead of `codes.FailedPrecondition` (0x9), restored the fix, confirmed green.

## rpg-api#659 regression test re-pointed

`internal/orchestrators/encounter/v2/move_entity_npc_first_test.go` (`TestMoveEntity_NPCFirstCombatEntry_DrivesGoblinTurnWithoutReconnect`) constructed its "goblin wins initiative and stalls" scenario via a player Move that itself triggered `checkCombatEntry` — but toolkit#867 now **forces the entity whose own action triggers combat into initiative slot 0**, so that exact vector can no longer produce "the monster won initiative" (the trigger, not the monster, always goes first now — an explicit creative-director ruling on toolkit#865, not a bug). The #659 regression itself — a stalled NPC-first turn silently waiting for a reconnect — is still fully reachable via the one trigger vector #867 deliberately leaves untouched: `AddMonster` (no acting player to attribute, so it stays plain roll order). Re-pointed the test's setup to construct the stalled state via an AddMonster-triggered entry, then exercise `MoveEntity` with an ordinary follow-up move to prove its post-Move check still drives whatever NPC currently holds the active slot — every original assertion (goblin wins the tiebreak, `MoveEntity` alone drives its turn to completion, zero reconnects) is preserved unchanged in substance. Doc comment on the test explains the vector change in detail.

## Range-gate test fallout (toolkit#864, the flagship fix)

Same class of fixture repair as toolkit PR #868 made in the toolkit repo itself: several existing rpg-api integration/handler tests called `TakeAction`/`OpenDoor`/`AttemptUnlock` from unrealistic distances (exploiting the previously-nonexistent validation as a testing shortcut). Fixed by repositioning attacker/interactor within reach — no assertions weakened, no test intent changed:

- **`internal/integration/dungeon_crypt_test.go`** (`TestDungeonCryptSuite`, 4 subtests) — added a `walkAdjacentToDoor` helper (BFS over the door's 6 neighbors via the real `MoveEntity` path) that `openCryptDoor` now calls before every `Interact`. `TestBossMonster_NoEntityAppeared_UntilBothDoorsOpenAndSightlinesForm` additionally needed its two connector doors opened in **physical traversal order** (entrance, then boss) instead of the old alphabetically-sorted `doorIDs[0]/doorIDs[1]` — the boss door's id happens to sort first alphabetically, but it's unreachable until the entrance door (which sits between spawn and it) is open; neither assertion cares *which* door is "first," only that opening one/both doesn't leak the boss, so the reorder doesn't change what's being proven.
  - **Behavior-contract note for Kirk**: `TestBossLock_FailedThenSuccessfulCheck_ProjectsPersistedDoorState` originally proved a door alice had *never seen* could still be `Interact`-ed (a server-authoritative check with no wire leak). Adjacency-gating `Interact` necessarily reveals the door's own hex first (confirmed empirically — standing next to a still-locked door puts its wall/edge on the wire), so "attempt a check against a door you've never seen" is no longer a reachable scenario at all post-toolkit#864. The rewrite keeps a genuine wire-leak proof (the boss door is invisible from spawn, before any movement) and keeps the fully-unaffected persisted-state assertions (`Locked`/`Open` via direct repo read), but drops the two "still doesn't leak after interacting" assertions rather than leave them silently vacuous testing something impossible. Flagged in the test's own doc comment as a KNOWN LIMITATION, not resolved unilaterally — if the pre-#864 "never-seen door doesn't leak" contract still matters to the product, closing that gap is a design call, not a mechanical test fix.
- **`internal/integration/encounter_v2_test.go`** (`TestEncounterV2IntegrationSuite`, 5 subtests) — `TestInteract_OpenDoor_TwoPlayers` and both `TestInteract_LockedDoor_*` tests: repositioned alice (the interacting player) to be adjacent to `door-east` at seed time instead of 4 hexes away; bob's own distance-4 line-of-sight to the door (the actual thing those tests verify — that a second viewer in LoS also receives `DoorOpened`) is untouched. `TestCombatSlice_KillLastHostile_FiresDeathChainAndEnds` and `TestCombatSlice_KillOneOfTwoHostiles_NoEncounterEnd`: repositioned the attacking player adjacent to their target monster (previously 2 and 3 hexes away respectively) so the kill-chain/encounter-end assertions those tests actually check are reached at all.
- **`internal/handlers/dnd5e/v2/encounter/integration_sneak_attack_test.go`** (`TestSneakAttackIntegrationL1Suite` + `TestSneakAttackIntegrationSuite`, 6 subtests each, 12 total) — both suites share `seedSneakEncounter`: alice (the rogue, hydrated with an equipped shortsword — melee, no Reach property) was 2 hexes from the goblin while bob (the ally, load-bearing for Sneak Attack's ally-adjacent-to-target rule) was correctly 1 hex away. Moved the goblin to `{Q:1, R:-1, S:0}` — a common hex neighbor of both alice `{0,0,0}` and bob `{1,0,-1}` — so both are within 1 hex simultaneously; bob's adjacency (the actual rule under test) is preserved exactly.
- **`internal/handlers/dnd5e/v2/encounter/combat_handlers_test.go`** — `TestTakeAction_AttackHappyPath_PersistsMonsterHP` was a **latent flake, not a deterministic failure**: `seedCombatEncounter`'s goblin was adjacent to bob but 2 hexes from alice, and this fixture uses a real (non-fixed) roller, so whichever player won initiative attacked — alice winning meant an out-of-range attack that used to silently succeed and now correctly fails. Repositioned the goblin to the same common-neighbor hex `{Q:1, R:-1, S:0}` used above, so either player's attack is in range regardless of who goes first. Verified with 8 repeated `-count=1` runs post-fix (no fixed roller, so this is the only way to build confidence against the flake) — all green.
- **`internal/integration/lobby_v1alpha1_test.go`** (`TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves`) — added a `walkAdjacentToGoblin` helper: the lobby-injected goblin lands at whatever unoccupied in-sight hex `devcombat.Inject`'s placement picks, not necessarily near whichever player initiative makes active. Walks the active player adjacent via a direct toolkit `Move` + persist before the `TakeAction` under test. One subtlety the helper handles explicitly: it reads the goblin's position **freshly from data**, not from the injection-time output, because `advanceUntilPlayerActive` may have already cycled one or more of the goblin's own `NPCAct` turns first, and monster AI can move it via `moveTowardEnemy` — walking toward the stale injection-time position intermittently missed. Verified with `-count=20`, all green.

## Test evidence

- Full `go test ./...` on the assembled tree: **all green** (every package, including `internal/integration`, `internal/integration/character`, `internal/integration/harness`, `internal/orchestrators/encounter/v2`, `internal/handlers/dnd5e/v2/encounter`).
- `golangci-lint run ./...`: diffed against a clean `origin/dev` baseline (stashed including untracked files to keep the comparison valid) — **29 issues before, 29 after, identical set** (the one line-number shift is the same pre-existing `findEntityDamaged is unused` finding, unmoved in substance, just shifted by the sneak-attack fixture's added comment lines above it). Zero new lint issues from this PR.
- `gofmt -l .`: clean.
- The three new `out_of_range_mapping_internal_test.go` mapping tests: RED→GREEN verified (see above).
- `TestTakeAction_AttackHappyPath_PersistsMonsterHP`: 8/8 repeated runs green post-fix (real roller, no fixed seed — this is the practical confidence bound for a test with genuine randomness).
- `TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves`: 20/20 repeated runs green post-fix.

— asset-pipeline agent, on behalf of KirkDiggler
