### PR TITLE
feat(content): both tomb hall skeletons hunt the wounded (#785)

### DIFF
--- a/internal/content/dungeons/reference-tomb.yaml
+++ b/internal/content/dungeons/reference-tomb.yaml
@@ -21,7 +21,7 @@ rooms:
       - { ref: "dnd5e:props:torch-ornate", at: [4, 1] }
       - { ref: "dnd5e:props:bone-pile", at: [8, 6] }
       - { ref: "dnd5e:monsters:skeleton", at: [5, 3], targeting: lowest-health }
-      - { ref: "dnd5e:monsters:skeleton", at: [7, 5] }
+      - { ref: "dnd5e:monsters:skeleton", at: [7, 5], targeting: lowest-health }
   - id: tomb
     archetype: boss
     width: 12


### PR DESCRIPTION
One-line content change per Kirk's post-merge play session: the [7,5] hall skeleton joins the [5,3] one on `targeting: lowest-health`, so the shipped tomb demos the slice-1 feature — two hunters converging past the closer, healthier character onto the wounded one — instead of preserving the A/B control that already served its purpose in the recorded acceptance run ([evidence](https://github.com/KirkDiggler/rpg-toolkit/pull/896#issuecomment-5229290437)).

`TestEveryEmbeddedSpecLoads` green (the canary validates the key against the pinned toolkit).

Closes #785

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB1QSaqAphp5J3rdREPR5