### PR TITLE
chore(deps): consume spatial v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.25.12
 
 require (
 	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260809161404-a6648cecf193
-	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/encounter v0.53.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.72.0
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260809161404-a6648cecf193 h1:Im0opbApePT8YBdY+i/EL+JLuUsytApiBBhdflYSkhg=
 github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260809161404-a6648cecf193/go.mod h1:m6SGwoVF/bxvg9du1E47BJjPPwzCq7HZ8HV7ie1eUqU=
-github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
-github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/encounter v0.53.0 h1:j5VYLcpPCo0K7qqqgQyqjFoIbBjVnIHiuyIfO0wpcSQ=
@@ -26,8 +26,8 @@ github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4 h1:v7Imq00j5KrQ/PLO
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.4/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857 h1:cVyWXDe/fEaQLwyub4N732O/juf0tkzQCUR1rwJz8PY=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0 h1:G3Fbc88oko5o0yM1jQ2wB7bAeaHRRWPAiZRpsub36uk=
 github.com/KirkDiggler/rpg-toolkit/tools/spawn v0.3.0/go.mod h1:vRkHHvBU1hXvlPyOySMfXov4S4Tj/bTWJ7lUGSwgVmI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary

- pin direct `github.com/KirkDiggler/rpg-toolkit/tools/spatial` to the corrected `v0.9.0` release
- align direct `github.com/KirkDiggler/rpg-toolkit/core` from `v0.10.0` to `v0.11.0`, as required by spatial v0.9.0
- leave encounter, dnd5e, environments, spawn, and every unrelated dependency unchanged
- make no behavior or compatibility-code changes: the released retained API compiles as-is

## Release proof

The branch was cut from fetched `origin/dev` at `f5c847e81c1d4e94c06ebf5e406aec17eaa52b63`.

Before consuming the release:

- `git ls-remote --tags` returned no ref for `refs/tags/tools/spatial/v0.8.1` (or its peeled ref)
- `refs/tags/tools/spatial/v0.9.0` is annotated tag object `01de1ad95120f7bd0763853e57c1e3f7fadbba02` and peels to toolkit merge `0fbcbcae9ae72a0c9ce22d6583023bc80cc098e9`
- `GOPROXY=direct go list -m -json .../tools/spatial@v0.9.0` reports origin hash `0fbcbcae9ae72a0c9ce22d6583023bc80cc098e9` and ref `refs/tags/tools/spatial/v0.9.0`
- `https://proxy.golang.org/.../tools/spatial/@v/v0.9.0.info` and an explicit `GOPROXY=https://proxy.golang.org go list -m -json` report the same origin hash/ref

## Dependency diff rationale

`GOWORK=off go get` named only spatial v0.9.0 and core v0.11.0, followed by `GOWORK=off go mod tidy`. The complete result is two direct-version changes plus replacement of those modules' four old `go.sum` lines with four new lines. The direct versions of encounter v0.53.0, dnd5e v0.72.0, environments v0.4.4, and spawn v0.3.0 did not move.

## Removed-symbol inventory

An import-aware Go AST scan checked all 20 removals from toolkit #910 as selectors of the spatial import. Results were zero for every symbol in:

- rpg-api: 6 spatial-importing Go files, 0 removed selectors
- encounter v0.53.0: 42 spatial-importing Go files, 0 removed selectors
- rulebooks/dnd5e v0.72.0: 25 spatial-importing Go files, 0 removed selectors
- tools/environments v0.4.4: 23 spatial-importing Go files, 0 removed selectors
- tools/spawn v0.3.0: 12 spatial-importing Go files, 0 removed selectors

The inventory covered the four filter helpers; `EntityID`/`NewEntityID`; began/ended transition events and topics; five `EventQuery*` constants; `LayoutMetrics`/`LayoutOrchestrator`; and `Transition`/`TransitionID`/`TransitionSystem`. Compilation against v0.9.0 provides the graph-level compatibility proof.

## Verification

PASS:

- `GOWORK=off ./scripts/verify-release-pin.sh`
- `GOWORK=off go mod tidy -diff` (empty)
- `GOWORK=off go build ./...`
- `GOWORK=off go test -race -count=1 -run '^TestMovementOAIntegrationSuite$' ./internal/handlers/dnd5e/v2/encounter` (includes diagonal axial adjacency)
- Docker available (`docker info` server 23.0.1)
- `GOWORK=off go test -race -count=1 -run '^TestLobbyStartThenMoveSuite$' ./internal/integration`
- `make ci-check` test stage: the full CI-mode race suite passed
- generated-code, formatting, import, EOF, release-pin, and tidy checks passed; worktree is clean after the committed-diff run
- GitHub Actions `test`: PASS (2m41s)
- GitHub Actions `build` (race tests + Docker image build): PASS (4m08s)

Known base tooling false-red (not introduced here):

- `GOWORK=off make pre-commit` stops at lint before its test target
- `GOWORK=off make ci-check` completes with only its lint check failed; its full test stage passes
- `make pre-commit` unconditionally installs `golangci-lint latest`, currently v2.12.2, which reports the same 29 unrelated issues on pristine `origin/dev` `f5c847e`
- GitHub workflows do **not** install or run golangci-lint; their `test` and `build` jobs run race tests (and Docker build for `build`). Existing #678 tracks the 29-issue local-gate debt/no-CI-lint mismatch.

## Integration handoff and scope

The supported local game-path verification is explicitly **pending** for the director's separate clean-environment runner. This PR does not claim character → Reference Tomb → adjacent MoveEntity → stream/persistence acceptance from this implementation worktree.

PR #782 also touches `go.mod`/`go.sum` but does not own this release. If #789 lands first, #782 must merge current `dev` and retain spatial v0.9.0/core v0.11.0.

Excluded: new spatial behavior, local shims for removed exports, #909 managed-membership adoption, toolkit auto-tag repair, #782 authoring, deployment changes, web changes, and unrelated dependency upgrades.

Closes #789

— rpg-api agent, on behalf of KirkDiggler
