### PR TITLE
test(encounter): make NPC-first initiative fixture deterministic

### DIFF
--- a/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_npc_first_test.go
@@ -147,7 +147,10 @@ func (s *MoveEntityNPCFirstSuite) SetupTest() {
 // this seed step, with no acting player to attribute — the goblin's
 // constant-rolled tie is broken by ascending id, and it wins.
 func (s *MoveEntityNPCFirstSuite) seedTurnBasedGoblinFirstStalled() {
-	enc := tkenc.New(s.ctx, core.EncounterID(mfEncID), s.broker)
+	// The combat-entry roll occurs during AddMonster below, before the
+	// orchestrator loads this encounter. Wire the fixture's deterministic roller
+	// into this seed aggregate as well as the orchestrator's subsequent load.
+	enc := tkenc.New(s.ctx, core.EncounterID(mfEncID), s.broker, tkenc.WithRoller(constantRoller{value: 10}))
 	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID:   mfPlayerZoe,
 		EntityID:   mfEntityZoe,


### PR DESCRIPTION
## What

Closes #761.

Wires the fixture's existing constant roller into the seed aggregate that calls `AddMonster`, where combat-entry initiative is rolled before the orchestrator later loads the encounter. This is deterministic test setup only: no gameplay, service, or Monk dependency changes.

This blocks #760 process cleanup: the same correction was mistakenly included in #760 while resolving its CI failure. Once this PR is merged to `dev`, #760's duplicate fixture change becomes base content, leaving #760 only the Monk dependency bump and its regression test.

## Evidence

- Fresh `origin/dev` baseline (`47155b6`): focused race run failed **24/50** (26 passed); every failure was the goblin-first premise assertion (`expected ann-goblin-mf, got zed-char-zoe`).
- After this change: the same focused race run passed **50/50**.
- Discrimination: each successful run executes the fixture's persisted-state assertions that `AddMonster` already entered `TURN_BASED`, initiative is non-empty, `ann-goblin-mf` is both `Initiative[0]` and the active actor before `MoveEntity`; zero premise failures in the 50-run result.
- The committed patch is byte-for-byte equivalent to the deterministic-fixture portion of #760 commit `d6c676a`; this PR is intentionally its separate owner.

## Checks

- `go test -race ./internal/orchestrators/encounter/v2 -run '^TestMoveEntityNPCFirstSuite$/^TestMoveEntity_NPCFirstCombatEntry_DrivesGoblinTurnWithoutReconnect$' -count=50 -v` — PASS (focused race, 50/50).
- `go build ./...` — PASS.
- `go vet ./...` — PASS.
- `make pre-commit` — BLOCKED at lint by 32 pre-existing findings outside this change (including stale external-worktree paths); formatting, tidy, and EOF steps completed before lint.
- `make ci-check` — its CI-mode test suite PASS; command remains BLOCKED by pre-existing lint findings and mock-generation drift in seven existing generated mocks. The script reverted that generated drift; the worktree stayed clean.

READY for review; do not merge from this PR.

— asset-pipeline agent, on behalf of KirkDiggler
