### PR TITLE
fix(character)#757: populate RaceInfo.traits from toolkit race data

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -574,6 +574,27 @@ func convertChoiceSourceToProto(source shared.ChoiceSource) dnd5ev1alpha1.Choice
 	}
 }
 
+// convertRaceTraitsToProto converts toolkit races.Trait entries to proto RacialTrait.
+//
+// races.Trait today only carries {ID, Name, Description} — there is no choice
+// information on the toolkit side, so is_choice/options are deliberately left at
+// their zero values (false/empty) rather than invented. If the toolkit ever grows
+// choice-bearing traits, extend this mapping then.
+func convertRaceTraitsToProto(traits []races.Trait) []*dnd5ev1alpha1.RacialTrait {
+	if len(traits) == 0 {
+		return nil
+	}
+
+	result := make([]*dnd5ev1alpha1.RacialTrait, 0, len(traits))
+	for _, trait := range traits {
+		result = append(result, &dnd5ev1alpha1.RacialTrait{
+			Name:        trait.Name,
+			Description: trait.Description,
+		})
+	}
+	return result
+}
+
 // convertRaceDataToProto converts toolkit races.Data to proto RaceInfo
 func convertRaceDataToProto(data *races.Data) *dnd5ev1alpha1.RaceInfo {
 	if data == nil {
@@ -782,7 +803,6 @@ func convertRaceDataToProto(data *races.Data) *dnd5ev1alpha1.RaceInfo {
 	}
 
 	// TODO: Convert Size string to proto enum when available
-	// TODO: Convert Traits when proto supports them
 	// TODO: Convert subraces when proto supports them
 	// TODO: Convert AbilityChoice for Half-Elf
 
@@ -792,6 +812,7 @@ func convertRaceDataToProto(data *races.Data) *dnd5ev1alpha1.RaceInfo {
 		Description:       data.Description(),
 		Speed:             int32(data.Speed),
 		AbilityBonuses:    abilityBonuses,
+		Traits:            convertRaceTraitsToProto(data.Traits),
 		Languages:         langs,
 		ProficiencyGrants: profGrants,
 		Choices:           choices,

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -12,6 +12,7 @@ import (
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
@@ -738,4 +739,80 @@ func (s *ConvertersTestSuite) TestConvertProtoArmorToToolkit() {
 			assert.Equal(s.T(), tc.expected, result)
 		})
 	}
+}
+
+func (s *ConvertersTestSuite) TestConvertRaceDataToProto_Human_NoTraits() {
+	humanData := races.RaceData[races.Human]
+	require.NotNil(s.T(), humanData, "Human race data should exist")
+	require.Empty(s.T(), humanData.Traits, "fixture assumption: Human has no toolkit traits")
+
+	result := convertRaceDataToProto(humanData)
+	require.NotNil(s.T(), result)
+
+	assert.Empty(s.T(), result.GetTraits(), "Human should not fabricate traits it doesn't have")
+}
+
+func (s *ConvertersTestSuite) TestConvertRaceDataToProto_Elf_PopulatesTraits() {
+	elfData := races.RaceData[races.Elf]
+	require.NotNil(s.T(), elfData, "Elf race data should exist")
+	require.NotEmpty(s.T(), elfData.Traits, "fixture assumption: Elf has toolkit traits")
+
+	result := convertRaceDataToProto(elfData)
+	require.NotNil(s.T(), result)
+
+	require.Len(s.T(), result.GetTraits(), len(elfData.Traits))
+
+	names := make([]string, 0, len(result.GetTraits()))
+	for _, trait := range result.GetTraits() {
+		names = append(names, trait.GetName())
+		// Honest mapping: toolkit races.Trait carries no choice data today.
+		assert.False(s.T(), trait.GetIsChoice(), "races.Trait has no choice data - is_choice must not be invented")
+		assert.Empty(s.T(), trait.GetOptions(), "races.Trait has no choice data - options must not be invented")
+	}
+	assert.Contains(s.T(), names, "Darkvision")
+	assert.Contains(s.T(), names, "Fey Ancestry")
+	assert.Contains(s.T(), names, "Keen Senses")
+	assert.Contains(s.T(), names, "Trance")
+
+	// Description should travel too, not just the name.
+	for _, trait := range result.GetTraits() {
+		if trait.GetName() == "Fey Ancestry" {
+			assert.Contains(s.T(), trait.GetDescription(), "charmed")
+		}
+	}
+}
+
+func (s *ConvertersTestSuite) TestConvertRaceDataToProto_Dwarf_PopulatesTraits() {
+	dwarfData := races.RaceData[races.Dwarf]
+	require.NotNil(s.T(), dwarfData, "Dwarf race data should exist")
+	require.NotEmpty(s.T(), dwarfData.Traits, "fixture assumption: Dwarf has toolkit traits")
+
+	result := convertRaceDataToProto(dwarfData)
+	require.NotNil(s.T(), result)
+
+	require.Len(s.T(), result.GetTraits(), len(dwarfData.Traits))
+
+	names := make([]string, 0, len(result.GetTraits()))
+	for _, trait := range result.GetTraits() {
+		names = append(names, trait.GetName())
+	}
+	assert.Contains(s.T(), names, "Darkvision")
+	assert.Contains(s.T(), names, "Dwarven Resilience")
+	assert.Contains(s.T(), names, "Stonecunning")
+}
+
+func (s *ConvertersTestSuite) TestConvertRaceTraitsToProto_Discriminates() {
+	// Directly exercise the helper: nil/empty input must yield nil, not a
+	// spurious empty-but-non-nil slice masquerading as "populated".
+	assert.Nil(s.T(), convertRaceTraitsToProto(nil))
+	assert.Nil(s.T(), convertRaceTraitsToProto([]races.Trait{}))
+
+	result := convertRaceTraitsToProto([]races.Trait{
+		{ID: "test-trait", Name: "Test Trait", Description: "A test trait description"},
+	})
+	require.Len(s.T(), result, 1)
+	assert.Equal(s.T(), "Test Trait", result[0].GetName())
+	assert.Equal(s.T(), "A test trait description", result[0].GetDescription())
+	assert.False(s.T(), result[0].GetIsChoice())
+	assert.Empty(s.T(), result[0].GetOptions())
 }

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -605,6 +605,51 @@ func (s *CharacterCreationSuite) TestListClasses_PopulatesEquipmentDetail() {
 	s.Assert().Equal(int32(600), weaponData.GetLongRange())
 }
 
+func (s *CharacterCreationSuite) TestListRaces_PopulatesTraits() {
+	ctx := s.authCtx("test-list-races-traits")
+
+	listResp, err := s.server.CharacterClient.ListRaces(ctx, &dnd5ev1alpha1.ListRacesRequest{})
+	s.Require().NoError(err)
+
+	var humanInfo, elfInfo, dwarfInfo *dnd5ev1alpha1.RaceInfo
+	for _, raceInfo := range listResp.GetRaces() {
+		switch raceInfo.GetRaceId() {
+		case dnd5ev1alpha1.Race_RACE_HUMAN:
+			humanInfo = raceInfo
+		case dnd5ev1alpha1.Race_RACE_ELF:
+			elfInfo = raceInfo
+		case dnd5ev1alpha1.Race_RACE_DWARF:
+			dwarfInfo = raceInfo
+		}
+	}
+	s.Require().NotNil(humanInfo, "ListRaces should include Human")
+	s.Require().NotNil(elfInfo, "ListRaces should include Elf")
+	s.Require().NotNil(dwarfInfo, "ListRaces should include Dwarf")
+
+	// Human has no toolkit traits - assert the real correct-empty behavior,
+	// not just "doesn't crash".
+	s.Assert().Empty(humanInfo.GetTraits(), "Human should have no racial traits on the wire")
+
+	// Elf and Dwarf have real toolkit traits - assert they travel over the
+	// real ListRaces RPC (not a converter-only unit test), with both name
+	// and description populated.
+	s.Require().NotEmpty(elfInfo.GetTraits(), "Elf should carry racial traits over the wire")
+	elfNames := make([]string, 0, len(elfInfo.GetTraits()))
+	for _, trait := range elfInfo.GetTraits() {
+		elfNames = append(elfNames, trait.GetName())
+		s.Assert().NotEmpty(trait.GetDescription(), "trait %q should carry a description over the wire", trait.GetName())
+	}
+	s.Assert().Contains(elfNames, "Darkvision")
+	s.Assert().Contains(elfNames, "Fey Ancestry")
+
+	s.Require().NotEmpty(dwarfInfo.GetTraits(), "Dwarf should carry racial traits over the wire")
+	dwarfNames := make([]string, 0, len(dwarfInfo.GetTraits()))
+	for _, trait := range dwarfInfo.GetTraits() {
+		dwarfNames = append(dwarfNames, trait.GetName())
+	}
+	s.Assert().Contains(dwarfNames, "Stonecunning")
+}
+
 func (s *CharacterCreationSuite) TestCreateMonk() {
 	s.T().Log("Creating Monk character...")
 	ctx := s.authCtx("test-player-monk")


### PR DESCRIPTION
## What

Closes #757.

`convertRaceDataToProto` built `RaceInfo` for `ListRaces` but never populated `RaceInfo.traits` — the field was skipped with a stale `// TODO: Convert Traits when proto supports them` comment. The proto field, the toolkit trait data, and the web rendering all already existed; this was a pure converter gap in rpg-api.

## Changes

- Add `convertRaceTraitsToProto`, a pure mapping from toolkit `races.Trait{ID, Name, Description}` to proto `RacialTrait{name, description}`.
- `is_choice`/`options` are deliberately left at their honest zero values (false/empty) — toolkit trait data carries no choice information today, so nothing is invented to fill those fields.
- Wire it into `convertRaceDataToProto` and remove the stale TODO.
- No changes to rpg-api-protos or rpg-dnd5e-web — additive data on an existing wire field both sides already understand.

## Tests

- `converters_test.go`: Human (no traits, stays empty), Elf and Dwarf (traits populated with real toolkit names/descriptions: Darkvision, Fey Ancestry, Keen Senses, Trance / Darkvision, Dwarven Resilience, Stonecunning), plus a direct unit test on the new helper discriminating nil/empty vs populated input.
- `internal/integration/character/creation_test.go`: `TestListRaces_PopulatesTraits` calls the real `ListRaces` RPC (not converter-only) and asserts traits travel over the wire for Human (empty), Elf, and Dwarf, following the existing `TestListClasses_PopulatesEquipmentDetail` pattern.

## Gates run locally

- `go build ./...` — clean
- `go vet ./...` — clean
- `make test-unit` — full suite green
- `go test -race -tags=integration ./internal/integration/...` — all three packages green (ephemeral testcontainers redis, self-terminating)
- `make test-ci` — green
- `golangci-lint run internal/handlers/dnd5e/v1alpha1/character/...` — 11 pre-existing issues (goconst/unconvert) confirmed present on `origin/dev` before this change too (verified via `git stash`); nothing new introduced by this diff.

## Notes

- Does not touch or repurpose #755 (unrelated equipment `EquipmentCategoryChoice.options` mapping).
- No running containers modified — integration tests use self-contained/self-terminating testcontainers.

— director, on behalf of KirkDiggler