### PR TITLE
Dungeon Builder: wire dungeon_key on StartEncounter

### DIFF
--- a/internal/handlers/dnd5e/lobby/v1alpha1/handler_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/handler_test.go
@@ -36,6 +36,7 @@ type HandlerSuite struct {
 	ctrl      *gomock.Controller
 	charRepo  *charactermock.MockRepository
 	lobbyRepo lobbyrepo.Repository
+	encRepo   encountersv2.Repository
 	broker    *lobbyorch.Broker
 	handler   *lobbyhandler.Handler
 }
@@ -53,11 +54,12 @@ func (s *HandlerSuite) SetupTest() {
 	registry, err := lobbyorch.LoadContentRegistry()
 	s.Require().NoError(err)
 
+	s.encRepo = encountersv2.NewInMemory()
 	orch, err := lobbyorch.New(&lobbyorch.Config{
 		LobbyRepo:              s.lobbyRepo,
 		LobbyBroker:            s.broker,
 		CharacterRepo:          s.charRepo,
-		EncounterRepo:          encountersv2.NewInMemory(),
+		EncounterRepo:          s.encRepo,
 		EncounterBroker:        tkenc.NewBroker(tkenc.NewInMemoryTransport()),
 		BuildCharacterResolver: func(_ *tkenc.Data) tkenc.CharacterResolver { return encounterhandlerv2.StubCharacterResolver{} },
 		BuildCombatResolver: func(_ *tkenc.Data) tkenc.CombatResolver {

--- a/internal/handlers/dnd5e/lobby/v1alpha1/start_encounter.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/start_encounter.go
@@ -30,6 +30,12 @@ func (h *Handler) StartEncounter(
 	out, err := h.orch.StartEncounter(ctx, &lobbyorch.StartEncounterInput{
 		PlayerID: playerID,
 		LobbyID:  req.GetLobbyId(),
+		// DungeonKey selects which authored dungeon to build from (S0,
+		// rpg-api-protos v0.1.115). Empty leaves the orchestrator's
+		// existing caller -> env -> default precedence (effectiveKey,
+		// start_encounter.go) exactly as it was before this field
+		// existed — additive, every pre-S2 caller unaffected.
+		DungeonKey: lobbyorch.DungeonKey(req.GetDungeonKey()),
 	})
 	if err != nil {
 		return nil, lobbyStatusError(err)

--- a/internal/handlers/dnd5e/lobby/v1alpha1/start_encounter_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/start_encounter_test.go
@@ -60,3 +60,62 @@ func (s *HandlerSuite) TestStartEncounter_Success_ReturnsEncounterID() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(resp.GetEncounterId())
 }
+
+// TestStartEncounter_DungeonKeyFromRequest_SelectsReferenceTomb is S2's
+// headline proof: StartEncounterRequest.dungeon_key (on the wire since S0,
+// rpg-api-protos v0.1.115) must actually reach StartEncounterInput.DungeonKey
+// — the orchestrator's own precedence logic (effectiveKey,
+// start_encounter.go:109-121) and content-key resolution are already fully
+// tested at the orchestrator layer (start_encounter_test.go's
+// TestStartEncounter_DungeonKeyOverride_* suite); this test proves ONLY the
+// one-line handler wiring this slice adds. Uses the embedded reference-tomb
+// key (not S1's uploaded "smoke-test" key) so this test stands alone with
+// no RPG_CONTENT_DIR override needed. Distinguishing signal is structural,
+// not a region count (reference-tomb and the legacy crypt default both
+// compile to 3 regions): only reference-tomb emits a chamber-archetype
+// "hall" region — the crypt template never does (verified against
+// tkenc's own crypt_dungeon.go).
+func (s *HandlerSuite) TestStartEncounter_DungeonKeyFromRequest_SelectsReferenceTomb() {
+	lobbyID, _ := s.createLobby("alice", "char-alice", "Alice")
+	_, err := s.handler.SetReady(s.ctx, &lobbyv1alpha1.SetReadyRequest{LobbyId: lobbyID, Ready: true})
+	s.Require().NoError(err)
+
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+	resp, err := s.handler.StartEncounter(s.ctx, &lobbyv1alpha1.StartEncounterRequest{
+		LobbyId: lobbyID, DungeonKey: "reference-tomb",
+	})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, resp.GetEncounterId())
+	s.Require().NoError(err)
+	s.Require().Len(encData.Space.Regions, 3)
+	var sawHall bool
+	for _, r := range encData.Space.Regions {
+		if r.ID == "hall" {
+			sawHall = true
+		}
+	}
+	s.Require().True(sawHall, "reference-tomb (not the legacy crypt default) must have been selected")
+}
+
+// TestStartEncounter_EmptyDungeonKey_UsesLegacyDefault proves the additive
+// half of S0's dungeon_key field: an empty (unset) dungeon_key must leave
+// StartEncounterInput.DungeonKey at the zero value, exactly like every
+// caller before this field existed — the legacy crypt default (entrance/
+// corridor/boss, no chamber-archetype region) must still be what gets
+// built, not a decode of "" into some other key.
+func (s *HandlerSuite) TestStartEncounter_EmptyDungeonKey_UsesLegacyDefault() {
+	lobbyID, _ := s.createLobby("alice", "char-alice", "Alice")
+	_, err := s.handler.SetReady(s.ctx, &lobbyv1alpha1.SetReadyRequest{LobbyId: lobbyID, Ready: true})
+	s.Require().NoError(err)
+
+	s.expectCharacter("char-alice", "alice", "Alice", 12, 12)
+	resp, err := s.handler.StartEncounter(s.ctx, &lobbyv1alpha1.StartEncounterRequest{LobbyId: lobbyID})
+	s.Require().NoError(err)
+
+	encData, err := s.encRepo.Get(s.ctx, resp.GetEncounterId())
+	s.Require().NoError(err)
+	for _, r := range encData.Space.Regions {
+		s.Assert().NotEqual("hall", r.ID, "an empty dungeon_key must not accidentally select reference-tomb")
+	}
+}

--- a/internal/handlers/dnd5e/lobby/v1alpha1/start_encounter_test.go
+++ b/internal/handlers/dnd5e/lobby/v1alpha1/start_encounter_test.go
@@ -103,7 +103,12 @@ func (s *HandlerSuite) TestStartEncounter_DungeonKeyFromRequest_SelectsReference
 // StartEncounterInput.DungeonKey at the zero value, exactly like every
 // caller before this field existed — the legacy crypt default (entrance/
 // corridor/boss, no chamber-archetype region) must still be what gets
-// built, not a decode of "" into some other key.
+// built, not a decode of "" into some other key. Asserts the crypt
+// template's own "corridor" region is actually PRESENT (rpg-toolkit's
+// crypt_dungeon.go: cryptRegionIDCorridor = "corridor"), not just that
+// "hall" is absent — a positive assertion many wrong outcomes (an error,
+// an empty Space, some other unrelated content key) would also satisfy
+// the weaker absence-only check.
 func (s *HandlerSuite) TestStartEncounter_EmptyDungeonKey_UsesLegacyDefault() {
 	lobbyID, _ := s.createLobby("alice", "char-alice", "Alice")
 	_, err := s.handler.SetReady(s.ctx, &lobbyv1alpha1.SetReadyRequest{LobbyId: lobbyID, Ready: true})
@@ -115,7 +120,15 @@ func (s *HandlerSuite) TestStartEncounter_EmptyDungeonKey_UsesLegacyDefault() {
 
 	encData, err := s.encRepo.Get(s.ctx, resp.GetEncounterId())
 	s.Require().NoError(err)
+	var sawCorridor, sawHall bool
 	for _, r := range encData.Space.Regions {
-		s.Assert().NotEqual("hall", r.ID, "an empty dungeon_key must not accidentally select reference-tomb")
+		switch r.ID {
+		case "corridor":
+			sawCorridor = true
+		case "hall":
+			sawHall = true
+		}
 	}
+	s.Require().True(sawCorridor, "the legacy crypt default's own \"corridor\" region must be present")
+	s.Assert().False(sawHall, "an empty dungeon_key must not accidentally select reference-tomb")
 }


### PR DESCRIPTION
Implements S2 of the Dungeon Builder arc: wires `StartEncounterRequest.dungeon_key`
(on the wire since S0, rpg-api-protos v0.1.115) through to
`StartEncounterInput.DungeonKey`. This closes the substitution caveat S1 could not
prove on its own — `StartEncounter` can now actually be pointed at an
authored/uploaded key, and the caller→env→default precedence logic that already
existed (`start_encounter.go`'s `effectiveKey`) is finally reachable from a real
proto surface.

Closes #751
Design: KirkDiggler/rpg-project#170
Plan: KirkDiggler/rpg-project#169 (S2 section)

## What changed

One-line handler wiring in `internal/handlers/dnd5e/lobby/v1alpha1/start_encounter.go`:
`req.GetDungeonKey()` now populates `StartEncounterInput.DungeonKey`. Everything
else — precedence (per-lobby key > `RPG_DUNGEON_KEY` env override > legacy
default), content-key resolution, disabled-key handling — was already fully
implemented and tested at the orchestrator layer before this slice; nothing
there changed.

Two new handler-level tests (`start_encounter_test.go`) prove the wiring itself,
using the embedded `reference-tomb` key so they stand alone with no
`RPG_CONTENT_DIR` override needed:
- `TestStartEncounter_DungeonKeyFromRequest_SelectsReferenceTomb` — a request
  with `dungeon_key: "reference-tomb"` must build reference-tomb's geometry
  (distinguishing signal: only reference-tomb's compiled Space has a
  chamber-archetype `"hall"` region — the legacy crypt default never does).
- `TestStartEncounter_EmptyDungeonKey_UsesLegacyDefault` — an empty
  `dungeon_key` must still resolve to the legacy crypt default, unchanged.

`HandlerSuite` (`handler_test.go`) gained `encRepo` visibility so tests can
inspect the resulting encounter's `Space` directly, mirroring the orchestrator
suite's own `s.encRepo` pattern.

## Verification

- `go test -race ./internal/handlers/dnd5e/lobby/... ./internal/orchestrators/lobby/...`
  — all green, including the full pre-existing suite (68 handler subtests, the
  full lobby orchestrator suite).
- `golangci-lint run ./internal/handlers/dnd5e/lobby/...` — **0 issues**.
- `make ci-check` — all tests pass; the two reported failures (mock-regeneration
  drift, lint findings in unrelated files) are the same pre-existing
  environment/repo conditions already documented in #750 — reproduced
  identically against an untouched `origin/dev` checkout in that PR, not
  caused by this change.
- Two live grpcurl transcripts below (`go run ./cmd/server server`,
  `AUTH_DEV_MODE=true`, `RPG_AUTHORING_ENABLED=1`, real Redis).

### Transcript 1 — plan's standalone acceptance (dungeon_key=reference-tomb)

Independent of S1: uses only the embedded `reference-tomb` key, no
`PutDungeon` involved.

```
$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"campaign_id": "s2-campaign", "character_id": "smoke-char-s2"}' \
    localhost:50051 dnd5e.api.lobby.v1alpha1.LobbyService/CreateLobby
{ "lobbyId": "lobby_bf9f8533-...", "joinRef": "join_80710bcc-...", "hostPlayerId": "player-1" }

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"lobby_id": "lobby_bf9f8533-...", "ready": true}' \
    localhost:50051 dnd5e.api.lobby.v1alpha1.LobbyService/SetReady
{}

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"lobby_id": "lobby_bf9f8533-...", "dungeon_key": "reference-tomb"}' \
    localhost:50051 dnd5e.api.lobby.v1alpha1.LobbyService/StartEncounter
{ "encounterId": "11f95c7e-d54b-4d8a-8b29-399d7c7864f2" }

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"encounter_id": "11f95c7e-d54b-4d8a-8b29-399d7c7864f2"}' \
    localhost:50051 dnd5e.api.v1alpha2.encounter.EncounterService/GetEncounter
{
  "encounter": {
    "space": {
      ...
      "zones": [
        {"id": "entrance", "archetype": "entrance"},
        {"id": "hall", "archetype": "chamber"},
        {"id": "tomb", "archetype": "boss"}
      ],
      "theme": "crypt"
    }
  }
}
# entrance/hall/tomb + a door literally named
# "reference-tomb-door-entrance-hall" (visible in the full response) --
# the legacy crypt default is entrance/corridor/boss and NEVER emits a
# chamber-archetype region. Confirmed: dungeon_key actually selected the
# authored spec, not the default.
```

### Transcript 2 — end-to-end no-restart loop (S1's substitution caveat, closed)

Gate on, `PutDungeon` a brand-new key, then `StartEncounter` with that exact
key immediately — same process, no restart in between.

```
$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"key": "s2-loop-test", "yaml": "version: 1\nkey: s2-loop-test\nname: S2 Loop Test\nheight: 8\nrooms:\n  - id: entrance\n    archetype: entrance\n    width: 6\n  - id: boss\n    archetype: boss\n    width: 8\n    boss: { ref: \"dnd5e:monsters:skeleton-captain\", at: [4, 2] }\nconnectors:\n  - { from: entrance, to: boss }\n", "validate_only": false}' \
    localhost:50051 dnd5e.api.authoring.v1alpha1.AuthoringService/PutDungeon
{
  "success": true,
  "floorPlan": {
    "rooms": [
      {"id": "entrance", "archetype": "entrance", "width": 6},
      {"id": "boss", "archetype": "boss", "width": 8, "startColumn": 7}
    ],
    "connectors": [
      {"doorId": "s2-loop-test-door-entrance-boss", "fromRoomId": "entrance", "toRoomId": "boss", "column": 6}
    ],
    "height": 8, "doorRow": 4, "entrance": {"row": 4}
  }
}

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"campaign_id": "s2-loop-campaign", "character_id": "smoke-char-s2"}' \
    localhost:50051 dnd5e.api.lobby.v1alpha1.LobbyService/CreateLobby
{ "lobbyId": "lobby_b3dfaa8e-...", "joinRef": "join_666d2ae2-...", "hostPlayerId": "player-1" }

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"lobby_id": "lobby_b3dfaa8e-...", "ready": true}' \
    localhost:50051 dnd5e.api.lobby.v1alpha1.LobbyService/SetReady
{}

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"lobby_id": "lobby_b3dfaa8e-...", "dungeon_key": "s2-loop-test"}' \
    localhost:50051 dnd5e.api.lobby.v1alpha1.LobbyService/StartEncounter
# NO restart between the PutDungeon call above and this one.
{ "encounterId": "ebaaaba7-4c7d-4bac-9a68-a881c54df85a" }

$ grpcurl -plaintext -H "Authorization: Dev player-1" \
    -d '{"encounter_id": "ebaaaba7-4c7d-4bac-9a68-a881c54df85a"}' \
    localhost:50051 dnd5e.api.v1alpha2.encounter.EncounterService/GetEncounter
{
  "encounter": {
    "space": {
      "zones": [
        {"id": "entrance", "archetype": "entrance"},
        {"id": "boss", "archetype": "boss"}
      ]
    }
  }
}
# door id "s2-loop-test-door-entrance-boss" also present -- this IS the
# spec just uploaded, built with zero server restart. This is the
# design's headline behavior (design.md's "PutDungeon must be visible to
# the very next StartEncounter, no restart") now demonstrable end to
# end, not just at the registry layer S1 could prove alone.
```

(Both transcripts are from a live run against a local server + real Redis,
port/Redis address normalized for readability — the actual run used
`localhost:50098` against `REDIS_ADDR=localhost:6380` to avoid colliding with
other concurrent work in this workspace.)

## Not in this PR

S3 (the web lobby dropdown) is a separate, later slice in a different repo —
not touched here.

Do not merge — waiting on the Opus gate + Kirk.

— asset-pipeline agent, on behalf of KirkDiggler
