### PR TITLE
feat(character): map resolved category choice options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.46.5
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.1
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.1
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/KirkDiggler/rpg-api
 go 1.25.3
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260731001915-3c1dc460e77a
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260803031544-94c9de0ad8de
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.46.5
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.2
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.0
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.1
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260731001915-3c1dc460e77a h1:44ZRHeGRLBpTY6/2IlJqGK7Tev/0u1/uRO9WssMlzps=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260731001915-3c1dc460e77a/go.mod h1:3foBBQUsA/gjaYx6UEnwdRaK9dK1BaobOUZRW3vlUMQ=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260803031544-94c9de0ad8de h1:Dqi/a37FdBMSPF/BYrfU5hKSfuex0Rq3a0MW1m+nkn0=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260803031544-94c9de0ad8de/go.mod h1:3foBBQUsA/gjaYx6UEnwdRaK9dK1BaobOUZRW3vlUMQ=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
 github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.2 h1:ItMZdYlrmUFFfje7FHxRzHv8qFEGIH+XsMDcWPnLjDQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.69.2/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.0 h1:7hI1G//+nsfxQeygjc/yszxK0RjyWtdvnBqF3aUEh6g=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4 h1:v7Imq00j5KrQ/PLOR3sOuaxBf3h5ERmHePpQuhGJr9g=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.0 h1:7hI1G//+nsfxQeygjc/yszxK0RjyWtdvnBqF3aUEh6g=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.1 h1:2SB40XyXeJLZNSgHd1eAC1tI8Po0oO8l5ISYKeTOJ3E=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4 h1:v7Imq00j5KrQ/PLOR3sOuaxBf3h5ERmHePpQuhGJr9g=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -3,6 +3,7 @@ package character
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
@@ -2506,8 +2507,9 @@ func setEquipmentItemTypeHint(item *dnd5ev1alpha1.EquipmentItem, itemID string) 
 		return
 	}
 
-	// TODO: Add tools and packs when needed
-	// For now, leave TypeHint nil for unknown items
+	if tool := convertToolToProto(tools.ToolID(itemID)); tool != dnd5ev1alpha1.Tool_TOOL_UNSPECIFIED {
+		item.TypeHint = &dnd5ev1alpha1.EquipmentItem_Tool{Tool: tool}
+	}
 }
 
 // parseSkillString converts a skill string to proto Skill enum
@@ -2926,6 +2928,7 @@ func convertEquipmentDetailToProto(detail *equipment.EquipmentDetail) *dnd5ev1al
 			Quantity: int32(detail.Weight),
 			Unit:     "lbs",
 		},
+		Cost: convertEquipmentCostToProto(detail.Cost),
 	}
 
 	switch {
@@ -2958,11 +2961,28 @@ func convertEquipmentDetailToProto(detail *equipment.EquipmentDetail) *dnd5ev1al
 			armorData.MaxDexBonus = int32(*detail.Armor.MaxDexBonus)
 		}
 		result.EquipmentData = &dnd5ev1alpha1.Equipment_ArmorData{ArmorData: armorData}
+	case detail.Type == shared.EquipmentTypeTool:
+		result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_TOOLS
 	default:
 		result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_ADVENTURING_GEAR
 	}
 
 	return result
+}
+
+// convertEquipmentCostToProto maps a toolkit cost string when it is exactly
+// representable by the proto's single quantity/unit pair. Multi-denomination
+// costs have no lossless representation in the current proto and remain unset.
+func convertEquipmentCostToProto(cost string) *dnd5ev1alpha1.Cost {
+	parts := strings.Fields(cost)
+	if len(parts) != 2 {
+		return nil
+	}
+	quantity, err := strconv.ParseInt(parts[0], 10, 32)
+	if err != nil {
+		return nil
+	}
+	return &dnd5ev1alpha1.Cost{Quantity: int32(quantity), Unit: parts[1]}
 }
 
 // convertDamageTypeToProto converts toolkit damage type to proto

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2348,28 +2348,16 @@ func createEquipmentChoice(req *choices.EquipmentRequirement) *dnd5ev1alpha1.Cho
 		// Create items for this bundle
 		equipmentItems := make([]*dnd5ev1alpha1.EquipmentItem, 0, len(opt.Items))
 		for _, item := range opt.Items {
-			// Create equipment item with selection ID and quantity
-			equipItem := &dnd5ev1alpha1.EquipmentItem{
-				SelectionId: item.ID,
-				Quantity:    int32(item.Quantity),
-			}
-			// Set type hint if we can determine the type
-			setEquipmentItemTypeHint(equipItem, item.ID)
-			// Set resolved equipment stats (damage, AC, properties, etc.) so
-			// the client can render EquipmentCard without a name-only fallback.
-			// item.Detail is already resolved by the toolkit's
-			// enrichEquipmentRequirements via equipment.ResolveEquipmentDetail —
-			// this is a pure translation, not a re-derivation of rules.
-			equipItem.EquipmentDetail = convertEquipmentDetailToProto(item.Detail)
-			equipmentItems = append(equipmentItems, equipItem)
+			equipmentItems = append(equipmentItems, convertEquipmentItemToProto(item))
 		}
 
 		// Convert category choices (e.g., "choose a martial weapon")
 		categoryChoices := make([]*dnd5ev1alpha1.EquipmentCategoryChoice, 0, len(opt.CategoryChoices))
 		for _, catChoice := range opt.CategoryChoices {
 			categoryChoice := &dnd5ev1alpha1.EquipmentCategoryChoice{
-				Choose: int32(catChoice.Choose),
-				Label:  catChoice.Label,
+				Choose:  int32(catChoice.Choose),
+				Label:   catChoice.Label,
+				Options: convertEquipmentItemsToProto(catChoice.Options),
 			}
 
 			// Determine the equipment type and set appropriate categories
@@ -2420,6 +2408,28 @@ func createEquipmentChoice(req *choices.EquipmentRequirement) *dnd5ev1alpha1.Cho
 			},
 		},
 	}
+}
+
+// convertEquipmentItemsToProto maps toolkit-resolved equipment in order. The
+// toolkit owns category eligibility; this converter only preserves its result.
+func convertEquipmentItemsToProto(items []choices.EquipmentItem) []*dnd5ev1alpha1.EquipmentItem {
+	result := make([]*dnd5ev1alpha1.EquipmentItem, 0, len(items))
+	for _, item := range items {
+		result = append(result, convertEquipmentItemToProto(item))
+	}
+	return result
+}
+
+// convertEquipmentItemToProto maps a concrete toolkit item to its wire shape.
+// Detail is resolved upstream by the toolkit; do not derive it here.
+func convertEquipmentItemToProto(item choices.EquipmentItem) *dnd5ev1alpha1.EquipmentItem {
+	result := &dnd5ev1alpha1.EquipmentItem{
+		SelectionId: item.ID,
+		Quantity:    int32(item.Quantity),
+	}
+	setEquipmentItemTypeHint(result, item.ID)
+	result.EquipmentDetail = convertEquipmentDetailToProto(item.Detail)
+	return result
 }
 
 // setEquipmentItemTypeHint sets the type hint on an EquipmentItem based on the item ID

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2507,7 +2507,7 @@ func setEquipmentItemTypeHint(item *dnd5ev1alpha1.EquipmentItem, itemID string) 
 		return
 	}
 
-	if tool := convertToolToProto(tools.ToolID(itemID)); tool != dnd5ev1alpha1.Tool_TOOL_UNSPECIFIED {
+	if tool := convertToolToProto(itemID); tool != dnd5ev1alpha1.Tool_TOOL_UNSPECIFIED {
 		item.TypeHint = &dnd5ev1alpha1.EquipmentItem_Tool{Tool: tool}
 	}
 }

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/tools"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
@@ -145,9 +146,9 @@ func (s *ConvertersTestSuite) TestConvertClassDataToProto_Fighter() {
 	assert.Equal(s.T(), "fighter-armor-b", leatherBundle.Id)
 	assert.Equal(s.T(), "Leather armor, longbow, and 20 arrows", leatherBundle.Label)
 	requireEquipmentItemsEqual(s.T(), leatherBundle.Items, []equipmentItemExpectation{
-		{id: armor.Leather, quantity: 1, detailName: "Leather Armor", armor: dnd5ev1alpha1.Armor_ARMOR_LEATHER},
-		{id: weapons.Longbow, quantity: 1, detailName: "Longbow", weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW},
-		{id: "arrows-20", quantity: 1, detailName: "Arrows (20)"},
+		{id: armor.Leather, quantity: 1, detailName: "Leather Armor", costQuantity: 10, costUnit: "gp", armor: dnd5ev1alpha1.Armor_ARMOR_LEATHER},
+		{id: weapons.Longbow, quantity: 1, detailName: "Longbow", costQuantity: 50, costUnit: "gp", weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW},
+		{id: "arrows-20", quantity: 1, detailName: "Arrows (20)", costQuantity: 1, costUnit: "gp"},
 	})
 
 	leather := leatherBundle.Items[0]
@@ -275,6 +276,39 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOption
 		"API must not invent the toolkit-excluded special weapon")
 }
 
+func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PreservesResolvedToolDetailsAndCost() {
+	bard := convertClassDataToProto(classes.ClassData[classes.Bard])
+	instruments := findEquipmentCategoryChoice(s.T(), bard, "bard-instrument", "bard-instrument-b")
+
+	expected := toolkitCategoryOptions(s.T(), classes.Bard, "bard-instrument", "bard-instrument-b")
+	s.Require().Len(instruments.GetOptions(), len(expected))
+	s.Require().Equal([]string{
+		"bagpipes", "drum", "dulcimer", "flute", "lute", "lyre", "horn", "pan-flute", "shawm", "viol",
+	}, equipmentItemSelectionIDs(instruments.GetOptions()))
+
+	for index, source := range expected {
+		item := instruments.GetOptions()[index]
+		s.Require().NotNil(item, "tool option %d", index)
+		s.Equal(source.ID, item.GetSelectionId(), "tool option %d selection ID", index)
+		s.Equal(int32(source.Quantity), item.GetQuantity(), "tool option %d quantity", index)
+		s.Equal(convertToolToProto(source.ID), item.GetTool(), "tool option %d type hint", index)
+		s.Require().IsType(&dnd5ev1alpha1.EquipmentItem_Tool{}, item.GetTypeHint(), "tool option %d type hint oneof", index)
+
+		detail := item.GetEquipmentDetail()
+		s.Require().NotNil(detail, "tool option %d detail", index)
+		s.Require().NotNil(source.Detail, "tool option %d toolkit detail", index)
+		s.Equal(source.Detail.Name, detail.GetName(), "tool option %d detail name", index)
+		s.Equal(int32(source.Detail.Weight), detail.GetWeight().GetQuantity(), "tool option %d detail weight", index)
+		s.Equal(dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_TOOLS, detail.GetCategory(), "tool option %d detail category", index)
+		s.Require().NotNil(detail.GetCost(), "tool option %d detail cost", index)
+	}
+
+	lute := instruments.GetOptions()[4]
+	s.Equal(tools.Lute, lute.GetSelectionId())
+	s.Equal(int32(35), lute.GetEquipmentDetail().GetCost().GetQuantity())
+	s.Equal("gp", lute.GetEquipmentDetail().GetCost().GetUnit())
+}
+
 func findEquipmentCategoryChoice(t *testing.T, classInfo *dnd5ev1alpha1.ClassInfo, choiceID, bundleID string) *dnd5ev1alpha1.EquipmentCategoryChoice {
 	t.Helper()
 	for _, choice := range classInfo.GetChoices() {
@@ -301,11 +335,13 @@ func equipmentItemSelectionIDs(items []*dnd5ev1alpha1.EquipmentItem) []string {
 }
 
 type equipmentItemExpectation struct {
-	id         string
-	quantity   int32
-	detailName string
-	weapon     dnd5ev1alpha1.Weapon
-	armor      dnd5ev1alpha1.Armor
+	id           string
+	quantity     int32
+	detailName   string
+	costQuantity int32
+	costUnit     string
+	weapon       dnd5ev1alpha1.Weapon
+	armor        dnd5ev1alpha1.Armor
 }
 
 func requireEquipmentItemsEqual(t *testing.T, actual []*dnd5ev1alpha1.EquipmentItem, expected []equipmentItemExpectation) {
@@ -318,6 +354,9 @@ func requireEquipmentItemsEqual(t *testing.T, actual []*dnd5ev1alpha1.EquipmentI
 		assert.Equal(t, expectation.quantity, item.GetQuantity(), "item %d quantity", index)
 		require.NotNil(t, item.GetEquipmentDetail(), "item %d detail", index)
 		assert.Equal(t, expectation.detailName, item.GetEquipmentDetail().GetName(), "item %d detail name", index)
+		require.NotNil(t, item.GetEquipmentDetail().GetCost(), "item %d detail cost", index)
+		assert.Equal(t, expectation.costQuantity, item.GetEquipmentDetail().GetCost().GetQuantity(), "item %d detail cost quantity", index)
+		assert.Equal(t, expectation.costUnit, item.GetEquipmentDetail().GetCost().GetUnit(), "item %d detail cost unit", index)
 		switch {
 		case expectation.weapon != dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED:
 			assert.Equal(t, expectation.weapon, item.GetWeapon(), "item %d weapon type hint", index)

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -217,6 +217,70 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail
 	assert.Contains(s.T(), weaponData.Properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_TWO_HANDED)
 }
 
+func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOptionsOneToOne() {
+	fighter := convertClassDataToProto(classes.ClassData[classes.Fighter])
+	fighterMartial := findEquipmentCategoryChoice(s.T(), fighter, "fighter-weapons-primary", "fighter-weapon-a")
+	require.NotEmpty(s.T(), fighterMartial.GetOptions())
+	assert.Contains(s.T(), equipmentItemSelectionIDs(fighterMartial.GetOptions()), "longsword",
+		"toolkit-resolved martial options must retain melee membership")
+	assert.Contains(s.T(), equipmentItemSelectionIDs(fighterMartial.GetOptions()), "longbow",
+		"toolkit-resolved martial options must retain ranged membership")
+
+	longbow := findEquipmentItem(s.T(), fighterMartial.GetOptions(), "longbow")
+	assert.Equal(s.T(), int32(1), longbow.GetQuantity())
+	require.NotNil(s.T(), longbow.GetEquipmentDetail())
+	assert.Equal(s.T(), "Longbow", longbow.GetEquipmentDetail().GetName())
+	assert.Equal(s.T(), "1d8", longbow.GetEquipmentDetail().GetWeaponData().GetDamageDice())
+
+	monk := convertClassDataToProto(classes.ClassData[classes.Monk])
+	monkSimple := findEquipmentCategoryChoice(s.T(), monk, "monk-weapons-primary", "monk-weapon-b")
+	monkOptionIDs := equipmentItemSelectionIDs(monkSimple.GetOptions())
+	assert.Contains(s.T(), monkOptionIDs, "dart",
+		"API must preserve the toolkit's simple-ranged membership")
+	assert.Contains(s.T(), monkOptionIDs, "light-crossbow",
+		"API must preserve the toolkit's simple-ranged membership")
+	assert.NotContains(s.T(), monkOptionIDs, "shortsword",
+		"shortsword is the toolkit's separate fixed Monk alternative")
+	assert.NotContains(s.T(), monkOptionIDs, "unarmed-strike",
+		"API must not invent the toolkit-excluded special weapon")
+}
+
+func findEquipmentCategoryChoice(t *testing.T, classInfo *dnd5ev1alpha1.ClassInfo, choiceID, bundleID string) *dnd5ev1alpha1.EquipmentCategoryChoice {
+	t.Helper()
+	for _, choice := range classInfo.GetChoices() {
+		if choice.GetId() != choiceID {
+			continue
+		}
+		for _, bundle := range choice.GetEquipmentOptions().GetBundles() {
+			if bundle.GetId() == bundleID {
+				require.Len(t, bundle.GetCategoryChoices(), 1)
+				return bundle.GetCategoryChoices()[0]
+			}
+		}
+	}
+	require.Failf(t, "missing category choice", "choice %q bundle %q", choiceID, bundleID)
+	return nil
+}
+
+func equipmentItemSelectionIDs(items []*dnd5ev1alpha1.EquipmentItem) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.GetSelectionId())
+	}
+	return ids
+}
+
+func findEquipmentItem(t *testing.T, items []*dnd5ev1alpha1.EquipmentItem, selectionID string) *dnd5ev1alpha1.EquipmentItem {
+	t.Helper()
+	for _, item := range items {
+		if item.GetSelectionId() == selectionID {
+			return item
+		}
+	}
+	require.Failf(t, "missing equipment item", "selection ID %q", selectionID)
+	return nil
+}
+
 func (s *ConvertersTestSuite) TestConvertClassDataToProto_Wizard() {
 	// Get Wizard class data from toolkit
 	wizardData := classes.ClassData[classes.Wizard]

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -136,11 +136,30 @@ func (s *ConvertersTestSuite) TestConvertClassDataToProto_Fighter() {
 	assert.Equal(s.T(), "chain-mail", chainMailBundle.Items[0].SelectionId)
 	assert.Equal(s.T(), int32(1), chainMailBundle.Items[0].Quantity)
 
-	// Check second bundle (leather + longbow + arrows)
+	// Check second bundle (leather + longbow + arrows). This legacy bundle
+	// predates category options, so keep its concrete IDs, quantities, details,
+	// type hints, and order pinned while the two paths share a converter.
 	leatherBundle := equipOptions.Bundles[1]
 	assert.Equal(s.T(), "fighter-armor-b", leatherBundle.Id)
 	assert.Equal(s.T(), "Leather armor, longbow, and 20 arrows", leatherBundle.Label)
-	assert.Len(s.T(), leatherBundle.Items, 3, "Leather bundle should have 3 items")
+	requireEquipmentItemsEqual(s.T(), leatherBundle.Items, []equipmentItemExpectation{
+		{id: "leather", quantity: 1, detailName: "Leather Armor", armor: dnd5ev1alpha1.Armor_ARMOR_LEATHER},
+		{id: "longbow", quantity: 1, detailName: "Longbow", weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW},
+		{id: "arrows-20", quantity: 1, detailName: "Arrows (20)"},
+	})
+
+	leather := leatherBundle.Items[0]
+	leatherData := leather.GetEquipmentDetail().GetArmorData()
+	require.NotNil(s.T(), leatherData)
+	assert.Equal(s.T(), dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_LIGHT, leatherData.GetArmorCategory())
+	assert.Equal(s.T(), int32(11), leatherData.GetBaseAc())
+	assert.True(s.T(), leatherData.GetDexBonus())
+
+	arrows := leatherBundle.Items[2]
+	assert.Nil(s.T(), arrows.GetTypeHint(), "legacy ammunition has no type hint; preserve that wire contract")
+	assert.Equal(s.T(), dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_ADVENTURING_GEAR,
+		arrows.GetEquipmentDetail().GetCategory())
+	assert.Nil(s.T(), arrows.GetEquipmentDetail().GetEquipmentData())
 }
 
 func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail_Armor() {
@@ -220,25 +239,34 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail
 func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOptionsOneToOne() {
 	fighter := convertClassDataToProto(classes.ClassData[classes.Fighter])
 	fighterMartial := findEquipmentCategoryChoice(s.T(), fighter, "fighter-weapons-primary", "fighter-weapon-a")
-	require.NotEmpty(s.T(), fighterMartial.GetOptions())
-	assert.Contains(s.T(), equipmentItemSelectionIDs(fighterMartial.GetOptions()), "longsword",
-		"toolkit-resolved martial options must retain melee membership")
-	assert.Contains(s.T(), equipmentItemSelectionIDs(fighterMartial.GetOptions()), "longbow",
-		"toolkit-resolved martial options must retain ranged membership")
-
-	longbow := findEquipmentItem(s.T(), fighterMartial.GetOptions(), "longbow")
-	assert.Equal(s.T(), int32(1), longbow.GetQuantity())
-	require.NotNil(s.T(), longbow.GetEquipmentDetail())
-	assert.Equal(s.T(), "Longbow", longbow.GetEquipmentDetail().GetName())
-	assert.Equal(s.T(), "1d8", longbow.GetEquipmentDetail().GetWeaponData().GetDamageDice())
+	requireCategoryOptionsMatchToolkit(
+		s.T(),
+		fighterMartial.GetOptions(),
+		classes.Fighter,
+		"fighter-weapons-primary",
+		"fighter-weapon-a",
+		[]string{
+			"greatsword", "longsword", "rapier", "shortsword", "battleaxe", "flail", "glaive", "greataxe",
+			"halberd", "lance", "maul", "morningstar", "pike", "scimitar", "trident", "war-pick",
+			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow", "net",
+		},
+	)
 
 	monk := convertClassDataToProto(classes.ClassData[classes.Monk])
 	monkSimple := findEquipmentCategoryChoice(s.T(), monk, "monk-weapons-primary", "monk-weapon-b")
+	requireCategoryOptionsMatchToolkit(
+		s.T(),
+		monkSimple.GetOptions(),
+		classes.Monk,
+		"monk-weapons-primary",
+		"monk-weapon-b",
+		[]string{
+			"club", "dagger", "handaxe", "javelin", "greatclub", "light-hammer", "mace", "quarterstaff",
+			"sickle", "spear", "light-crossbow", "shortbow", "dart", "sling",
+		},
+	)
+
 	monkOptionIDs := equipmentItemSelectionIDs(monkSimple.GetOptions())
-	assert.Contains(s.T(), monkOptionIDs, "dart",
-		"API must preserve the toolkit's simple-ranged membership")
-	assert.Contains(s.T(), monkOptionIDs, "light-crossbow",
-		"API must preserve the toolkit's simple-ranged membership")
 	assert.NotContains(s.T(), monkOptionIDs, "shortsword",
 		"shortsword is the toolkit's separate fixed Monk alternative")
 	assert.NotContains(s.T(), monkOptionIDs, "unarmed-strike",
@@ -270,14 +298,76 @@ func equipmentItemSelectionIDs(items []*dnd5ev1alpha1.EquipmentItem) []string {
 	return ids
 }
 
-func findEquipmentItem(t *testing.T, items []*dnd5ev1alpha1.EquipmentItem, selectionID string) *dnd5ev1alpha1.EquipmentItem {
+type equipmentItemExpectation struct {
+	id         string
+	quantity   int32
+	detailName string
+	weapon     dnd5ev1alpha1.Weapon
+	armor      dnd5ev1alpha1.Armor
+}
+
+func requireEquipmentItemsEqual(t *testing.T, actual []*dnd5ev1alpha1.EquipmentItem, expected []equipmentItemExpectation) {
 	t.Helper()
-	for _, item := range items {
-		if item.GetSelectionId() == selectionID {
-			return item
+	require.Len(t, actual, len(expected))
+	for index, expectation := range expected {
+		item := actual[index]
+		require.NotNil(t, item)
+		assert.Equal(t, expectation.id, item.GetSelectionId(), "item %d selection ID", index)
+		assert.Equal(t, expectation.quantity, item.GetQuantity(), "item %d quantity", index)
+		require.NotNil(t, item.GetEquipmentDetail(), "item %d detail", index)
+		assert.Equal(t, expectation.detailName, item.GetEquipmentDetail().GetName(), "item %d detail name", index)
+		switch {
+		case expectation.weapon != dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED:
+			assert.Equal(t, expectation.weapon, item.GetWeapon(), "item %d weapon type hint", index)
+		case expectation.armor != dnd5ev1alpha1.Armor_ARMOR_UNSPECIFIED:
+			assert.Equal(t, expectation.armor, item.GetArmor(), "item %d armor type hint", index)
 		}
 	}
-	require.Failf(t, "missing equipment item", "selection ID %q", selectionID)
+}
+
+func requireCategoryOptionsMatchToolkit(
+	t *testing.T,
+	actual []*dnd5ev1alpha1.EquipmentItem,
+	classID classes.Class,
+	choiceID string,
+	bundleID string,
+	expectedIDs []string,
+) {
+	t.Helper()
+	expected := toolkitCategoryOptions(t, classID, choiceID, bundleID)
+	require.Len(t, actual, len(expected), "wire options must have the same cardinality as toolkit options")
+	require.Equal(t, expectedIDs, equipmentItemSelectionIDs(actual), "wire options must retain the published registry order")
+
+	for index, source := range expected {
+		item := actual[index]
+		require.NotNil(t, item)
+		assert.Equal(t, string(source.ID), item.GetSelectionId(), "option %d selection ID", index)
+		assert.Equal(t, int32(source.Quantity), item.GetQuantity(), "option %d quantity", index)
+		require.NotNil(t, item.GetEquipmentDetail(), "option %d detail", index)
+		require.NotNil(t, source.Detail, "toolkit option %d detail", index)
+		assert.Equal(t, source.Detail.Name, item.GetEquipmentDetail().GetName(), "option %d detail name", index)
+		assert.Equal(t, int32(source.Detail.Weight), item.GetEquipmentDetail().GetWeight().GetQuantity(), "option %d detail weight", index)
+		require.NotNil(t, source.Detail.Weapon, "option %d must be a weapon", index)
+		weaponData := item.GetEquipmentDetail().GetWeaponData()
+		require.NotNil(t, weaponData, "option %d weapon detail", index)
+		assert.Equal(t, source.Detail.Weapon.Damage, weaponData.GetDamageDice(), "option %d damage dice", index)
+	}
+}
+
+func toolkitCategoryOptions(t *testing.T, classID classes.Class, choiceID, bundleID string) []choices.EquipmentItem {
+	t.Helper()
+	for _, requirement := range choices.GetClassRequirements(classID).Equipment {
+		if string(requirement.ID) != choiceID {
+			continue
+		}
+		for _, bundle := range requirement.Options {
+			if bundle.ID == bundleID {
+				require.Len(t, bundle.CategoryChoices, 1)
+				return bundle.CategoryChoices[0].Options
+			}
+		}
+	}
+	require.Failf(t, "missing toolkit category choice", "class %q choice %q bundle %q", classID, choiceID, bundleID)
 	return nil
 }
 

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
 type ConvertersTestSuite struct {
@@ -143,8 +145,8 @@ func (s *ConvertersTestSuite) TestConvertClassDataToProto_Fighter() {
 	assert.Equal(s.T(), "fighter-armor-b", leatherBundle.Id)
 	assert.Equal(s.T(), "Leather armor, longbow, and 20 arrows", leatherBundle.Label)
 	requireEquipmentItemsEqual(s.T(), leatherBundle.Items, []equipmentItemExpectation{
-		{id: "leather", quantity: 1, detailName: "Leather Armor", armor: dnd5ev1alpha1.Armor_ARMOR_LEATHER},
-		{id: "longbow", quantity: 1, detailName: "Longbow", weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW},
+		{id: armor.Leather, quantity: 1, detailName: "Leather Armor", armor: dnd5ev1alpha1.Armor_ARMOR_LEATHER},
+		{id: weapons.Longbow, quantity: 1, detailName: "Longbow", weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW},
 		{id: "arrows-20", quantity: 1, detailName: "Arrows (20)"},
 	})
 
@@ -246,9 +248,9 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOption
 		"fighter-weapons-primary",
 		"fighter-weapon-a",
 		[]string{
-			"greatsword", "longsword", "rapier", "shortsword", "battleaxe", "flail", "glaive", "greataxe",
-			"halberd", "lance", "maul", "morningstar", "pike", "scimitar", "trident", "war-pick",
-			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow", "net",
+			weapons.Greatsword, weapons.Longsword, weapons.Rapier, weapons.Shortsword, weapons.Battleaxe, weapons.Flail, weapons.Glaive, weapons.Greataxe,
+			weapons.Halberd, weapons.Lance, weapons.Maul, weapons.Morningstar, weapons.Pike, weapons.Scimitar, weapons.Trident, weapons.WarPick,
+			weapons.Warhammer, weapons.Whip, weapons.HeavyCrossbow, weapons.Longbow, weapons.Blowgun, weapons.HandCrossbow, weapons.Net,
 		},
 	)
 
@@ -261,15 +263,15 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOption
 		"monk-weapons-primary",
 		"monk-weapon-b",
 		[]string{
-			"club", "dagger", "handaxe", "javelin", "greatclub", "light-hammer", "mace", "quarterstaff",
-			"sickle", "spear", "light-crossbow", "shortbow", "dart", "sling",
+			weapons.Club, weapons.Dagger, weapons.Handaxe, weapons.Javelin, weapons.Greatclub, weapons.LightHammer, weapons.Mace, weapons.Quarterstaff,
+			weapons.Sickle, weapons.Spear, weapons.LightCrossbow, weapons.Shortbow, weapons.Dart, weapons.Sling,
 		},
 	)
 
 	monkOptionIDs := equipmentItemSelectionIDs(monkSimple.GetOptions())
-	assert.NotContains(s.T(), monkOptionIDs, "shortsword",
+	assert.NotContains(s.T(), monkOptionIDs, weapons.Shortsword,
 		"shortsword is the toolkit's separate fixed Monk alternative")
-	assert.NotContains(s.T(), monkOptionIDs, "unarmed-strike",
+	assert.NotContains(s.T(), monkOptionIDs, weapons.UnarmedStrike,
 		"API must not invent the toolkit-excluded special weapon")
 }
 
@@ -341,7 +343,7 @@ func requireCategoryOptionsMatchToolkit(
 	for index, source := range expected {
 		item := actual[index]
 		require.NotNil(t, item)
-		assert.Equal(t, string(source.ID), item.GetSelectionId(), "option %d selection ID", index)
+		assert.Equal(t, source.ID, item.GetSelectionId(), "option %d selection ID", index)
 		assert.Equal(t, int32(source.Quantity), item.GetQuantity(), "option %d quantity", index)
 		require.NotNil(t, item.GetEquipmentDetail(), "option %d detail", index)
 		require.NotNil(t, source.Detail, "toolkit option %d detail", index)

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -86,7 +86,7 @@ func (s *CharacterCreationSuite) assertInventoryCounts(char *dnd5ev1alpha1.Chara
 // FIGHTER - Equipment + Fighting Style
 // =============================================================================
 
-func (s *CharacterCreationSuite) TestCreateFighter() {
+func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongbow() {
 	s.T().Log("Creating Fighter character...")
 	ctx := s.authCtx("test-player-fighter")
 
@@ -158,7 +158,8 @@ func (s *CharacterCreationSuite) TestCreateFighter() {
 					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
 				},
 			},
-			// Primary weapons: Martial + Shield (need to specify which martial weapon)
+			// Primary weapons: the displayed broad martial category includes Longbow;
+			// exercise that real category selection rather than its common melee path.
 			{
 				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
 				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
@@ -167,7 +168,7 @@ func (s *CharacterCreationSuite) TestCreateFighter() {
 				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
 					Equipment: &dnd5ev1alpha1.EquipmentSelection{
 						Items: []*dnd5ev1alpha1.EquipmentSelectionItem{
-							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGSWORD}},
+							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW}},
 						},
 					},
 				},
@@ -239,6 +240,17 @@ func (s *CharacterCreationSuite) TestCreateFighter() {
 	s.T().Logf("✅ Fighter created: %s", char.GetId())
 	s.Assert().Equal("Sir Roland", char.GetName())
 	s.Assert().Equal(dnd5ev1alpha1.Class_CLASS_FIGHTER, char.GetClass())
+	s.assertInventoryCounts(char, map[string]int32{
+		weapons.Longbow: 1,
+		armor.Shield:    1,
+	})
+
+	persisted, err := s.server.CharacterClient.GetCharacter(ctx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: char.GetId()})
+	s.Require().NoError(err)
+	s.assertInventoryCounts(persisted.GetCharacter(), map[string]int32{
+		weapons.Longbow: 1,
+		armor.Shield:    1,
+	})
 }
 
 // =============================================================================
@@ -610,20 +622,43 @@ func (s *CharacterCreationSuite) TestListClasses_PopulatesEquipmentDetail() {
 	s.Assert().Equal(int32(16), armorData.GetBaseAc())
 	s.Assert().True(armorData.GetStealthDisadvantage())
 
-	// Bundle 1: leather armor, longbow, arrows - assert the weapon item
-	// (longbow) carries equipment_detail too.
+	// Bundle 1 is the legacy concrete path. Keep every published field in
+	// order: category-choice conversion must not regress existing bundles.
 	leatherBundle := bundles[1]
-	s.Require().Len(leatherBundle.GetItems(), 3)
-	longbow := leatherBundle.GetItems()[1]
-	s.Assert().Equal("longbow", longbow.GetSelectionId())
+	legacyItems := leatherBundle.GetItems()
+	s.Require().Len(legacyItems, 3)
+	s.Assert().Equal([]string{"leather", "longbow", "arrows-20"}, equipmentSelectionIDs(legacyItems))
+	s.Assert().Equal([]int32{1, 1, 1}, equipmentItemQuantities(legacyItems))
+
+	leather := legacyItems[0]
+	s.Assert().Equal(dnd5ev1alpha1.Armor_ARMOR_LEATHER, leather.GetArmor())
+	s.Require().NotNil(leather.GetEquipmentDetail(), "leather should carry resolved detail over the wire")
+	s.Assert().Equal("Leather Armor", leather.GetEquipmentDetail().GetName())
+	leatherData := leather.GetEquipmentDetail().GetArmorData()
+	s.Require().NotNil(leatherData)
+	s.Assert().Equal(dnd5ev1alpha1.ArmorCategory_ARMOR_CATEGORY_LIGHT, leatherData.GetArmorCategory())
+	s.Assert().Equal(int32(11), leatherData.GetBaseAc())
+	s.Assert().True(leatherData.GetDexBonus())
+
+	longbow := legacyItems[1]
+	s.Assert().Equal(dnd5ev1alpha1.Weapon_WEAPON_LONGBOW, longbow.GetWeapon())
 	s.Require().NotNil(longbow.GetEquipmentDetail(),
 		"longbow EquipmentItem should carry equipment_detail over the wire")
+	s.Assert().Equal("Longbow", longbow.GetEquipmentDetail().GetName())
 	weaponData := longbow.GetEquipmentDetail().GetWeaponData()
 	s.Require().NotNil(weaponData, "longbow equipment_detail should carry weapon data")
 	s.Assert().Equal("1d8", weaponData.GetDamageDice())
 	s.Assert().Equal(dnd5ev1alpha1.DamageType_DAMAGE_TYPE_PIERCING, weaponData.GetDamageType())
 	s.Assert().Equal(int32(150), weaponData.GetNormalRange())
 	s.Assert().Equal(int32(600), weaponData.GetLongRange())
+
+	arrows := legacyItems[2]
+	s.Assert().Nil(arrows.GetTypeHint(), "legacy ammunition type hint must remain absent")
+	s.Require().NotNil(arrows.GetEquipmentDetail(), "arrows should carry resolved detail over the wire")
+	s.Assert().Equal("Arrows (20)", arrows.GetEquipmentDetail().GetName())
+	s.Assert().Equal(dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_ADVENTURING_GEAR,
+		arrows.GetEquipmentDetail().GetCategory())
+	s.Assert().Nil(arrows.GetEquipmentDetail().GetEquipmentData())
 }
 
 func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptions() {
@@ -638,19 +673,32 @@ func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptio
 	}
 
 	fighterMartial := categoryChoiceFromClass(s.T(), classesByID[dnd5ev1alpha1.Class_CLASS_FIGHTER], "fighter-weapons-primary", "fighter-weapon-a")
-	fighterIDs := equipmentSelectionIDs(fighterMartial.GetOptions())
-	s.Assert().Contains(fighterIDs, "longsword", "real ListClasses RPC must preserve toolkit martial-melee membership")
-	s.Assert().Contains(fighterIDs, "longbow", "real ListClasses RPC must preserve toolkit martial-ranged membership")
+	assertCategoryWeaponOptions(
+		s.T(),
+		fighterMartial.GetOptions(),
+		[]string{
+			"greatsword", "longsword", "rapier", "shortsword", "battleaxe", "flail", "glaive", "greataxe",
+			"halberd", "lance", "maul", "morningstar", "pike", "scimitar", "trident", "war-pick",
+			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow", "net",
+		},
+	)
 	longbow := equipmentItemByID(s.T(), fighterMartial.GetOptions(), "longbow")
+	s.Equal(dnd5ev1alpha1.Weapon_WEAPON_LONGBOW, longbow.GetWeapon())
 	s.Equal(int32(1), longbow.GetQuantity())
 	s.Require().NotNil(longbow.GetEquipmentDetail(), "resolved detail must survive the real RPC")
 	s.Equal("Longbow", longbow.GetEquipmentDetail().GetName())
 	s.Equal("1d8", longbow.GetEquipmentDetail().GetWeaponData().GetDamageDice())
 
 	monkSimple := categoryChoiceFromClass(s.T(), classesByID[dnd5ev1alpha1.Class_CLASS_MONK], "monk-weapons-primary", "monk-weapon-b")
+	assertCategoryWeaponOptions(
+		s.T(),
+		monkSimple.GetOptions(),
+		[]string{
+			"club", "dagger", "handaxe", "javelin", "greatclub", "light-hammer", "mace", "quarterstaff",
+			"sickle", "spear", "light-crossbow", "shortbow", "dart", "sling",
+		},
+	)
 	monkIDs := equipmentSelectionIDs(monkSimple.GetOptions())
-	s.Assert().Contains(monkIDs, "dart", "real ListClasses RPC must retain Monk simple-ranged membership")
-	s.Assert().Contains(monkIDs, "light-crossbow", "real ListClasses RPC must retain Monk simple-ranged membership")
 	s.Assert().NotContains(monkIDs, "shortsword", "shortsword remains the separate fixed Monk alternative")
 	s.Assert().NotContains(monkIDs, "unarmed-strike", "toolkit special-weapon exclusion must survive the RPC")
 }
@@ -679,6 +727,28 @@ func equipmentSelectionIDs(items []*dnd5ev1alpha1.EquipmentItem) []string {
 		ids = append(ids, item.GetSelectionId())
 	}
 	return ids
+}
+
+func equipmentItemQuantities(items []*dnd5ev1alpha1.EquipmentItem) []int32 {
+	quantities := make([]int32, 0, len(items))
+	for _, item := range items {
+		quantities = append(quantities, item.GetQuantity())
+	}
+	return quantities
+}
+
+func assertCategoryWeaponOptions(t *testing.T, actual []*dnd5ev1alpha1.EquipmentItem, expectedIDs []string) {
+	t.Helper()
+	require.Equal(t, expectedIDs, equipmentSelectionIDs(actual), "category option IDs and registry order")
+	require.Len(t, actual, len(expectedIDs))
+	for index, item := range actual {
+		require.NotNil(t, item, "option %d", index)
+		require.Equal(t, int32(1), item.GetQuantity(), "option %d quantity", index)
+		require.NotEqual(t, dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED, item.GetWeapon(), "option %d type hint", index)
+		require.NotNil(t, item.GetEquipmentDetail(), "option %d detail", index)
+		require.NotNil(t, item.GetEquipmentDetail().GetWeaponData(), "option %d weapon detail", index)
+		require.NotEmpty(t, item.GetEquipmentDetail().GetName(), "option %d detail name", index)
+	}
 }
 
 func equipmentItemByID(t *testing.T, items []*dnd5ev1alpha1.EquipmentItem, selectionID string) *dnd5ev1alpha1.EquipmentItem {
@@ -737,9 +807,47 @@ func (s *CharacterCreationSuite) TestListRaces_PopulatesTraits() {
 	s.Assert().Contains(dwarfNames, "Stonecunning")
 }
 
-func (s *CharacterCreationSuite) TestCreateMonk() {
-	s.T().Log("Creating Monk character...")
-	ctx := s.authCtx("test-player-monk")
+func (s *CharacterCreationSuite) TestCreateMonk_SimpleRangedCategorySelections() {
+	testCases := []struct {
+		name     string
+		weapon   dnd5ev1alpha1.Weapon
+		expected map[string]int32
+	}{
+		{
+			name:   "dart",
+			weapon: dnd5ev1alpha1.Weapon_WEAPON_DART,
+			expected: map[string]int32{
+				weapons.Dart: 11, // 10 class-granted darts + the selected category weapon
+			},
+		},
+		{
+			name:   "light-crossbow",
+			weapon: dnd5ev1alpha1.Weapon_WEAPON_LIGHT_CROSSBOW,
+			expected: map[string]int32{
+				weapons.Dart:          10,
+				weapons.LightCrossbow: 1,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.Run(testCase.name, func() {
+			ctx := s.authCtx("test-player-monk-" + testCase.name)
+			char := s.createMonkWithSimpleRangedWeapon(ctx, testCase.weapon)
+			s.assertInventoryCounts(char, testCase.expected)
+
+			persisted, err := s.server.CharacterClient.GetCharacter(ctx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: char.GetId()})
+			s.Require().NoError(err)
+			s.assertInventoryCounts(persisted.GetCharacter(), testCase.expected)
+		})
+	}
+}
+
+func (s *CharacterCreationSuite) createMonkWithSimpleRangedWeapon(
+	ctx context.Context,
+	weapon dnd5ev1alpha1.Weapon,
+) *dnd5ev1alpha1.Character {
+	s.T().Logf("Creating Monk with simple-ranged %s...", weapon)
 
 	// Create draft
 	createResp, err := s.server.CharacterClient.CreateDraft(ctx, &dnd5ev1alpha1.CreateDraftRequest{})
@@ -793,14 +901,19 @@ func (s *CharacterCreationSuite) TestCreateMonk() {
 					},
 				},
 			},
-			// Weapon: Shortsword
+			// Monk's broad simple-weapon option accepts the ranged choice advertised
+			// by ListClasses; the toolkit remains the selection validator.
 			{
 				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
 				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
 				ChoiceId: "monk-weapons-primary",
-				OptionId: "monk-weapon-a", // Shortsword
+				OptionId: "monk-weapon-b", // Any simple weapon
 				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
-					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{
+						Items: []*dnd5ev1alpha1.EquipmentSelectionItem{
+							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: weapon}},
+						},
+					},
 				},
 			},
 			// Pack: Dungeoneer's pack
@@ -860,16 +973,6 @@ func (s *CharacterCreationSuite) TestCreateMonk() {
 	char := finalizeResp.GetCharacter()
 	s.Assert().Equal("Shadow", char.GetName())
 	s.Assert().Equal(dnd5ev1alpha1.Class_CLASS_MONK, char.GetClass())
-
-	s.assertInventoryCounts(char, map[string]int32{
-		weapons.Dart: 10,
-	})
-
-	persisted, err := s.server.CharacterClient.GetCharacter(ctx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: char.GetId()})
-	s.Require().NoError(err)
-	s.assertInventoryCounts(persisted.GetCharacter(), map[string]int32{
-		weapons.Dart: 10,
-	})
-
 	s.T().Logf("✅ Monk created: %s", char.GetId())
+	return char
 }

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -829,6 +829,21 @@ func (s *CharacterCreationSuite) TestListRaces_PopulatesTraits() {
 	s.Assert().Contains(dwarfNames, "Stonecunning")
 }
 
+func (s *CharacterCreationSuite) TestCreateMonk_FixedShortsword() {
+	ctx := s.authCtx("test-player-monk-shortsword")
+	char := s.createMonkWithPrimaryWeapon(ctx, "monk-weapon-a", dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED)
+
+	expectedInventory := map[string]int32{
+		weapons.Dart:       10,
+		weapons.Shortsword: 1,
+	}
+	s.assertInventoryCounts(char, expectedInventory)
+
+	persisted, err := s.server.CharacterClient.GetCharacter(ctx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: char.GetId()})
+	s.Require().NoError(err)
+	s.assertInventoryCounts(persisted.GetCharacter(), expectedInventory)
+}
+
 func (s *CharacterCreationSuite) TestCreateMonk_SimpleRangedCategorySelections() {
 	testCases := []struct {
 		name     string
@@ -855,7 +870,7 @@ func (s *CharacterCreationSuite) TestCreateMonk_SimpleRangedCategorySelections()
 	for _, testCase := range testCases {
 		s.Run(testCase.name, func() {
 			ctx := s.authCtx("test-player-monk-" + testCase.name)
-			char := s.createMonkWithSimpleRangedWeapon(ctx, testCase.weapon)
+			char := s.createMonkWithPrimaryWeapon(ctx, "monk-weapon-b", testCase.weapon)
 			s.assertInventoryCounts(char, testCase.expected)
 
 			persisted, err := s.server.CharacterClient.GetCharacter(ctx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: char.GetId()})
@@ -865,11 +880,12 @@ func (s *CharacterCreationSuite) TestCreateMonk_SimpleRangedCategorySelections()
 	}
 }
 
-func (s *CharacterCreationSuite) createMonkWithSimpleRangedWeapon(
+func (s *CharacterCreationSuite) createMonkWithPrimaryWeapon(
 	ctx context.Context,
+	optionID string,
 	weapon dnd5ev1alpha1.Weapon,
 ) *dnd5ev1alpha1.Character {
-	s.T().Logf("Creating Monk with simple-ranged %s...", weapon)
+	s.T().Logf("Creating Monk with primary weapon option %s...", optionID)
 
 	// Create draft
 	createResp, err := s.server.CharacterClient.CreateDraft(ctx, &dnd5ev1alpha1.CreateDraftRequest{})
@@ -901,6 +917,13 @@ func (s *CharacterCreationSuite) createMonkWithSimpleRangedWeapon(
 	})
 	s.Require().NoError(err)
 
+	weaponSelection := &dnd5ev1alpha1.EquipmentSelection{}
+	if weapon != dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED {
+		weaponSelection.Items = []*dnd5ev1alpha1.EquipmentSelectionItem{
+			{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: weapon}},
+		}
+	}
+
 	// Set Monk with required choices:
 	// - 2 skills (from Monk skill list)
 	// - Weapon choice (shortsword or simple weapon)
@@ -923,19 +946,15 @@ func (s *CharacterCreationSuite) createMonkWithSimpleRangedWeapon(
 					},
 				},
 			},
-			// Monk's broad simple-weapon option accepts the ranged choice advertised
-			// by ListClasses; the toolkit remains the selection validator.
+			// The fixed Shortsword alternative needs no explicit item; the broad
+			// simple-weapon alternative carries its selected toolkit-advertised weapon.
 			{
 				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
 				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
 				ChoiceId: "monk-weapons-primary",
-				OptionId: "monk-weapon-b", // Any simple weapon
+				OptionId: optionID,
 				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
-					Equipment: &dnd5ev1alpha1.EquipmentSelection{
-						Items: []*dnd5ev1alpha1.EquipmentSelectionItem{
-							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: weapon}},
-						},
-					},
+					Equipment: weaponSelection,
 				},
 			},
 			// Pack: Dungeoneer's pack

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -16,7 +16,12 @@ import (
 
 	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
 	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+	"github.com/KirkDiggler/rpg-api/internal/pkg/clock"
+	"github.com/KirkDiggler/rpg-api/internal/pkg/idgen"
+	redisclient "github.com/KirkDiggler/rpg-api/internal/redis"
+	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/tools"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
@@ -880,6 +885,14 @@ func (s *CharacterCreationSuite) TestCreateMonk_SimpleRangedCategorySelections()
 		expected map[string]int32
 	}{
 		{
+			name:   "club",
+			weapon: dnd5ev1alpha1.Weapon_WEAPON_CLUB,
+			expected: map[string]int32{
+				weapons.Club: 1,
+				weapons.Dart: 10,
+			},
+		},
+		{
 			name:   "dart",
 			weapon: dnd5ev1alpha1.Weapon_WEAPON_DART,
 			expected: map[string]int32{
@@ -909,11 +922,87 @@ func (s *CharacterCreationSuite) TestCreateMonk_SimpleRangedCategorySelections()
 	}
 }
 
+func (s *CharacterCreationSuite) TestCreateMonk_RejectsLiveAndPersistedUnarmedStrikeCategorySelection() {
+	ctx := s.authCtx("test-player-monk-unarmed-strike")
+
+	// A live request must fail before the invalid selection is saved.
+	createResp, err := s.server.CharacterClient.CreateDraft(ctx, &dnd5ev1alpha1.CreateDraftRequest{})
+	s.Require().NoError(err)
+	invalidChoices := monkClassChoices("monk-weapon-b", dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED)
+	invalidChoices[1].GetEquipment().Items = []*dnd5ev1alpha1.EquipmentSelectionItem{{
+		Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_OtherEquipmentId{OtherEquipmentId: weapons.UnarmedStrike},
+	}}
+	_, err = s.server.CharacterClient.UpdateClass(ctx, &dnd5ev1alpha1.UpdateClassRequest{
+		DraftId:      createResp.GetDraft().GetId(),
+		Class:        dnd5ev1alpha1.Class_CLASS_MONK,
+		ClassChoices: invalidChoices,
+	})
+	s.Require().Error(err)
+	s.ErrorContains(err, "Invalid equipment choice 'unarmed-strike'")
+
+	// Seed the serialized shape accepted by v0.70.0, then prove the real
+	// FinalizeDraft RPC revalidates persisted selections before creating a character.
+	draftID := s.createMonkDraftWithPrimaryWeapon(ctx, "monk-weapon-b", dnd5ev1alpha1.Weapon_WEAPON_CLUB)
+	draftRepo := s.newDraftRepository()
+	stored, err := draftRepo.Get(ctx, characterdraft.GetInput{ID: draftID})
+	s.Require().NoError(err)
+	mutated := false
+	for i := range stored.Draft.Data.Choices {
+		choice := &stored.Draft.Data.Choices[i]
+		if choice.ChoiceID == "monk-weapons-primary" && choice.OptionID == "monk-weapon-b" {
+			choice.EquipmentSelection = []shared.SelectionID{weapons.UnarmedStrike}
+			mutated = true
+			break
+		}
+	}
+	s.Require().True(mutated, "valid Monk category selection must be persisted before the regression mutation")
+	_, err = draftRepo.Update(ctx, characterdraft.UpdateInput{Draft: stored.Draft})
+	s.Require().NoError(err)
+
+	_, err = s.server.CharacterClient.FinalizeDraft(ctx, &dnd5ev1alpha1.FinalizeDraftRequest{DraftId: draftID})
+	s.Require().Error(err)
+	s.ErrorContains(err, "unarmed-strike")
+}
+
+func (s *CharacterCreationSuite) newDraftRepository() characterdraft.Repository {
+	client, err := redisclient.NewClient(sharedRedis.Addr, nil)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { _ = client.Close() })
+
+	repo, err := characterdraft.NewRedis(&characterdraft.Config{
+		Client:      client,
+		Clock:       clock.New(),
+		IDGenerator: idgen.NewPrefixed("test-draft-"),
+	})
+	s.Require().NoError(err)
+	return repo
+}
+
 func (s *CharacterCreationSuite) createMonkWithPrimaryWeapon(
 	ctx context.Context,
 	optionID string,
 	weapon dnd5ev1alpha1.Weapon,
 ) *dnd5ev1alpha1.Character {
+	draftID := s.createMonkDraftWithPrimaryWeapon(ctx, optionID, weapon)
+
+	finalizeResp, err := s.server.CharacterClient.FinalizeDraft(ctx, &dnd5ev1alpha1.FinalizeDraftRequest{
+		DraftId: draftID,
+	})
+	s.Require().NoError(err, "finalize should succeed")
+	s.Require().NotNil(finalizeResp.GetCharacter())
+
+	char := finalizeResp.GetCharacter()
+	s.Assert().Equal("Shadow", char.GetName())
+	s.Assert().Equal(dnd5ev1alpha1.Class_CLASS_MONK, char.GetClass())
+	s.T().Logf("✅ Monk created: %s", char.GetId())
+	return char
+}
+
+func (s *CharacterCreationSuite) createMonkDraftWithPrimaryWeapon(
+	ctx context.Context,
+	optionID string,
+	weapon dnd5ev1alpha1.Weapon,
+) string {
 	s.T().Logf("Creating Monk with primary weapon option %s...", optionID)
 
 	// Create draft
@@ -946,67 +1035,11 @@ func (s *CharacterCreationSuite) createMonkWithPrimaryWeapon(
 	})
 	s.Require().NoError(err)
 
-	weaponSelection := &dnd5ev1alpha1.EquipmentSelection{}
-	if weapon != dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED {
-		weaponSelection.Items = []*dnd5ev1alpha1.EquipmentSelectionItem{
-			{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: weapon}},
-		}
-	}
-
-	// Set Monk with required choices:
-	// - 2 skills (from Monk skill list)
-	// - Weapon choice (shortsword or simple weapon)
-	// - Pack choice (dungeoneer's or explorer's)
-	// - Tool choice (artisan's tools or musical instrument)
+	// Set Monk with required choices.
 	_, err = s.server.CharacterClient.UpdateClass(ctx, &dnd5ev1alpha1.UpdateClassRequest{
-		DraftId: draftID,
-		Class:   dnd5ev1alpha1.Class_CLASS_MONK,
-		ClassChoices: []*dnd5ev1alpha1.ChoiceData{
-			// Skills: Acrobatics and Stealth
-			{
-				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_SKILLS,
-				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
-				Selection: &dnd5ev1alpha1.ChoiceData_Skills{
-					Skills: &dnd5ev1alpha1.SkillSelection{
-						Skills: []dnd5ev1alpha1.Skill{
-							dnd5ev1alpha1.Skill_SKILL_ACROBATICS,
-							dnd5ev1alpha1.Skill_SKILL_STEALTH,
-						},
-					},
-				},
-			},
-			// The fixed Shortsword alternative needs no explicit item; the broad
-			// simple-weapon alternative carries its selected toolkit-advertised weapon.
-			{
-				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
-				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
-				ChoiceId: "monk-weapons-primary",
-				OptionId: optionID,
-				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
-					Equipment: weaponSelection,
-				},
-			},
-			// Pack: Dungeoneer's pack
-			{
-				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
-				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
-				ChoiceId: "monk-pack",
-				OptionId: "monk-pack-a", // Dungeoneer's pack
-				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
-					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
-				},
-			},
-			// Tools: Calligrapher's supplies (fits the Monk aesthetic)
-			{
-				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_TOOLS,
-				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
-				Selection: &dnd5ev1alpha1.ChoiceData_Tools{
-					Tools: &dnd5ev1alpha1.ToolSelection{
-						Tools: []dnd5ev1alpha1.Tool{dnd5ev1alpha1.Tool_TOOL_CALLIGRAPHER_SUPPLIES},
-					},
-				},
-			},
-		},
+		DraftId:      draftID,
+		Class:        dnd5ev1alpha1.Class_CLASS_MONK,
+		ClassChoices: monkClassChoices(optionID, weapon),
 	})
 	s.Require().NoError(err)
 
@@ -1033,16 +1066,45 @@ func (s *CharacterCreationSuite) createMonkWithPrimaryWeapon(
 	})
 	s.Require().NoError(err)
 
-	// Finalize
-	finalizeResp, err := s.server.CharacterClient.FinalizeDraft(ctx, &dnd5ev1alpha1.FinalizeDraftRequest{
-		DraftId: draftID,
-	})
-	s.Require().NoError(err, "finalize should succeed")
-	s.Require().NotNil(finalizeResp.GetCharacter())
+	return draftID
+}
 
-	char := finalizeResp.GetCharacter()
-	s.Assert().Equal("Shadow", char.GetName())
-	s.Assert().Equal(dnd5ev1alpha1.Class_CLASS_MONK, char.GetClass())
-	s.T().Logf("✅ Monk created: %s", char.GetId())
-	return char
+func monkClassChoices(optionID string, weapon dnd5ev1alpha1.Weapon) []*dnd5ev1alpha1.ChoiceData {
+	weaponSelection := &dnd5ev1alpha1.EquipmentSelection{}
+	if weapon != dnd5ev1alpha1.Weapon_WEAPON_UNSPECIFIED {
+		weaponSelection.Items = []*dnd5ev1alpha1.EquipmentSelectionItem{
+			{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: weapon}},
+		}
+	}
+
+	return []*dnd5ev1alpha1.ChoiceData{
+		{
+			Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_SKILLS,
+			Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+			Selection: &dnd5ev1alpha1.ChoiceData_Skills{Skills: &dnd5ev1alpha1.SkillSelection{
+				Skills: []dnd5ev1alpha1.Skill{dnd5ev1alpha1.Skill_SKILL_ACROBATICS, dnd5ev1alpha1.Skill_SKILL_STEALTH},
+			}},
+		},
+		{
+			Category:  dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+			Source:    dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+			ChoiceId:  "monk-weapons-primary",
+			OptionId:  optionID,
+			Selection: &dnd5ev1alpha1.ChoiceData_Equipment{Equipment: weaponSelection},
+		},
+		{
+			Category:  dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+			Source:    dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+			ChoiceId:  "monk-pack",
+			OptionId:  "monk-pack-a",
+			Selection: &dnd5ev1alpha1.ChoiceData_Equipment{Equipment: &dnd5ev1alpha1.EquipmentSelection{}},
+		},
+		{
+			Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_TOOLS,
+			Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+			Selection: &dnd5ev1alpha1.ChoiceData_Tools{Tools: &dnd5ev1alpha1.ToolSelection{
+				Tools: []dnd5ev1alpha1.Tool{dnd5ev1alpha1.Tool_TOOL_CALLIGRAPHER_SUPPLIES},
+			}},
+		},
+	}
 }

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
 
@@ -623,6 +624,72 @@ func (s *CharacterCreationSuite) TestListClasses_PopulatesEquipmentDetail() {
 	s.Assert().Equal(dnd5ev1alpha1.DamageType_DAMAGE_TYPE_PIERCING, weaponData.GetDamageType())
 	s.Assert().Equal(int32(150), weaponData.GetNormalRange())
 	s.Assert().Equal(int32(600), weaponData.GetLongRange())
+}
+
+func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptions() {
+	ctx := s.authCtx("test-list-classes-category-choice-options")
+
+	response, err := s.server.CharacterClient.ListClasses(ctx, &dnd5ev1alpha1.ListClassesRequest{})
+	s.Require().NoError(err)
+
+	classesByID := make(map[dnd5ev1alpha1.Class]*dnd5ev1alpha1.ClassInfo, len(response.GetClasses()))
+	for _, classInfo := range response.GetClasses() {
+		classesByID[classInfo.GetClassId()] = classInfo
+	}
+
+	fighterMartial := categoryChoiceFromClass(s.T(), classesByID[dnd5ev1alpha1.Class_CLASS_FIGHTER], "fighter-weapons-primary", "fighter-weapon-a")
+	fighterIDs := equipmentSelectionIDs(fighterMartial.GetOptions())
+	s.Assert().Contains(fighterIDs, "longsword", "real ListClasses RPC must preserve toolkit martial-melee membership")
+	s.Assert().Contains(fighterIDs, "longbow", "real ListClasses RPC must preserve toolkit martial-ranged membership")
+	longbow := equipmentItemByID(s.T(), fighterMartial.GetOptions(), "longbow")
+	s.Equal(int32(1), longbow.GetQuantity())
+	s.Require().NotNil(longbow.GetEquipmentDetail(), "resolved detail must survive the real RPC")
+	s.Equal("Longbow", longbow.GetEquipmentDetail().GetName())
+	s.Equal("1d8", longbow.GetEquipmentDetail().GetWeaponData().GetDamageDice())
+
+	monkSimple := categoryChoiceFromClass(s.T(), classesByID[dnd5ev1alpha1.Class_CLASS_MONK], "monk-weapons-primary", "monk-weapon-b")
+	monkIDs := equipmentSelectionIDs(monkSimple.GetOptions())
+	s.Assert().Contains(monkIDs, "dart", "real ListClasses RPC must retain Monk simple-ranged membership")
+	s.Assert().Contains(monkIDs, "light-crossbow", "real ListClasses RPC must retain Monk simple-ranged membership")
+	s.Assert().NotContains(monkIDs, "shortsword", "shortsword remains the separate fixed Monk alternative")
+	s.Assert().NotContains(monkIDs, "unarmed-strike", "toolkit special-weapon exclusion must survive the RPC")
+}
+
+func categoryChoiceFromClass(t *testing.T, classInfo *dnd5ev1alpha1.ClassInfo, choiceID, bundleID string) *dnd5ev1alpha1.EquipmentCategoryChoice {
+	t.Helper()
+	require.NotNil(t, classInfo)
+	for _, choice := range classInfo.GetChoices() {
+		if choice.GetId() != choiceID {
+			continue
+		}
+		for _, bundle := range choice.GetEquipmentOptions().GetBundles() {
+			if bundle.GetId() == bundleID {
+				require.Len(t, bundle.GetCategoryChoices(), 1)
+				return bundle.GetCategoryChoices()[0]
+			}
+		}
+	}
+	require.Failf(t, "missing category choice", "choice %q bundle %q", choiceID, bundleID)
+	return nil
+}
+
+func equipmentSelectionIDs(items []*dnd5ev1alpha1.EquipmentItem) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.GetSelectionId())
+	}
+	return ids
+}
+
+func equipmentItemByID(t *testing.T, items []*dnd5ev1alpha1.EquipmentItem, selectionID string) *dnd5ev1alpha1.EquipmentItem {
+	t.Helper()
+	for _, item := range items {
+		if item.GetSelectionId() == selectionID {
+			return item
+		}
+	}
+	require.Failf(t, "missing equipment item", "selection ID %q", selectionID)
+	return nil
 }
 
 func (s *CharacterCreationSuite) TestListRaces_PopulatesTraits() {

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -711,6 +711,18 @@ func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptio
 	s.Equal("Longbow", longbow.GetEquipmentDetail().GetName())
 	s.Equal("1d8", longbow.GetEquipmentDetail().GetWeaponData().GetDamageDice())
 
+	monkFixed := equipmentBundleFromClass(s.T(), classesByID[dnd5ev1alpha1.Class_CLASS_MONK], "monk-weapons-primary", "monk-weapon-a")
+	s.Require().Empty(monkFixed.GetCategoryChoices(), "fixed Monk alternative must not become a category choice")
+	s.Require().Len(monkFixed.GetItems(), 1)
+	shortsword := monkFixed.GetItems()[0]
+	s.Equal("shortsword", shortsword.GetSelectionId())
+	s.Equal(int32(1), shortsword.GetQuantity())
+	s.Equal(dnd5ev1alpha1.Weapon_WEAPON_SHORTSWORD, shortsword.GetWeapon())
+	s.Require().NotNil(shortsword.GetEquipmentDetail())
+	s.Equal("Shortsword", shortsword.GetEquipmentDetail().GetName())
+	s.Equal(int32(10), shortsword.GetEquipmentDetail().GetCost().GetQuantity())
+	s.Equal("gp", shortsword.GetEquipmentDetail().GetCost().GetUnit())
+
 	monkSimple := categoryChoiceFromClass(s.T(), classesByID[dnd5ev1alpha1.Class_CLASS_MONK], "monk-weapons-primary", "monk-weapon-b")
 	assertCategoryWeaponOptions(
 		s.T(),
@@ -723,6 +735,23 @@ func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptio
 	monkIDs := equipmentSelectionIDs(monkSimple.GetOptions())
 	s.Assert().NotContains(monkIDs, "shortsword", "shortsword remains the separate fixed Monk alternative")
 	s.Assert().NotContains(monkIDs, "unarmed-strike", "toolkit special-weapon exclusion must survive the RPC")
+}
+
+func equipmentBundleFromClass(t *testing.T, classInfo *dnd5ev1alpha1.ClassInfo, choiceID, bundleID string) *dnd5ev1alpha1.EquipmentBundle {
+	t.Helper()
+	require.NotNil(t, classInfo)
+	for _, choice := range classInfo.GetChoices() {
+		if choice.GetId() != choiceID {
+			continue
+		}
+		for _, bundle := range choice.GetEquipmentOptions().GetBundles() {
+			if bundle.GetId() == bundleID {
+				return bundle
+			}
+		}
+	}
+	require.Failf(t, "missing equipment bundle", "choice %q bundle %q", choiceID, bundleID)
+	return nil
 }
 
 func categoryChoiceFromClass(t *testing.T, classInfo *dnd5ev1alpha1.ClassInfo, choiceID, bundleID string) *dnd5ev1alpha1.EquipmentCategoryChoice {

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -87,8 +87,36 @@ func (s *CharacterCreationSuite) assertInventoryCounts(char *dnd5ev1alpha1.Chara
 // =============================================================================
 
 func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongbow() {
-	s.T().Log("Creating Fighter character...")
-	ctx := s.authCtx("test-player-fighter")
+	s.createFighterWithMartialWeapon(
+		s.authCtx("test-player-fighter-longbow"),
+		"Sir Roland",
+		dnd5ev1alpha1.Weapon_WEAPON_LONGBOW,
+		map[string]int32{
+			weapons.Longbow: 1,
+			armor.Shield:    1,
+		},
+	)
+}
+
+func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongsword() {
+	s.createFighterWithMartialWeapon(
+		s.authCtx("test-player-fighter-longsword"),
+		"Dame Elara",
+		dnd5ev1alpha1.Weapon_WEAPON_LONGSWORD,
+		map[string]int32{
+			weapons.Longsword: 1,
+			armor.Shield:      1,
+		},
+	)
+}
+
+func (s *CharacterCreationSuite) createFighterWithMartialWeapon(
+	ctx context.Context,
+	name string,
+	weapon dnd5ev1alpha1.Weapon,
+	expectedInventory map[string]int32,
+) {
+	s.T().Logf("Creating Fighter with broad-category %s...", weapon)
 
 	// Create draft
 	createResp, err := s.server.CharacterClient.CreateDraft(ctx, &dnd5ev1alpha1.CreateDraftRequest{})
@@ -98,7 +126,7 @@ func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongbow() {
 	// Set name
 	_, err = s.server.CharacterClient.UpdateName(ctx, &dnd5ev1alpha1.UpdateNameRequest{
 		DraftId: draftID,
-		Name:    "Sir Roland",
+		Name:    name,
 	})
 	s.Require().NoError(err)
 
@@ -158,8 +186,8 @@ func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongbow() {
 					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
 				},
 			},
-			// Primary weapons: the displayed broad martial category includes Longbow;
-			// exercise that real category selection rather than its common melee path.
+			// Primary weapons: choose a concrete option from the advertised broad
+			// martial category; toolkit owns selection eligibility.
 			{
 				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
 				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
@@ -168,7 +196,7 @@ func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongbow() {
 				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
 					Equipment: &dnd5ev1alpha1.EquipmentSelection{
 						Items: []*dnd5ev1alpha1.EquipmentSelectionItem{
-							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGBOW}},
+							{Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{Weapon: weapon}},
 						},
 					},
 				},
@@ -238,19 +266,13 @@ func (s *CharacterCreationSuite) TestCreateFighter_BroadCategoryLongbow() {
 
 	char := finalizeResp.GetCharacter()
 	s.T().Logf("✅ Fighter created: %s", char.GetId())
-	s.Assert().Equal("Sir Roland", char.GetName())
+	s.Assert().Equal(name, char.GetName())
 	s.Assert().Equal(dnd5ev1alpha1.Class_CLASS_FIGHTER, char.GetClass())
-	s.assertInventoryCounts(char, map[string]int32{
-		weapons.Longbow: 1,
-		armor.Shield:    1,
-	})
+	s.assertInventoryCounts(char, expectedInventory)
 
 	persisted, err := s.server.CharacterClient.GetCharacter(ctx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: char.GetId()})
 	s.Require().NoError(err)
-	s.assertInventoryCounts(persisted.GetCharacter(), map[string]int32{
-		weapons.Longbow: 1,
-		armor.Shield:    1,
-	})
+	s.assertInventoryCounts(persisted.GetCharacter(), expectedInventory)
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

Closes #755.

Maps toolkit-resolved `EquipmentCategoryChoice.Options` directly to the additive proto `options` field. The API neither determines eligibility nor reconstructs category membership.

Follow-up `bd7a31c` adds production creation-path coverage and strengthens the legacy wire assertions.

## Dependencies / merge order

- `github.com/KirkDiggler/rpg-api-protos/gen/go@v0.0.0-20260803031544-94c9de0ad8de`, generated from rpg-api-protos#207 (`01da01b28e379d46cf567c31aa074bbc5c0232e3`)
- `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e@v0.70.1`, published from rpg-toolkit#879 (`d77ef3b0525f513fcd172a6b3234f7a2b78d3dd8`)
- Design: rpg-project#173; downstream web adoption: rpg-dnd5e-web#668

No `replace` directives; dependency versions remain exactly as published above.

## Evidence

- Converter and real `ListClasses` RPC tests compare the **full ordered** Fighter martial (23) and Monk simple (14) option lists. They verify source-equivalent ID, quantity, resolved name/weight/damage, type hint, and detail presence.
- The real RPC legacy-bundle test pins `leather`, `longbow`, `arrows-20` in order with quantities, type hints, and resolved armor/weapon/ammunition detail.
- Genuine real-Redis creation flows prove `CreateDraft → UpdateClass → FinalizeDraft` succeeds for Fighter's broad-category `longbow`, then persists it; and for Monk's broad simple-ranged `dart` (including its +1 selected item) and `light-crossbow`, then persists both results.

## TDD / selection-constraint regression

The real Redis/gRPC regression first runs red against the prior published
`v0.70.0`: `UpdateClass` accepts `OtherEquipmentId: "unarmed-strike"` for
Monk `monk-weapon-b`. With `v0.70.1`, the same live request fails before it
can persist. The regression also creates a legitimate persisted Monk `club`
draft, seeds the legacy serialized `unarmed-strike` category selection through
the draft repository seam, and proves the real `FinalizeDraft` RPC rejects it.
The valid `club`, `dart`, and `light-crossbow` paths still finalize and persist.
No API eligibility logic was added: toolkit remains the validator.

## Verification

Passed: focused unit + real-Redis creation RPC tests (including `-race`), `go build ./...`, `go vet ./...`, `go test -race ./...`, and `make test-ci`.

`make ci-check` passes its test phase and remains nonzero only for the 29-diagnostic baseline linter and existing mock-generation drift; it leaves the tree clean. Scoped and full `golangci-lint` match the base finding counts; the new `converters.go:2510` unconvert is fixed.

— asset-pipeline agent, on behalf of KirkDiggler
