### PR TITLE
fix(character): populate equipment_detail on ListClasses EquipmentItem

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2334,6 +2334,12 @@ func createEquipmentChoice(req *choices.EquipmentRequirement) *dnd5ev1alpha1.Cho
 			}
 			// Set type hint if we can determine the type
 			setEquipmentItemTypeHint(equipItem, item.ID)
+			// Set resolved equipment stats (damage, AC, properties, etc.) so
+			// the client can render EquipmentCard without a name-only fallback.
+			// item.Detail is already resolved by the toolkit's
+			// enrichEquipmentRequirements via equipment.ResolveEquipmentDetail —
+			// this is a pure translation, not a re-derivation of rules.
+			equipItem.EquipmentDetail = convertEquipmentDetailToProto(item.Detail)
 			equipmentItems = append(equipmentItems, equipItem)
 		}
 
@@ -2742,15 +2748,13 @@ func ConvertEquipmentToProto(equip equipment.Equipment) *dnd5ev1alpha1.Equipment
 	return result
 }
 
-// convertWeaponData converts weapon-specific data to proto
-func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
-	if weapon == nil {
-		return nil
-	}
-
-	// Convert weapon properties
-	properties := make([]dnd5ev1alpha1.WeaponProperty, 0, len(weapon.Properties))
-	for _, prop := range weapon.Properties {
+// convertWeaponProperties converts toolkit weapon properties to proto weapon properties.
+// Shared by convertWeaponData (concrete weapons.Weapon) and
+// convertWeaponDetailToProto (resolved equipment.WeaponDetail) so the mapping
+// lives in exactly one place.
+func convertWeaponProperties(props []weapons.WeaponProperty) []dnd5ev1alpha1.WeaponProperty {
+	properties := make([]dnd5ev1alpha1.WeaponProperty, 0, len(props))
+	for _, prop := range props {
 		switch prop {
 		case weapons.PropertyLight:
 			properties = append(properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_LIGHT)
@@ -2774,6 +2778,63 @@ func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 			properties = append(properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_SPECIAL)
 		}
 	}
+	return properties
+}
+
+// convertWeaponCategoryToProto converts the toolkit's fine-grained weapon
+// category (simple-melee, simple-ranged, martial-melee, martial-ranged) to
+// the proto's broader SIMPLE/MARTIAL category.
+func convertWeaponCategoryToProto(cat weapons.WeaponCategory) dnd5ev1alpha1.WeaponCategory {
+	switch {
+	case strings.HasPrefix(string(cat), "simple"):
+		return dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_SIMPLE
+	case strings.HasPrefix(string(cat), "martial"):
+		return dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_MARTIAL
+	default:
+		return dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_UNSPECIFIED
+	}
+}
+
+// convertArmorCategoryToProto converts the toolkit's armor category
+// (light/medium/heavy/shield) to the proto ArmorCategory enum.
+func convertArmorCategoryToProto(cat armor.ArmorCategory) dnd5ev1alpha1.ArmorCategory {
+	switch cat {
+	case armor.CategoryLight:
+		return dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_LIGHT
+	case armor.CategoryMedium:
+		return dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_MEDIUM
+	case armor.CategoryHeavy:
+		return dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_HEAVY
+	case armor.CategoryShield:
+		return dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_SHIELD
+	default:
+		return dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_UNSPECIFIED
+	}
+}
+
+// convertArmorCategoryToEquipmentCategory converts the toolkit's armor
+// category to the proto's top-level EquipmentCategory enum used on
+// Equipment.category.
+func convertArmorCategoryToEquipmentCategory(cat armor.ArmorCategory) dnd5ev1alpha1.EquipmentCategory {
+	switch cat {
+	case armor.CategoryLight:
+		return dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_LIGHT_ARMOR
+	case armor.CategoryMedium:
+		return dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_MEDIUM_ARMOR
+	case armor.CategoryHeavy:
+		return dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_HEAVY_ARMOR
+	case armor.CategoryShield:
+		return dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_SHIELD
+	default:
+		return dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_UNSPECIFIED
+	}
+}
+
+// convertWeaponData converts weapon-specific data to proto
+func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
+	if weapon == nil {
+		return nil
+	}
 
 	// Determine weapon category
 	var weaponCategory dnd5ev1alpha1.WeaponCategory
@@ -2787,7 +2848,7 @@ func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 		WeaponCategory: weaponCategory,
 		DamageDice:     weapon.Damage,
 		DamageType:     convertDamageTypeToProto(string(weapon.DamageType)),
-		Properties:     properties,
+		Properties:     convertWeaponProperties(weapon.Properties),
 	}
 
 	// Add range if present
@@ -2797,6 +2858,69 @@ func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 		result.LongRange = int32(weapon.Range.Long)
 	} else {
 		result.Range = "melee"
+	}
+
+	return result
+}
+
+// convertEquipmentDetailToProto converts the toolkit's resolved
+// equipment.EquipmentDetail (already produced by
+// equipment.ResolveEquipmentDetail, e.g. via choices.EquipmentItem.Detail)
+// into the proto Equipment message used by EquipmentItem.equipment_detail.
+// This is a pure translation — it does not recompute any D&D rule (damage,
+// AC, properties); those values are read straight off the toolkit's
+// already-resolved detail.
+func convertEquipmentDetailToProto(detail *equipment.EquipmentDetail) *dnd5ev1alpha1.Equipment {
+	if detail == nil {
+		return nil
+	}
+
+	result := &dnd5ev1alpha1.Equipment{
+		Name: detail.Name,
+		Weight: &dnd5ev1alpha1.Weight{
+			Quantity: int32(detail.Weight),
+			Unit:     "lbs",
+		},
+	}
+
+	switch {
+	case detail.Weapon != nil:
+		weaponCategory := convertWeaponCategoryToProto(detail.Weapon.Category)
+		if weaponCategory == dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_MARTIAL {
+			result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_MARTIAL_WEAPON
+		} else {
+			result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_SIMPLE_WEAPON
+		}
+		weaponData := &dnd5ev1alpha1.WeaponData{
+			WeaponCategory: weaponCategory,
+			DamageDice:     detail.Weapon.Damage,
+			DamageType:     convertDamageTypeToProto(string(detail.Weapon.DamageType)),
+			Properties:     convertWeaponProperties(detail.Weapon.Properties),
+		}
+		if detail.Weapon.Range != nil {
+			weaponData.Range = "ranged"
+			weaponData.NormalRange = int32(detail.Weapon.Range.Normal)
+			weaponData.LongRange = int32(detail.Weapon.Range.Long)
+		} else {
+			weaponData.Range = "melee"
+		}
+		result.EquipmentData = &dnd5ev1alpha1.Equipment_WeaponData{WeaponData: weaponData}
+	case detail.Armor != nil:
+		result.Category = convertArmorCategoryToEquipmentCategory(detail.Armor.Category)
+		armorData := &dnd5ev1alpha1.ArmorData{
+			ArmorCategory:       convertArmorCategoryToProto(detail.Armor.Category),
+			BaseAc:              int32(detail.Armor.BaseAC),
+			DexBonus:            detail.Armor.DexBonus,
+			StrMinimum:          int32(detail.Armor.StrengthRequirement),
+			StealthDisadvantage: detail.Armor.StealthDisadvantage,
+		}
+		if detail.Armor.MaxDexBonus != nil {
+			armorData.HasDexLimit = true
+			armorData.MaxDexBonus = int32(*detail.Armor.MaxDexBonus)
+		}
+		result.EquipmentData = &dnd5ev1alpha1.Equipment_ArmorData{ArmorData: armorData}
+	default:
+		result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_ADVENTURING_GEAR
 	}
 
 	return result

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2850,17 +2850,31 @@ func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 		DamageType:     convertDamageTypeToProto(string(weapon.DamageType)),
 		Properties:     convertWeaponProperties(weapon.Properties),
 	}
-
-	// Add range if present
-	if weapon.Range != nil {
-		result.Range = "ranged"
-		result.NormalRange = int32(weapon.Range.Normal)
-		result.LongRange = int32(weapon.Range.Long)
-	} else {
-		result.Range = "melee"
-	}
+	applyWeaponRange(result, weapon.Range)
 
 	return result
+}
+
+// weaponRangeMelee and weaponRangeRanged are the proto WeaponData.range
+// string values. Shared by convertWeaponData and convertEquipmentDetailToProto
+// so the literal exists in exactly one place.
+const (
+	weaponRangeMelee  = "melee"
+	weaponRangeRanged = "ranged"
+)
+
+// applyWeaponRange sets WeaponData.range/normal_range/long_range from a
+// toolkit weapons.Range (nil means melee). Shared by convertWeaponData
+// (concrete weapons.Weapon) and convertEquipmentDetailToProto (resolved
+// equipment.WeaponDetail).
+func applyWeaponRange(weaponData *dnd5ev1alpha1.WeaponData, rng *weapons.Range) {
+	if rng != nil {
+		weaponData.Range = weaponRangeRanged
+		weaponData.NormalRange = int32(rng.Normal)
+		weaponData.LongRange = int32(rng.Long)
+	} else {
+		weaponData.Range = weaponRangeMelee
+	}
 }
 
 // convertEquipmentDetailToProto converts the toolkit's resolved
@@ -2897,13 +2911,7 @@ func convertEquipmentDetailToProto(detail *equipment.EquipmentDetail) *dnd5ev1al
 			DamageType:     convertDamageTypeToProto(string(detail.Weapon.DamageType)),
 			Properties:     convertWeaponProperties(detail.Weapon.Properties),
 		}
-		if detail.Weapon.Range != nil {
-			weaponData.Range = "ranged"
-			weaponData.NormalRange = int32(detail.Weapon.Range.Normal)
-			weaponData.LongRange = int32(detail.Weapon.Range.Long)
-		} else {
-			weaponData.Range = "melee"
-		}
+		applyWeaponRange(weaponData, detail.Weapon.Range)
 		result.EquipmentData = &dnd5ev1alpha1.Equipment_WeaponData{WeaponData: weaponData}
 	case detail.Armor != nil:
 		result.Category = convertArmorCategoryToEquipmentCategory(detail.Armor.Category)

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -142,6 +142,80 @@ func (s *ConvertersTestSuite) TestConvertClassDataToProto_Fighter() {
 	assert.Len(s.T(), leatherBundle.Items, 3, "Leather bundle should have 3 items")
 }
 
+func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail_Armor() {
+	fighterData := classes.ClassData[classes.Fighter]
+	require.NotNil(s.T(), fighterData, "Fighter class data should exist")
+
+	result := convertClassDataToProto(fighterData)
+	require.NotNil(s.T(), result)
+
+	var armorChoice *dnd5ev1alpha1.Choice
+	for _, choice := range result.Choices {
+		if choice.Id == "fighter-armor" {
+			armorChoice = choice
+			break
+		}
+	}
+	require.NotNil(s.T(), armorChoice, "Fighter should have armor choice")
+
+	chainMailBundle := armorChoice.GetEquipmentOptions().Bundles[0]
+	require.Len(s.T(), chainMailBundle.Items, 1)
+	chainMail := chainMailBundle.Items[0]
+	require.Equal(s.T(), "chain-mail", chainMail.SelectionId)
+
+	// This is the field the fix populates. Without the fix, EquipmentDetail
+	// is nil and the web's EquipmentCard falls back to a name-only render.
+	require.NotNil(s.T(), chainMail.EquipmentDetail, "chain mail should carry resolved equipment detail")
+	assert.Equal(s.T(), "Chain Mail", chainMail.EquipmentDetail.Name)
+
+	armorData := chainMail.EquipmentDetail.GetArmorData()
+	require.NotNil(s.T(), armorData, "chain mail detail should carry armor data")
+	assert.Equal(s.T(), dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_HEAVY, armorData.ArmorCategory)
+	assert.Equal(s.T(), int32(16), armorData.BaseAc)
+	assert.False(s.T(), armorData.DexBonus, "chain mail grants no dex bonus (max dex 0)")
+	assert.Equal(s.T(), int32(13), armorData.StrMinimum)
+	assert.True(s.T(), armorData.StealthDisadvantage)
+}
+
+func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail_Weapon() {
+	fighterData := classes.ClassData[classes.Fighter]
+	require.NotNil(s.T(), fighterData, "Fighter class data should exist")
+
+	result := convertClassDataToProto(fighterData)
+	require.NotNil(s.T(), result)
+
+	var armorChoice *dnd5ev1alpha1.Choice
+	for _, choice := range result.Choices {
+		if choice.Id == "fighter-armor" {
+			armorChoice = choice
+			break
+		}
+	}
+	require.NotNil(s.T(), armorChoice, "Fighter should have armor choice")
+
+	leatherBundle := armorChoice.GetEquipmentOptions().Bundles[1]
+	require.Len(s.T(), leatherBundle.Items, 3)
+	longbow := leatherBundle.Items[1]
+	require.Equal(s.T(), "longbow", longbow.SelectionId)
+
+	// This is the field the fix populates. Without the fix, EquipmentDetail
+	// is nil and the web's EquipmentCard falls back to a name-only render.
+	require.NotNil(s.T(), longbow.EquipmentDetail, "longbow should carry resolved equipment detail")
+	assert.Equal(s.T(), "Longbow", longbow.EquipmentDetail.Name)
+
+	weaponData := longbow.EquipmentDetail.GetWeaponData()
+	require.NotNil(s.T(), weaponData, "longbow detail should carry weapon data")
+	assert.Equal(s.T(), dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_MARTIAL, weaponData.WeaponCategory)
+	assert.Equal(s.T(), "1d8", weaponData.DamageDice)
+	assert.Equal(s.T(), dnd5ev1alpha1.DamageType_DAMAGE_TYPE_PIERCING, weaponData.DamageType)
+	assert.Equal(s.T(), "ranged", weaponData.Range)
+	assert.Equal(s.T(), int32(150), weaponData.NormalRange)
+	assert.Equal(s.T(), int32(600), weaponData.LongRange)
+	assert.Contains(s.T(), weaponData.Properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_AMMUNITION)
+	assert.Contains(s.T(), weaponData.Properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_HEAVY)
+	assert.Contains(s.T(), weaponData.Properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_TWO_HANDED)
+}
+
 func (s *ConvertersTestSuite) TestConvertClassDataToProto_Wizard() {
 	// Get Wizard class data from toolkit
 	wizardData := classes.ClassData[classes.Wizard]

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -549,6 +549,62 @@ func (s *CharacterCreationSuite) TestValidation_MissingClass() {
 	s.T().Logf("✅ Correctly rejected: %v", err)
 }
 
+func (s *CharacterCreationSuite) TestListClasses_PopulatesEquipmentDetail() {
+	ctx := s.authCtx("test-list-classes-equipment-detail")
+
+	listResp, err := s.server.CharacterClient.ListClasses(ctx, &dnd5ev1alpha1.ListClassesRequest{})
+	s.Require().NoError(err)
+
+	var fighterInfo *dnd5ev1alpha1.ClassInfo
+	for _, classInfo := range listResp.GetClasses() {
+		if classInfo.GetClassId() == dnd5ev1alpha1.Class_CLASS_FIGHTER {
+			fighterInfo = classInfo
+			break
+		}
+	}
+	s.Require().NotNil(fighterInfo, "ListClasses should include Fighter")
+
+	var armorChoice *dnd5ev1alpha1.Choice
+	for _, choice := range fighterInfo.GetChoices() {
+		if choice.GetId() == "fighter-armor" {
+			armorChoice = choice
+			break
+		}
+	}
+	s.Require().NotNil(armorChoice, "Fighter should advertise an armor equipment choice")
+
+	bundles := armorChoice.GetEquipmentOptions().GetBundles()
+	s.Require().Len(bundles, 2, "fighter-armor should have 2 bundle options")
+
+	// Bundle 0: chain mail (armor item) - assert equipment_detail is populated
+	// over the real gRPC path, not just the converter unit.
+	chainMailBundle := bundles[0]
+	s.Require().Len(chainMailBundle.GetItems(), 1)
+	chainMail := chainMailBundle.GetItems()[0]
+	s.Assert().Equal("chain-mail", chainMail.GetSelectionId())
+	s.Require().NotNil(chainMail.GetEquipmentDetail(),
+		"chain mail EquipmentItem should carry equipment_detail over the wire")
+	armorData := chainMail.GetEquipmentDetail().GetArmorData()
+	s.Require().NotNil(armorData, "chain mail equipment_detail should carry armor data")
+	s.Assert().Equal(int32(16), armorData.GetBaseAc())
+	s.Assert().True(armorData.GetStealthDisadvantage())
+
+	// Bundle 1: leather armor, longbow, arrows - assert the weapon item
+	// (longbow) carries equipment_detail too.
+	leatherBundle := bundles[1]
+	s.Require().Len(leatherBundle.GetItems(), 3)
+	longbow := leatherBundle.GetItems()[1]
+	s.Assert().Equal("longbow", longbow.GetSelectionId())
+	s.Require().NotNil(longbow.GetEquipmentDetail(),
+		"longbow EquipmentItem should carry equipment_detail over the wire")
+	weaponData := longbow.GetEquipmentDetail().GetWeaponData()
+	s.Require().NotNil(weaponData, "longbow equipment_detail should carry weapon data")
+	s.Assert().Equal("1d8", weaponData.GetDamageDice())
+	s.Assert().Equal(dnd5ev1alpha1.DamageType_DAMAGE_TYPE_PIERCING, weaponData.GetDamageType())
+	s.Assert().Equal(int32(150), weaponData.GetNormalRange())
+	s.Assert().Equal(int32(600), weaponData.GetLongRange())
+}
+
 func (s *CharacterCreationSuite) TestCreateMonk() {
 	s.T().Log("Creating Monk character...")
 	ctx := s.authCtx("test-player-monk")


### PR DESCRIPTION
## What

`CharacterService.ListClasses` never populated `EquipmentItem.equipment_detail`
on the proto message, even though the field, the `Equipment`/`WeaponData`/
`ArmorData` messages, and the toolkit-side resolution all already existed.
`createEquipmentChoice` built each `EquipmentItem` from only `SelectionId`,
`Quantity`, and a hand-rolled `TypeHint`, dropping the toolkit's
already-resolved `choices.EquipmentItem.Detail` (`*equipment.EquipmentDetail`)
on the floor. The already-shipped web `EquipmentCard` component reads
`equipment_data` to render damage/AC/properties and could only ever fall
back to a name-only render.

## Fix

Pure translation, no rules recomputed:

- `convertEquipmentDetailToProto` (new) converts the toolkit's resolved
  `equipment.EquipmentDetail` — already populated for every class via
  `enrichEquipmentRequirements` → `equipment.ResolveEquipmentDetail` — into
  the proto `Equipment` message.
- Extracted `convertWeaponProperties` and `applyWeaponRange` out of the
  existing `convertWeaponData` so the weapon-property/range mapping lives in
  exactly one place, shared by both the concrete-`weapons.Weapon` path and
  the new resolved-`EquipmentDetail` path.
- Added `convertWeaponCategoryToProto`, `convertArmorCategoryToProto`,
  `convertArmorCategoryToEquipmentCategory` for the toolkit's fine-grained
  category strings (`simple-melee`/`martial-ranged`, `light`/`heavy`/…).
- Wired `equipItem.EquipmentDetail = convertEquipmentDetailToProto(item.Detail)`
  into `createEquipmentChoice`.

No toolkit, proto, or web changes. rpg-api is on toolkit `v0.69.1` (already
pinned), which already resolves and attaches `Detail` to every class's
`choices.EquipmentItem`; the proto already had `equipment_detail` (field 8)
and full `WeaponData`/`ArmorData` shapes.

**Scope note:** category-based selections (`EquipmentCategoryChoice`, e.g.
"choose a martial weapon") are unaffected on purpose — they have no concrete
`selection_id` until a player submits one, so there's nothing to resolve
`equipment_detail` from yet.

## Tests

- `converters_test.go`: two new unit tests exercise the production path —
  `convertClassDataToProto` against real `classes.ClassData[classes.Fighter]`
  — for a representative **armor** item (chain mail: AC 16, no dex bonus,
  Str 13, stealth disadvantage) and a representative **weapon** item
  (longbow: 1d8 piercing, martial, ranged 150/600, ammunition/heavy/two-handed
  properties). Both fail without the fix (`EquipmentDetail` nil).
- `creation_test.go`: new integration test
  `TestListClasses_PopulatesEquipmentDetail` calls the real gRPC harness
  (`ListClasses`) and asserts `equipment_detail` reaches the wire for the
  same chain-mail/longbow items — proves the live path, not just the
  converter unit. Fails without the fix.

All new tests verified red-then-green (failed on the pre-fix commit, pass
after).

## Gates

- `go build ./...` — clean
- `make fmt tidy fix-eof test` — clean, all packages pass
- Focused: `go test ./internal/handlers/dnd5e/v1alpha1/character/...
  ./internal/integration/character/...` — pass
- `make lint` / `make ci-check`: this checkout inherits three **pre-existing,
  unrelated** issues also present on a pristine `origin/dev` clone (verified
  by diffing a fresh clone before touching anything here):
  1. `go generate ./...` mockgen version drift on 7 unrelated mock files
     (tracked lesson: rpg-api#583/"#580 mockgen drift always diffs") — not
     touched by this PR, reverted after confirming.
  2. `golangci-lint` baseline of 32 pre-existing issues (goconst/gosec/govet/
     staticcheck/unconvert/unused) across unrelated files (some paths
     resolve into sibling `.claude/worktrees/...` checkouts on this
     machine). This PR's diff introduces **zero new** lint issues — verified
     the issue count and categories are identical before/after this change.
  3. `TestMoveEntityNPCFirstSuite/TestMoveEntity_NPCFirstCombatEntry_DrivesGoblinTurnWithoutReconnect`
     fails on a pristine `origin/dev` clone with no changes at all — an
     unrelated flaky/pre-existing failure in `internal/orchestrators/encounter/v2`.

None of the three touch character/equipment code and none are introduced by
this diff.

## Self-review

- Boundary: no D&D rules recomputed in rpg-api — every value in
  `convertEquipmentDetailToProto` is read straight off the toolkit's
  already-resolved `EquipmentDetail`; category/range/property mapping is a
  1:1 label translation identical in shape to the pre-existing
  `convertWeaponData`.
- Pattern followed: same converter-layer shape as the rest of
  `converters.go` (handler-layer proto↔entity translation only).
- Proven by tests exercising the production path (`convertClassDataToProto`
  and the real `ListClasses` RPC), not a fixture bypass.
- Pushback: none needed — proto and toolkit already had everything; this
  was a pure "the converter never wired it up" gap.

Closes #753

— asset-pipeline agent, on behalf of KirkDiggler
