### PR TITLE
feat: add toolkit contributor sandbox provider

### DIFF
--- a/cmd/sandboxseed/main.go
+++ b/cmd/sandboxseed/main.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// sandboxseed resets the fixed toolkit-contributor sandbox characters through
+// the production CharacterService exposed by Envoy.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
+
+	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/sandboxseed"
+)
+
+const defaultAddress = "localhost:8080"
+
+type config struct {
+	address string
+	health  bool
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		log.Fatalf("sandboxseed: %v", err)
+	}
+}
+
+func run(args []string) error {
+	config, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+
+	conn, err := grpc.NewClient(config.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if config.health {
+		return checkHealth(ctx, conn)
+	}
+	if err := sandboxseed.Seed(ctx, dnd5ev1alpha1.NewCharacterServiceClient(conn)); err != nil {
+		return fmt.Errorf("seed: %w", err)
+	}
+	return nil
+}
+
+func parseConfig(args []string) (*config, error) {
+	flags := flag.NewFlagSet("sandboxseed", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+
+	result := &config{}
+	flags.StringVar(&result.address, "address", defaultAddress, "gRPC address for Envoy")
+	flags.BoolVar(&result.health, "health", false, "check Envoy gRPC health only")
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+	if flags.NArg() != 0 {
+		return nil, fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	if result.address == "" {
+		return nil, errors.New("address is required")
+	}
+	return result, nil
+}
+
+func checkHealth(ctx context.Context, conn *grpc.ClientConn) error {
+	response, err := grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		return fmt.Errorf("health check: %w", err)
+	}
+	if response.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		return fmt.Errorf("health check is not serving: %s", response.GetStatus())
+	}
+	fmt.Println("sandboxseed: health=SERVING")
+	return nil
+}

--- a/cmd/sandboxseed/main_test.go
+++ b/cmd/sandboxseed/main_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestParseConfig_DefaultsToEnvoyAddress(t *testing.T) {
+	config, err := parseConfig(nil)
+	require.NoError(t, err)
+	require.Equal(t, defaultAddress, config.address)
+	require.False(t, config.health)
+}
+
+func TestRun_HealthReturnsSuccessOnlyForServing(t *testing.T) {
+	listener, server := healthServer(t, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	err := run([]string{"--address", listener.Addr().String(), "--health"})
+	require.NoError(t, err)
+
+	server.Stop()
+}
+
+func TestRun_HealthRejectsNonServingResponse(t *testing.T) {
+	listener, _ := healthServer(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	err := run([]string{"--address", listener.Addr().String(), "--health"})
+	require.ErrorContains(t, err, "not serving")
+}
+
+func healthServer(t *testing.T, servingStatus grpc_health_v1.HealthCheckResponse_ServingStatus) (net.Listener, *grpc.Server) {
+	t.Helper()
+
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	healthService := health.NewServer()
+	healthService.SetServingStatus("", servingStatus)
+	grpc_health_v1.RegisterHealthServer(server, healthService)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	return listener, server
+}

--- a/docs/how-to/local-toolkit-override.md
+++ b/docs/how-to/local-toolkit-override.md
@@ -1,7 +1,7 @@
 ---
 name: local rpg-toolkit override loop
-description: Iterate on rpg-toolkit/encounter changes in the local Docker loop without publish -> tag -> go get
-updated: 2026-07-27
+description: Iterate on one allowlisted rpg-toolkit module in the local Docker loop without publish -> tag -> go get
+updated: 2026-08-11
 ---
 
 # How to iterate on rpg-toolkit changes without publishing
@@ -13,10 +13,12 @@ change you're confident in — but a bug that needs several edit-and-look
 cycles (e.g. rpg-toolkit#858, #859) makes a publish-per-attempt loop
 impractical.
 
-This script lets you point rpg-api's build at a **local** rpg-toolkit
-checkout instead, for `github.com/KirkDiggler/rpg-toolkit/encounter` only.
-It rejects any unapproved replacement or second replacement; one local module
-is the entire override budget for an iteration.
+This script lets you point rpg-api's build at one **local** rpg-toolkit
+module instead. The allowlisted targets are `encounter` and
+`rulebooks/dnd5e`; it rejects any unapproved replacement or second
+replacement. One local module is the entire override budget for an iteration.
+The selected target and source are recorded in the ignored
+`local-toolkit/.toolkit-local-override-state` ownership record.
 
 ## The constraint this solves
 
@@ -31,27 +33,45 @@ pointing outside it (e.g. `../../rpg-toolkit/encounter`) compiles fine with
 a plain `go build` on the host, then **fails inside Docker**, because the
 toolkit source was never sent to the build context.
 
-The fix: sync the toolkit module's source into a gitignored directory
-**inside** this repo (`local-toolkit/encounter/`) and point the `replace`
-at that relative path, so it's part of the context Docker actually sees.
+The fix: sync the selected toolkit module's source into a gitignored
+directory inside this repo (`local-toolkit/<target>/`) and point the
+`replace` at that relative path, so it's part of the context Docker actually
+sees.
 
-Only `rpg-toolkit/encounter` is overridden. Its own dependencies on sibling
-toolkit modules (`core`, `events`, `tools/spatial`, ...) stay at whatever
-published versions its `go.mod` already names — this script does not sync
-the whole toolkit.
+Only the selected allowlisted module is overridden. Its own dependencies on
+sibling toolkit modules (`core`, `events`, `tools/spatial`, ...) stay at
+whatever published versions its `go.mod` already names — this script does not
+sync the whole toolkit.
 
 ## Turning it on
 
 ```bash
-scripts/toolkit-local-override.sh on [--src <path-to-rpg-toolkit-checkout>]
+# Explicit D&D 5e rulebook override:
+scripts/toolkit-local-override.sh on \
+  --target rulebooks/dnd5e \
+  --src /home/kirk/game-dev/rpg-toolkit
+
+# Existing encounter override (the default when --target is omitted):
+scripts/toolkit-local-override.sh on \
+  --target encounter \
+  --src /home/kirk/game-dev/rpg-toolkit
+# Equivalent legacy form:
+scripts/toolkit-local-override.sh on --src /home/kirk/game-dev/rpg-toolkit
 ```
 
 Defaults to `$TOOLKIT_SRC_DIR`, then `~/game-dev/rpg-toolkit`, then a couple
-of relative guesses if you didn't pass `--src`. This:
+of relative guesses if you don't pass `--src`. The source must contain the
+selected module's `go.mod` with the matching module declaration. The command:
 
-1. rsyncs `<src>/encounter/` into `local-toolkit/encounter/` (gitignored).
-2. Runs `go mod edit -replace github.com/KirkDiggler/rpg-toolkit/encounter=./local-toolkit/encounter`.
-3. Sanity-builds on the host (`go build ./...`).
+1. rsyncs `<src>/<target>/` into `local-toolkit/<target>/` (gitignored).
+2. Runs `go mod edit -replace <module>=./local-toolkit/<target>`.
+3. Writes the literal ownership record only after the exact replacement is
+   present.
+4. Sanity-builds on the host (`go build ./...`).
+
+Only one replacement may be active. Switching from `encounter` to
+`rulebooks/dnd5e` (or vice versa) requires `off` first; the script refuses to
+transiently create a second replacement.
 
 Then rebuild the image with the **dev-only Dockerfile** (`Dockerfile.local-toolkit`,
 not the normal `Dockerfile` — see why below) and redeploy the primary
@@ -73,7 +93,7 @@ instances; redeploy only the primary `rpg-api` service.
 
 The normal `Dockerfile` copies `go.mod`/`go.sum` first, runs `go mod
 download`, and only copies the rest of the source afterward (a layer-caching
-optimization). With an active `replace` pointing at `local-toolkit/encounter/`,
+optimization). With an active `replace` pointing at `local-toolkit/<target>/`,
 that directory doesn't exist yet at the `go mod download` step, and the
 build fails. `Dockerfile.local-toolkit` is identical except it copies the
 full source (including `local-toolkit/`) *before* `go mod download` — it
@@ -83,10 +103,17 @@ override, it produces the exact same image as `Dockerfile`.
 
 ### Edit-and-look cycle
 
-Each time you change something in `<rpg-toolkit-checkout>/encounter/`:
+Each time you change something in the selected toolkit module:
 
 ```bash
-scripts/toolkit-local-override.sh on   # re-syncs + re-points the replace
+# D&D 5e:
+scripts/toolkit-local-override.sh refresh \
+  --src /home/kirk/game-dev/rpg-toolkit
+
+# Encounter (the same command works with --target encounter on `on`):
+scripts/toolkit-local-override.sh refresh \
+  --src /home/kirk/game-dev/rpg-toolkit
+
 docker build -f Dockerfile.local-toolkit -t rpg-api:local .
 # redeploy rpg-api as above
 ```
@@ -97,9 +124,11 @@ docker build -f Dockerfile.local-toolkit -t rpg-api:local .
 scripts/toolkit-local-override.sh off
 ```
 
-This drops the `replace` directive and deletes `local-toolkit/` entirely,
-restoring `go.mod`/`go.sum` to the published pin with no residue, then
-sanity-builds to confirm. Follow with a normal `docker build -t rpg-api:local .`
+This validates ownership, drops only the selected `replace` directive,
+deletes only `local-toolkit/<target>/` and the ownership record, and restores
+`go.mod`/`go.sum` to the published pin. An unrelated `local-toolkit/` sibling
+is preserved. It then sanity-builds to confirm. Follow with a normal
+`docker build -t rpg-api:local .`
 (the regular `Dockerfile` again) and redeploy `rpg-api` to go back to the
 published toolkit version.
 
@@ -109,10 +138,11 @@ published toolkit version.
 scripts/toolkit-local-override.sh status
 ```
 
-Reports the complete active `go.mod` replacement module list, then whether
-this exact approved override is active and whether `local-toolkit/encounter/`
-exists on disk. It exits non-zero if a second or unapproved replacement exists;
-that output is the verification record before running a local build.
+Reports the complete active `go.mod` replacement module list, the selected
+target/source ownership record, and whether `local-toolkit/<target>/` exists
+on disk. It exits non-zero if a second, unapproved, unowned, or path-mismatched
+replacement exists; that output is the verification record before running a
+local build.
 
 ## Deploy discipline — do not skip this
 
@@ -123,10 +153,11 @@ but that's defense in depth, not the only line. Treat it as a hard rule:
 
 1. Iterate locally with the override ON until the toolkit fix is right.
 2. **Publish the toolkit change**: commit + push in rpg-toolkit, tag the new
-   `encounter/vX.Y.Z` version.
-3. Pull the real published version into rpg-api the normal way:
+   version for the selected module (`encounter/vX.Y.Z` or
+   `rulebooks/dnd5e/vX.Y.Z`).
+3. Pull the real published version into rpg-api the normal way, for example:
    ```bash
-   GOPROXY=direct go get github.com/KirkDiggler/rpg-toolkit/encounter@vX.Y.Z
+   GOPROXY=direct go get github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e@vX.Y.Z
    ```
 4. **Remove the local override**: `scripts/toolkit-local-override.sh off`.
 5. Commit the real `go.mod`/`go.sum` version bump — never a `replace` line.
@@ -138,5 +169,5 @@ is deliberately **not** part of this script's `on` path, so the temporary
 local development loop remains usable; run `off` before a pre-PR gate.
 
 Before opening a PR (or even committing), check `git diff go.mod` — if it
-shows a `replace ... => ./local-toolkit/encounter` line, the override is
-still on. Run `off` first.
+shows a `replace ... => ./local-toolkit/<target>` line, the override is still
+on. Run `off` first.

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -1281,6 +1281,9 @@ func ConvertCharacterDataToProto(data *toolkitchar.Data) *dnd5ev1alpha1.Characte
 			// Map to enum and derive display name
 			conditionEnum := conditionIDToEnum(conditionID)
 			conditionName := conditionIDToDisplayName(conditionID)
+			if fightingStyle := conditionIDToFightingStyle(conditionID); fightingStyle != dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_UNSPECIFIED {
+				char.FightingStyles = append(char.FightingStyles, fightingStyle)
+			}
 
 			char.ActiveConditions = append(char.ActiveConditions, &dnd5ev1alpha1.Condition{
 				Id:            conditionEnum,
@@ -3218,6 +3221,27 @@ func conditionIDToEnum(id string) dnd5ev1alpha1.ConditionId {
 		return dnd5ev1alpha1.ConditionId_CONDITION_ID_UNARMORED_MOVEMENT
 	default:
 		return dnd5ev1alpha1.ConditionId_CONDITION_ID_UNSPECIFIED
+	}
+}
+
+// conditionIDToFightingStyle maps persisted fighting-style conditions to the
+// existing Character.fighting_styles wire field.
+func conditionIDToFightingStyle(id string) dnd5ev1alpha1.FightingStyle {
+	switch id {
+	case refs.Conditions.FightingStyleArchery().ID:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_ARCHERY
+	case refs.Conditions.FightingStyleDefense().ID:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_DEFENSE
+	case refs.Conditions.FightingStyleDueling().ID:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_DUELING
+	case refs.Conditions.FightingStyleGreatWeaponFighting().ID:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_GREAT_WEAPON_FIGHTING
+	case refs.Conditions.FightingStyleProtection().ID:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_PROTECTION
+	case refs.Conditions.FightingStyleTwoWeaponFighting().ID:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_TWO_WEAPON_FIGHTING
+	default:
+		return dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_UNSPECIFIED
 	}
 }
 

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -654,6 +654,33 @@ func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_WithConditions() {
 	assert.Equal(s.T(), int32(6), blessedCondition.Duration)
 }
 
+// TestConvertCharacterDataToProto_ProjectsStoredProtectionFightingStyle
+// fixes the v1alpha1 projection seam used by the sandbox seeder. Finalized
+// toolkit character data persists the selected style as a condition; the
+// existing wire field must project that persisted selection rather than leave
+// FightingStyles empty.
+func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_ProjectsStoredProtectionFightingStyle() {
+	testData := &toolkitchar.Data{
+		ID:    "test-protection-fighter",
+		Name:  "Protection Fighter",
+		Level: 1,
+		Conditions: []json.RawMessage{
+			json.RawMessage(`{
+				"ref": "dnd5e:conditions:fighting_style_protection",
+				"character_id": "test-protection-fighter"
+			}`),
+		},
+	}
+
+	result := ConvertCharacterDataToProto(testData)
+
+	require.NotNil(s.T(), result)
+	require.Len(s.T(), result.GetActiveConditions(), 1)
+	assert.Equal(s.T(), dnd5ev1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_PROTECTION,
+		result.GetActiveConditions()[0].GetId())
+	assert.Contains(s.T(), result.GetFightingStyles(), dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_PROTECTION)
+}
+
 func (s *ConvertersTestSuite) TestConvertCharacterDataToProto_EmptyConditions() {
 	// Create test data with no conditions
 	testData := &toolkitchar.Data{

--- a/internal/integration/character/sandboxseed_test.go
+++ b/internal/integration/character/sandboxseed_test.go
@@ -1,0 +1,271 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character_integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	lobbyv1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/lobby/v1alpha1"
+	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/integration/harness"
+	"github.com/KirkDiggler/rpg-api/internal/sandboxseed"
+)
+
+const (
+	sandboxFighterID   = "toolkit-sandbox-fighter"
+	sandboxBarbarianID = "toolkit-sandbox-barbarian"
+)
+
+// SandboxSeedSuite exercises the fixed production-RPC seed path over the
+// real CharacterService and verifies the two seeded characters bind only to
+// their authenticated lobby identities.
+type SandboxSeedSuite struct {
+	suite.Suite
+	ctx     context.Context
+	cancel  context.CancelFunc
+	server  *harness.TestServer
+	release func()
+}
+
+func TestSandboxSeedSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	suite.Run(t, new(SandboxSeedSuite))
+}
+
+func (s *SandboxSeedSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 3*time.Minute)
+	s.release = sharedRedis.Lease()
+
+	var err error
+	s.server, err = harness.NewWithRedis(s.ctx, nil, sharedRedis.Addr)
+	s.Require().NoError(err, "failed to create test server")
+	s.Require().NoError(s.server.FlushRedis(s.ctx), "failed to flush redis")
+}
+
+func (s *SandboxSeedSuite) TearDownTest() {
+	if s.server != nil {
+		s.server.Close()
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.release != nil {
+		s.release()
+	}
+}
+
+func (s *SandboxSeedSuite) authCtx(playerID string) context.Context {
+	return metadata.AppendToOutgoingContext(s.ctx, "authorization", "Dev "+playerID)
+}
+
+func (s *SandboxSeedSuite) listExactlyOne(identity string) *dnd5ev1alpha1.Character {
+	s.T().Helper()
+	response, err := s.server.CharacterClient.ListCharacters(s.authCtx(identity), &dnd5ev1alpha1.ListCharactersRequest{
+		PageSize: 100,
+	})
+	require.NoError(s.T(), err)
+	require.Empty(s.T(), response.GetNextPageToken())
+	require.Len(s.T(), response.GetCharacters(), 1)
+	return response.GetCharacters()[0]
+}
+
+func (s *SandboxSeedSuite) TestSandboxSeed_ResetsTwoIdentitiesThroughRPCs() {
+	require.NoError(s.T(), sandboxseed.Seed(s.ctx, s.server.CharacterClient))
+	require.NoError(s.T(), sandboxseed.Seed(s.ctx, s.server.CharacterClient))
+
+	recordingClient := &recordingCharacterClient{CharacterRPC: s.server.CharacterClient}
+	require.NoError(s.T(), sandboxseed.Seed(s.ctx, recordingClient))
+	require.Equal(s.T(), []string{
+		"toolkit-sandbox-fighter:ListCharacters",
+		"toolkit-sandbox-fighter:DeleteCharacter",
+		"toolkit-sandbox-fighter:CreateDraft",
+		"toolkit-sandbox-fighter:UpdateName",
+		"toolkit-sandbox-fighter:UpdateRace",
+		"toolkit-sandbox-fighter:UpdateClass",
+		"toolkit-sandbox-fighter:UpdateBackground",
+		"toolkit-sandbox-fighter:UpdateAbilityScores",
+		"toolkit-sandbox-fighter:GetDraft",
+		"toolkit-sandbox-fighter:FinalizeDraft",
+		"toolkit-sandbox-fighter:ListCharacters",
+		"toolkit-sandbox-fighter:GetCharacter",
+		"toolkit-sandbox-fighter:EquipItem",
+		"toolkit-sandbox-fighter:ListCharacters",
+		"toolkit-sandbox-barbarian:ListCharacters",
+		"toolkit-sandbox-barbarian:DeleteCharacter",
+		"toolkit-sandbox-barbarian:CreateDraft",
+		"toolkit-sandbox-barbarian:UpdateName",
+		"toolkit-sandbox-barbarian:UpdateRace",
+		"toolkit-sandbox-barbarian:UpdateClass",
+		"toolkit-sandbox-barbarian:UpdateBackground",
+		"toolkit-sandbox-barbarian:UpdateAbilityScores",
+		"toolkit-sandbox-barbarian:GetDraft",
+		"toolkit-sandbox-barbarian:FinalizeDraft",
+		"toolkit-sandbox-barbarian:ListCharacters",
+		"toolkit-sandbox-barbarian:GetCharacter",
+		"toolkit-sandbox-barbarian:ListCharacters",
+	}, recordingClient.calls)
+
+	fighter := s.listExactlyOne("toolkit-sandbox-fighter")
+	require.Equal(s.T(), "Toolkit Sandbox Fighter", fighter.GetName())
+	require.Contains(s.T(), fighter.GetFightingStyles(), dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_PROTECTION)
+	require.Equal(s.T(), "shield", fighter.GetEquipmentSlots().GetOffHand().GetItemId())
+	require.EqualValues(s.T(), 16, fighter.GetAbilityScores().GetStrength())
+	require.Equal(s.T(), dnd5ev1alpha1.Race_RACE_HUMAN, fighter.GetRace())
+	require.Equal(s.T(), dnd5ev1alpha1.Class_CLASS_FIGHTER, fighter.GetClass())
+	require.Equal(s.T(), int32(14), fighter.GetAbilityScores().GetDexterity())
+	require.Equal(s.T(), int32(15), fighter.GetAbilityScores().GetConstitution())
+	require.Equal(s.T(), int32(11), fighter.GetAbilityScores().GetIntelligence())
+	require.Equal(s.T(), int32(13), fighter.GetAbilityScores().GetWisdom())
+	require.Equal(s.T(), int32(9), fighter.GetAbilityScores().GetCharisma())
+
+	barbarian := s.listExactlyOne("toolkit-sandbox-barbarian")
+	require.Equal(s.T(), "Toolkit Sandbox Barbarian", barbarian.GetName())
+	require.Equal(s.T(), dnd5ev1alpha1.Race_RACE_HUMAN, barbarian.GetRace())
+	require.Equal(s.T(), dnd5ev1alpha1.Class_CLASS_BARBARIAN, barbarian.GetClass())
+	require.EqualValues(s.T(), 16, barbarian.GetAbilityScores().GetStrength())
+	require.Equal(s.T(), int32(14), barbarian.GetAbilityScores().GetDexterity())
+	require.Equal(s.T(), int32(15), barbarian.GetAbilityScores().GetConstitution())
+	require.Equal(s.T(), int32(9), barbarian.GetAbilityScores().GetIntelligence())
+	require.Equal(s.T(), int32(13), barbarian.GetAbilityScores().GetWisdom())
+	require.Equal(s.T(), int32(11), barbarian.GetAbilityScores().GetCharisma())
+
+	_, err := s.server.LobbyClient.CreateLobby(s.authCtx(sandboxBarbarianID), &lobbyv1alpha1.CreateLobbyRequest{
+		CampaignId:  "toolkit-sandbox-wrong-owner-create",
+		CharacterId: fighter.GetId(),
+	})
+	require.Equal(s.T(), codes.PermissionDenied, status.Code(err))
+
+	wrongOwnerHost, err := s.server.LobbyClient.CreateLobby(s.authCtx(sandboxFighterID), &lobbyv1alpha1.CreateLobbyRequest{
+		CampaignId:  "toolkit-sandbox-wrong-owner-join",
+		CharacterId: fighter.GetId(),
+	})
+	require.NoError(s.T(), err)
+	_, err = s.server.LobbyClient.JoinLobby(s.authCtx(sandboxBarbarianID), &lobbyv1alpha1.JoinLobbyRequest{
+		JoinRef:     wrongOwnerHost.GetJoinRef(),
+		CharacterId: fighter.GetId(),
+	})
+	require.Equal(s.T(), codes.PermissionDenied, status.Code(err))
+
+	s.assertPartyOrder("toolkit-sandbox-fighter-then-barbarian", sandboxFighterID, fighter.GetId(), sandboxBarbarianID, barbarian.GetId())
+	s.assertPartyOrder("toolkit-sandbox-barbarian-then-fighter", sandboxBarbarianID, barbarian.GetId(), sandboxFighterID, fighter.GetId())
+}
+
+// recordingCharacterClient proves Seed keeps each call under its fixed Dev
+// identity and obtains the post-finalize ID from that identity's list before
+// GetCharacter or EquipItem.
+type recordingCharacterClient struct {
+	sandboxseed.CharacterRPC
+	calls []string
+}
+
+func (c *recordingCharacterClient) record(ctx context.Context, method string) {
+	metadataValues, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		c.calls = append(c.calls, "missing-metadata:"+method)
+		return
+	}
+	values := metadataValues.Get("authorization")
+	if len(values) != 1 {
+		c.calls = append(c.calls, "invalid-metadata:"+method)
+		return
+	}
+	c.calls = append(c.calls, values[0][len("Dev "):]+":"+method)
+}
+
+func (c *recordingCharacterClient) ListCharacters(ctx context.Context, req *dnd5ev1alpha1.ListCharactersRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.ListCharactersResponse, error) {
+	c.record(ctx, "ListCharacters")
+	return c.CharacterRPC.ListCharacters(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) DeleteCharacter(ctx context.Context, req *dnd5ev1alpha1.DeleteCharacterRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.DeleteCharacterResponse, error) {
+	c.record(ctx, "DeleteCharacter")
+	return c.CharacterRPC.DeleteCharacter(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) CreateDraft(ctx context.Context, req *dnd5ev1alpha1.CreateDraftRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.CreateDraftResponse, error) {
+	c.record(ctx, "CreateDraft")
+	return c.CharacterRPC.CreateDraft(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) UpdateName(ctx context.Context, req *dnd5ev1alpha1.UpdateNameRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.UpdateNameResponse, error) {
+	c.record(ctx, "UpdateName")
+	return c.CharacterRPC.UpdateName(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) UpdateRace(ctx context.Context, req *dnd5ev1alpha1.UpdateRaceRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.UpdateRaceResponse, error) {
+	c.record(ctx, "UpdateRace")
+	return c.CharacterRPC.UpdateRace(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) UpdateClass(ctx context.Context, req *dnd5ev1alpha1.UpdateClassRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.UpdateClassResponse, error) {
+	c.record(ctx, "UpdateClass")
+	return c.CharacterRPC.UpdateClass(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) UpdateBackground(ctx context.Context, req *dnd5ev1alpha1.UpdateBackgroundRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.UpdateBackgroundResponse, error) {
+	c.record(ctx, "UpdateBackground")
+	return c.CharacterRPC.UpdateBackground(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) UpdateAbilityScores(ctx context.Context, req *dnd5ev1alpha1.UpdateAbilityScoresRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.UpdateAbilityScoresResponse, error) {
+	c.record(ctx, "UpdateAbilityScores")
+	return c.CharacterRPC.UpdateAbilityScores(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) GetDraft(ctx context.Context, req *dnd5ev1alpha1.GetDraftRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.GetDraftResponse, error) {
+	c.record(ctx, "GetDraft")
+	return c.CharacterRPC.GetDraft(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) FinalizeDraft(ctx context.Context, req *dnd5ev1alpha1.FinalizeDraftRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.FinalizeDraftResponse, error) {
+	c.record(ctx, "FinalizeDraft")
+	return c.CharacterRPC.FinalizeDraft(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) GetCharacter(ctx context.Context, req *dnd5ev1alpha1.GetCharacterRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.GetCharacterResponse, error) {
+	c.record(ctx, "GetCharacter")
+	return c.CharacterRPC.GetCharacter(ctx, req, opts...)
+}
+
+func (c *recordingCharacterClient) EquipItem(ctx context.Context, req *dnd5ev1alpha1.EquipItemRequest, opts ...grpc.CallOption) (*dnd5ev1alpha1.EquipItemResponse, error) {
+	c.record(ctx, "EquipItem")
+	return c.CharacterRPC.EquipItem(ctx, req, opts...)
+}
+
+func (s *SandboxSeedSuite) assertPartyOrder(campaignID, hostIdentity, hostCharacterID, joinIdentity, joinCharacterID string) {
+	s.T().Helper()
+
+	created, err := s.server.LobbyClient.CreateLobby(s.authCtx(hostIdentity), &lobbyv1alpha1.CreateLobbyRequest{
+		CampaignId:  campaignID,
+		CharacterId: hostCharacterID,
+	})
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), hostIdentity, created.GetHostPlayerId())
+
+	joined, err := s.server.LobbyClient.JoinLobby(s.authCtx(joinIdentity), &lobbyv1alpha1.JoinLobbyRequest{
+		JoinRef:     created.GetJoinRef(),
+		CharacterId: joinCharacterID,
+	})
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), created.GetLobbyId(), joined.GetLobbyId())
+	require.Len(s.T(), joined.GetMembers(), 2)
+
+	characterByPlayer := make(map[string]string, len(joined.GetMembers()))
+	for _, member := range joined.GetMembers() {
+		characterByPlayer[member.GetPlayerId()] = member.GetCharacterId()
+	}
+	require.Equal(s.T(), hostCharacterID, characterByPlayer[hostIdentity])
+	require.Equal(s.T(), joinCharacterID, characterByPlayer[joinIdentity])
+}

--- a/internal/sandboxseed/sandboxseed.go
+++ b/internal/sandboxseed/sandboxseed.go
@@ -1,0 +1,424 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package sandboxseed creates the two fixed toolkit-contributor sandbox
+// characters through the production CharacterService RPC surface.
+package sandboxseed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+)
+
+const (
+	fighterIdentity   = "toolkit-sandbox-fighter"
+	barbarianIdentity = "toolkit-sandbox-barbarian"
+
+	fighterName   = "Toolkit Sandbox Fighter"
+	barbarianName = "Toolkit Sandbox Barbarian"
+
+	listPageSize = 100
+	shieldItemID = "shield"
+)
+
+// CharacterRPC is the narrow CharacterService client surface used by Seed.
+type CharacterRPC interface {
+	ListCharacters(context.Context, *dnd5ev1alpha1.ListCharactersRequest, ...grpc.CallOption) (*dnd5ev1alpha1.ListCharactersResponse, error)
+	DeleteCharacter(context.Context, *dnd5ev1alpha1.DeleteCharacterRequest, ...grpc.CallOption) (*dnd5ev1alpha1.DeleteCharacterResponse, error)
+	CreateDraft(context.Context, *dnd5ev1alpha1.CreateDraftRequest, ...grpc.CallOption) (*dnd5ev1alpha1.CreateDraftResponse, error)
+	UpdateName(context.Context, *dnd5ev1alpha1.UpdateNameRequest, ...grpc.CallOption) (*dnd5ev1alpha1.UpdateNameResponse, error)
+	UpdateRace(context.Context, *dnd5ev1alpha1.UpdateRaceRequest, ...grpc.CallOption) (*dnd5ev1alpha1.UpdateRaceResponse, error)
+	UpdateClass(context.Context, *dnd5ev1alpha1.UpdateClassRequest, ...grpc.CallOption) (*dnd5ev1alpha1.UpdateClassResponse, error)
+	UpdateBackground(context.Context, *dnd5ev1alpha1.UpdateBackgroundRequest, ...grpc.CallOption) (*dnd5ev1alpha1.UpdateBackgroundResponse, error)
+	UpdateAbilityScores(context.Context, *dnd5ev1alpha1.UpdateAbilityScoresRequest, ...grpc.CallOption) (*dnd5ev1alpha1.UpdateAbilityScoresResponse, error)
+	GetDraft(context.Context, *dnd5ev1alpha1.GetDraftRequest, ...grpc.CallOption) (*dnd5ev1alpha1.GetDraftResponse, error)
+	FinalizeDraft(context.Context, *dnd5ev1alpha1.FinalizeDraftRequest, ...grpc.CallOption) (*dnd5ev1alpha1.FinalizeDraftResponse, error)
+	GetCharacter(context.Context, *dnd5ev1alpha1.GetCharacterRequest, ...grpc.CallOption) (*dnd5ev1alpha1.GetCharacterResponse, error)
+	EquipItem(context.Context, *dnd5ev1alpha1.EquipItemRequest, ...grpc.CallOption) (*dnd5ev1alpha1.EquipItemResponse, error)
+}
+
+// Seed resets the two fixed sandbox identities and recreates their fixed
+// characters through implemented CharacterService RPCs only.
+func Seed(ctx context.Context, client CharacterRPC) error {
+	if client == nil {
+		return errors.New("sandbox seed: character RPC client is required")
+	}
+
+	if err := seedFighter(ctx, client); err != nil {
+		return err
+	}
+	return seedBarbarian(ctx, client)
+}
+
+func seedFighter(ctx context.Context, client CharacterRPC) error {
+	identityCtx := authenticatedContext(ctx, fighterIdentity)
+	if err := deleteListedCharacters(identityCtx, client, fighterIdentity); err != nil {
+		return err
+	}
+
+	createResponse, createErr := client.CreateDraft(identityCtx, &dnd5ev1alpha1.CreateDraftRequest{})
+	if createErr != nil {
+		return rpcError(fighterIdentity, "CreateDraft", createErr)
+	}
+	draftID := createResponse.GetDraft().GetId()
+	if draftID == "" {
+		return fmt.Errorf("%s CreateDraft: response draft ID is empty", fighterIdentity)
+	}
+
+	if _, err := client.UpdateName(identityCtx, &dnd5ev1alpha1.UpdateNameRequest{
+		DraftId: draftID,
+		Name:    fighterName,
+	}); err != nil {
+		return rpcError(fighterIdentity, "UpdateName", err)
+	}
+	if _, err := client.UpdateRace(identityCtx, &dnd5ev1alpha1.UpdateRaceRequest{
+		DraftId: draftID,
+		Race:    dnd5ev1alpha1.Race_RACE_HUMAN,
+		RaceChoices: []*dnd5ev1alpha1.ChoiceData{{
+			Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_LANGUAGES,
+			Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_RACE,
+			Selection: &dnd5ev1alpha1.ChoiceData_Languages{
+				Languages: &dnd5ev1alpha1.LanguageSelection{
+					Languages: []dnd5ev1alpha1.Language{dnd5ev1alpha1.Language_LANGUAGE_DWARVISH},
+				},
+			},
+		}},
+	}); err != nil {
+		return rpcError(fighterIdentity, "UpdateRace", err)
+	}
+	if _, err := client.UpdateClass(identityCtx, &dnd5ev1alpha1.UpdateClassRequest{
+		DraftId: draftID,
+		Class:   dnd5ev1alpha1.Class_CLASS_FIGHTER,
+		ClassChoices: []*dnd5ev1alpha1.ChoiceData{
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_SKILLS,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				Selection: &dnd5ev1alpha1.ChoiceData_Skills{
+					Skills: &dnd5ev1alpha1.SkillSelection{
+						Skills: []dnd5ev1alpha1.Skill{
+							dnd5ev1alpha1.Skill_SKILL_ATHLETICS,
+							dnd5ev1alpha1.Skill_SKILL_PERCEPTION,
+						},
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_FIGHTING_STYLE,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				Selection: &dnd5ev1alpha1.ChoiceData_FightingStyle{
+					FightingStyle: &dnd5ev1alpha1.FightingStyleSelection{
+						Style: dnd5ev1alpha1.FightingStyle_FIGHTING_STYLE_PROTECTION,
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-armor",
+				OptionId: "fighter-armor-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-weapons-primary",
+				OptionId: "fighter-weapon-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{
+						Items: []*dnd5ev1alpha1.EquipmentSelectionItem{{
+							Equipment: &dnd5ev1alpha1.EquipmentSelectionItem_Weapon{
+								Weapon: dnd5ev1alpha1.Weapon_WEAPON_LONGSWORD,
+							},
+						}},
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-weapons-secondary",
+				OptionId: "fighter-ranged-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "fighter-pack",
+				OptionId: "fighter-pack-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+		},
+	}); err != nil {
+		return rpcError(fighterIdentity, "UpdateClass", err)
+	}
+	if _, err := client.UpdateBackground(identityCtx, &dnd5ev1alpha1.UpdateBackgroundRequest{
+		DraftId:    draftID,
+		Background: dnd5ev1alpha1.Background_BACKGROUND_SOLDIER,
+	}); err != nil {
+		return rpcError(fighterIdentity, "UpdateBackground", err)
+	}
+	if _, err := client.UpdateAbilityScores(identityCtx, &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: draftID,
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_AbilityScores{
+			AbilityScores: &dnd5ev1alpha1.AbilityScores{
+				Strength:     15,
+				Dexterity:    13,
+				Constitution: 14,
+				Intelligence: 10,
+				Wisdom:       12,
+				Charisma:     8,
+			},
+		},
+	}); err != nil {
+		return rpcError(fighterIdentity, "UpdateAbilityScores", err)
+	}
+	if _, err := client.GetDraft(identityCtx, &dnd5ev1alpha1.GetDraftRequest{DraftId: draftID}); err != nil {
+		return rpcError(fighterIdentity, "GetDraft", err)
+	}
+	if _, err := client.FinalizeDraft(identityCtx, &dnd5ev1alpha1.FinalizeDraftRequest{DraftId: draftID}); err != nil {
+		return rpcError(fighterIdentity, "FinalizeDraft", err)
+	}
+
+	characterID, err := listExactlyOne(identityCtx, client, fighterIdentity, fighterName)
+	if err != nil {
+		return err
+	}
+	characterResponse, err := client.GetCharacter(identityCtx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: characterID})
+	if err != nil {
+		return rpcError(fighterIdentity, "GetCharacter", err)
+	}
+	shieldID, err := inventoryItemID(characterResponse.GetCharacter(), shieldItemID)
+	if err != nil {
+		return fmt.Errorf("%s GetCharacter: %w", fighterIdentity, err)
+	}
+	equipResponse, err := client.EquipItem(identityCtx, &dnd5ev1alpha1.EquipItemRequest{
+		CharacterId: characterID,
+		ItemId:      shieldID,
+		Slot:        dnd5ev1alpha1.EquipmentSlot_EQUIPMENT_SLOT_OFF_HAND,
+	})
+	if err != nil {
+		return rpcError(fighterIdentity, "EquipItem", err)
+	}
+	if equipResponse.GetCharacter().GetEquipmentSlots().GetOffHand().GetItemId() != shieldItemID {
+		return fmt.Errorf("%s EquipItem: off hand item is %q, want %q",
+			fighterIdentity,
+			equipResponse.GetCharacter().GetEquipmentSlots().GetOffHand().GetItemId(),
+			shieldItemID,
+		)
+	}
+	if _, finalListErr := listExactlyOne(identityCtx, client, fighterIdentity, fighterName); finalListErr != nil {
+		return finalListErr
+	}
+
+	fmt.Printf("sandboxseed: identity=%s character_id=%s strength=%d off_hand=%s\n",
+		fighterIdentity,
+		characterID,
+		equipResponse.GetCharacter().GetAbilityScores().GetStrength(),
+		equipResponse.GetCharacter().GetEquipmentSlots().GetOffHand().GetItemId(),
+	)
+	return nil
+}
+
+func seedBarbarian(ctx context.Context, client CharacterRPC) error {
+	identityCtx := authenticatedContext(ctx, barbarianIdentity)
+	if err := deleteListedCharacters(identityCtx, client, barbarianIdentity); err != nil {
+		return err
+	}
+
+	createResponse, createErr := client.CreateDraft(identityCtx, &dnd5ev1alpha1.CreateDraftRequest{})
+	if createErr != nil {
+		return rpcError(barbarianIdentity, "CreateDraft", createErr)
+	}
+	draftID := createResponse.GetDraft().GetId()
+	if draftID == "" {
+		return fmt.Errorf("%s CreateDraft: response draft ID is empty", barbarianIdentity)
+	}
+
+	if _, err := client.UpdateName(identityCtx, &dnd5ev1alpha1.UpdateNameRequest{
+		DraftId: draftID,
+		Name:    barbarianName,
+	}); err != nil {
+		return rpcError(barbarianIdentity, "UpdateName", err)
+	}
+	if _, err := client.UpdateRace(identityCtx, &dnd5ev1alpha1.UpdateRaceRequest{
+		DraftId: draftID,
+		Race:    dnd5ev1alpha1.Race_RACE_HUMAN,
+		RaceChoices: []*dnd5ev1alpha1.ChoiceData{{
+			Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_LANGUAGES,
+			Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_RACE,
+			Selection: &dnd5ev1alpha1.ChoiceData_Languages{
+				Languages: &dnd5ev1alpha1.LanguageSelection{
+					Languages: []dnd5ev1alpha1.Language{dnd5ev1alpha1.Language_LANGUAGE_ORC},
+				},
+			},
+		}},
+	}); err != nil {
+		return rpcError(barbarianIdentity, "UpdateRace", err)
+	}
+	if _, err := client.UpdateClass(identityCtx, &dnd5ev1alpha1.UpdateClassRequest{
+		DraftId: draftID,
+		Class:   dnd5ev1alpha1.Class_CLASS_BARBARIAN,
+		ClassChoices: []*dnd5ev1alpha1.ChoiceData{
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_SKILLS,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				Selection: &dnd5ev1alpha1.ChoiceData_Skills{
+					Skills: &dnd5ev1alpha1.SkillSelection{
+						Skills: []dnd5ev1alpha1.Skill{
+							dnd5ev1alpha1.Skill_SKILL_ATHLETICS,
+							dnd5ev1alpha1.Skill_SKILL_INTIMIDATION,
+						},
+					},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "barbarian-weapons-primary",
+				OptionId: "barbarian-weapon-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "barbarian-weapons-secondary",
+				OptionId: "barbarian-secondary-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+			{
+				Category: dnd5ev1alpha1.ChoiceCategory_CHOICE_CATEGORY_EQUIPMENT,
+				Source:   dnd5ev1alpha1.ChoiceSource_CHOICE_SOURCE_CLASS,
+				ChoiceId: "barbarian-pack",
+				OptionId: "barbarian-pack-a",
+				Selection: &dnd5ev1alpha1.ChoiceData_Equipment{
+					Equipment: &dnd5ev1alpha1.EquipmentSelection{},
+				},
+			},
+		},
+	}); err != nil {
+		return rpcError(barbarianIdentity, "UpdateClass", err)
+	}
+	if _, err := client.UpdateBackground(identityCtx, &dnd5ev1alpha1.UpdateBackgroundRequest{
+		DraftId:    draftID,
+		Background: dnd5ev1alpha1.Background_BACKGROUND_OUTLANDER,
+	}); err != nil {
+		return rpcError(barbarianIdentity, "UpdateBackground", err)
+	}
+	if _, err := client.UpdateAbilityScores(identityCtx, &dnd5ev1alpha1.UpdateAbilityScoresRequest{
+		DraftId: draftID,
+		ScoresInput: &dnd5ev1alpha1.UpdateAbilityScoresRequest_AbilityScores{
+			AbilityScores: &dnd5ev1alpha1.AbilityScores{
+				Strength:     15,
+				Dexterity:    13,
+				Constitution: 14,
+				Intelligence: 8,
+				Wisdom:       12,
+				Charisma:     10,
+			},
+		},
+	}); err != nil {
+		return rpcError(barbarianIdentity, "UpdateAbilityScores", err)
+	}
+	if _, err := client.GetDraft(identityCtx, &dnd5ev1alpha1.GetDraftRequest{DraftId: draftID}); err != nil {
+		return rpcError(barbarianIdentity, "GetDraft", err)
+	}
+	if _, err := client.FinalizeDraft(identityCtx, &dnd5ev1alpha1.FinalizeDraftRequest{DraftId: draftID}); err != nil {
+		return rpcError(barbarianIdentity, "FinalizeDraft", err)
+	}
+
+	characterID, err := listExactlyOne(identityCtx, client, barbarianIdentity, barbarianName)
+	if err != nil {
+		return err
+	}
+	characterResponse, err := client.GetCharacter(identityCtx, &dnd5ev1alpha1.GetCharacterRequest{CharacterId: characterID})
+	if err != nil {
+		return rpcError(barbarianIdentity, "GetCharacter", err)
+	}
+	if characterResponse.GetCharacter() == nil {
+		return fmt.Errorf("%s GetCharacter: response character is empty", barbarianIdentity)
+	}
+	if _, finalListErr := listExactlyOne(identityCtx, client, barbarianIdentity, barbarianName); finalListErr != nil {
+		return finalListErr
+	}
+
+	fmt.Printf("sandboxseed: identity=%s character_id=%s strength=%d off_hand=%s\n",
+		barbarianIdentity,
+		characterID,
+		characterResponse.GetCharacter().GetAbilityScores().GetStrength(),
+		characterResponse.GetCharacter().GetEquipmentSlots().GetOffHand().GetItemId(),
+	)
+	return nil
+}
+
+func authenticatedContext(ctx context.Context, identity string) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "authorization", "Dev "+identity)
+}
+
+func deleteListedCharacters(ctx context.Context, client CharacterRPC, identity string) error {
+	response, err := client.ListCharacters(ctx, &dnd5ev1alpha1.ListCharactersRequest{PageSize: listPageSize})
+	if err != nil {
+		return rpcError(identity, "ListCharacters", err)
+	}
+	if response.GetNextPageToken() != "" {
+		return fmt.Errorf("%s ListCharacters: unexpected next page token", identity)
+	}
+	for _, character := range response.GetCharacters() {
+		if _, deleteErr := client.DeleteCharacter(ctx, &dnd5ev1alpha1.DeleteCharacterRequest{CharacterId: character.GetId()}); deleteErr != nil {
+			return rpcError(identity, "DeleteCharacter", deleteErr)
+		}
+	}
+	return nil
+}
+
+func listExactlyOne(ctx context.Context, client CharacterRPC, identity, expectedName string) (string, error) {
+	response, err := client.ListCharacters(ctx, &dnd5ev1alpha1.ListCharactersRequest{PageSize: listPageSize})
+	if err != nil {
+		return "", rpcError(identity, "ListCharacters", err)
+	}
+	if response.GetNextPageToken() != "" {
+		return "", fmt.Errorf("%s ListCharacters: unexpected next page token", identity)
+	}
+	characters := response.GetCharacters()
+	if len(characters) != 1 {
+		return "", fmt.Errorf("%s ListCharacters: got %d characters, want exactly one", identity, len(characters))
+	}
+	if characters[0].GetName() != expectedName {
+		return "", fmt.Errorf("%s ListCharacters: character name is %q, want %q", identity, characters[0].GetName(), expectedName)
+	}
+	if characters[0].GetId() == "" {
+		return "", fmt.Errorf("%s ListCharacters: character ID is empty", identity)
+	}
+	return characters[0].GetId(), nil
+}
+
+func inventoryItemID(character *dnd5ev1alpha1.Character, expectedItemID string) (string, error) {
+	if character == nil {
+		return "", errors.New("response character is empty")
+	}
+	for _, item := range character.GetInventory() {
+		if item.GetItemId() == expectedItemID {
+			return item.GetItemId(), nil
+		}
+	}
+	return "", fmt.Errorf("inventory item %q not found", expectedItemID)
+}
+
+func rpcError(identity, method string, err error) error {
+	return fmt.Errorf("%s %s: %w", identity, method, err)
+}

--- a/scripts/toolkit-local-override.sh
+++ b/scripts/toolkit-local-override.sh
@@ -1,85 +1,218 @@
 #!/bin/bash
-# toolkit-local-override.sh — iterate on rpg-toolkit/encounter changes in the
-# local Docker loop without publish -> version tag -> `go get`.
+# toolkit-local-override.sh — iterate on one rpg-toolkit module in the local
+# Docker loop without publish -> version tag -> `go get`.
 #
-# THE constraint this solves: the local rpg-api image is built with
-#   docker build -t rpg-api:local <rpg-api-dir>
-# — the build context is the rpg-api directory ALONE. A go.mod `replace`
-# pointing outside that directory (e.g. `../../rpg-toolkit/encounter`)
-# compiles fine on the host but fails inside Docker, because the toolkit
-# source is not in the context. This script instead SYNCS the toolkit
-# module's source INTO a gitignored directory inside this repo
-# (local-toolkit/encounter) and points the replace at that relative path, so
-# it stays inside the build context.
-#
-# Exactly one module may be overridden: github.com/KirkDiggler/rpg-toolkit/encounter.
-# Its sibling-module requires (core, events, tools/spatial, ...) stay at their
-# published versions. Do not add another replace: this script rejects any
-# unapproved or second active replacement.
-#
-# Usage:
-#   scripts/toolkit-local-override.sh on [--src <path-to-rpg-toolkit-checkout>]
-#   scripts/toolkit-local-override.sh off
-#   scripts/toolkit-local-override.sh status
-#
-# on:     rsyncs <src>/encounter/ -> local-toolkit/encounter/, then
-#         `go mod edit -replace` to point go.mod at it. Re-run `on` after
-#         every toolkit edit to re-sync (fast — no publish, no tag, no
-#         `go get`); rebuild the image with Dockerfile.local-toolkit
-#         afterward (see docs/how-to/local-toolkit-override.md).
-# off:    `go mod edit -dropreplace` and deletes local-toolkit/ entirely,
-#         restoring go.mod/go.sum to the published pin with no residue.
-# status: reports whether the override is currently active.
-#
-# The `replace` this script adds/removes must NEVER be committed while
-# active — it points at a directory (local-toolkit/) that doesn't exist on
-# CI or any other machine, and CI's own `go build` would catch an escaped
-# replace regardless (defense in depth, not the only line — see
-# docs/how-to/local-toolkit-override.md).
+# The synced source lives inside this checkout because Docker's build context
+# is the rpg-api directory alone.  Exactly one allowlisted module may be
+# replaced at a time; the state record binds the replacement to its target so
+# refresh/status/off cannot act on an ambiguous or unowned tree.
 set -euo pipefail
 
-MODULE="github.com/KirkDiggler/rpg-toolkit/encounter"
-REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
-LOCAL_DIR="$REPO_ROOT/local-toolkit/encounter"
+TARGET_ENCOUNTER='encounter'
+TARGET_DND5E='rulebooks/dnd5e'
+STATE_BASENAME='.toolkit-local-override-state'
 
-# replace_modules prints every module path with an active replace directive.
-# Keeping this list explicit makes status auditable and lets on/off reject a
-# second module rather than silently building a mixed unpublished dependency
-# graph.
-replace_modules() {
-	(cd "$REPO_ROOT" && go mod edit -json | jq -r '.Replace[]? | .Old.Path')
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+STATE_FILE="$REPO_ROOT/local-toolkit/$STATE_BASENAME"
+
+# These are populated by inspect_active_replacement and validate_state.
+ACTIVE_COUNT=0
+ACTIVE_MODULE=''
+ACTIVE_REPLACE=''
+ACTIVE_TARGET=''
+STATE_TARGET=''
+STATE_MODULE=''
+STATE_REPLACE=''
+STATE_SOURCE=''
+STATE_REVISION=''
+STATE_SYNCED_AT=''
+
+module_for_target() {
+	case "$1" in
+	"$TARGET_ENCOUNTER")
+		printf '%s\n' 'github.com/KirkDiggler/rpg-toolkit/encounter'
+		;;
+	"$TARGET_DND5E")
+		printf '%s\n' 'github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e'
+		;;
+	*)
+		printf 'error: unsupported override target: %s\n' "$1" >&2
+		return 1
+		;;
+	esac
 }
 
-assert_only_approved_override() {
-	local modules=()
-	mapfile -t modules < <(replace_modules)
-	if [ "${#modules[@]}" -gt 1 ]; then
-		echo "error: exactly one local override is permitted; active modules: ${modules[*]}" >&2
+target_for_module() {
+	case "$1" in
+	github.com/KirkDiggler/rpg-toolkit/encounter)
+		printf '%s\n' "$TARGET_ENCOUNTER"
+		;;
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e)
+		printf '%s\n' "$TARGET_DND5E"
+		;;
+	*)
+		printf 'error: unsupported override module: %s\n' "$1" >&2
 		return 1
-	fi
-	if [ "${#modules[@]}" -eq 1 ] && [ "${modules[0]}" != "$MODULE" ]; then
-		echo "error: unapproved local override for ${modules[0]}; only $MODULE is permitted" >&2
-		return 1
-	fi
+		;;
+	esac
 }
 
 usage() {
-	echo "Usage: $0 {on [--src <path>]|off|status}" >&2
+	echo "Usage: $0 on [--target encounter|rulebooks/dnd5e] [--src <path>]" >&2
+	echo "       $0 refresh [--src <path>]" >&2
+	echo "       $0 status" >&2
+	echo "       $0 off" >&2
 	exit 1
 }
 
-# resolve_src finds an rpg-toolkit checkout to sync from: an explicit --src,
-# then TOOLKIT_SRC_DIR, then a couple of common game-dev workspace layouts.
-# Errors with a clear message rather than guessing further — silently
-# syncing the wrong checkout would be worse than asking.
+# inspect_active_replacement reads only go.mod's JSON replacement table.  It
+# never reads the state file; callers validate the exact target path before
+# they read ownership metadata.
+inspect_active_replacement() {
+	local json
+	json="$(cd "$REPO_ROOT" && go mod edit -json)"
+	ACTIVE_COUNT="$(jq -r '(.Replace // []) | length' <<<"$json")"
+	ACTIVE_MODULE=''
+	ACTIVE_REPLACE=''
+	ACTIVE_TARGET=''
+
+	if [ "$ACTIVE_COUNT" -eq 0 ]; then
+		return 1
+	fi
+	if [ "$ACTIVE_COUNT" -ne 1 ]; then
+		echo "error: exactly one local override is permitted; active replacements: $ACTIVE_COUNT" >&2
+		return 1
+	fi
+
+	ACTIVE_MODULE="$(jq -r '.Replace[0].Old.Path // empty' <<<"$json")"
+	ACTIVE_REPLACE="$(jq -r '.Replace[0].New.Path // empty' <<<"$json")"
+	ACTIVE_TARGET="$(target_for_module "$ACTIVE_MODULE")" || {
+		echo "error: unapproved local override for $ACTIVE_MODULE" >&2
+		return 1
+	}
+	local expected
+	expected="./local-toolkit/$ACTIVE_TARGET"
+	if [ "$ACTIVE_REPLACE" != "$expected" ]; then
+		echo "error: replacement for $ACTIVE_MODULE must be exactly $expected (got '$ACTIVE_REPLACE')" >&2
+		return 1
+	fi
+	return 0
+}
+
+# validate_state parses literal key=value lines.  It deliberately never
+# source-evaluates the file: values are data, including a hostile value such
+# as $(touch /tmp/marker).  Every key is required exactly once and no unknown
+# key is accepted.
+validate_state() {
+	local expected_target="$1"
+	local expected_module="$2"
+	local expected_replace="$3"
+	local -A seen=()
+	local line key value
+
+	if [ ! -f "$STATE_FILE" ]; then
+		echo "error: ownership state is missing: $STATE_FILE" >&2
+		return 1
+	fi
+
+	while IFS= read -r line || [ -n "$line" ]; do
+		if [[ "$line" != *=* ]]; then
+			echo "error: invalid ownership state line" >&2
+			return 1
+		fi
+		key="${line%%=*}"
+		value="${line#*=}"
+		if [ -z "$key" ] || [ -z "$value" ]; then
+			echo "error: ownership state keys and values must be non-empty" >&2
+			return 1
+		fi
+		case "$key" in
+		target|module|replace|source|revision|synced_at) ;;
+		*)
+			echo "error: unknown ownership state key: $key" >&2
+			return 1
+			;;
+		esac
+		if [[ -n "${seen[$key]+present}" ]]; then
+			echo "error: duplicate ownership state key: $key" >&2
+			return 1
+		fi
+		seen["$key"]=1
+		case "$key" in
+		target) STATE_TARGET="$value" ;;
+		module) STATE_MODULE="$value" ;;
+		replace) STATE_REPLACE="$value" ;;
+		source) STATE_SOURCE="$value" ;;
+		revision) STATE_REVISION="$value" ;;
+		synced_at) STATE_SYNCED_AT="$value" ;;
+		esac
+	done <"$STATE_FILE"
+
+	local required
+	for required in target module replace source revision synced_at; do
+		if [[ -z "${seen[$required]+present}" ]]; then
+			echo "error: missing ownership state key: $required" >&2
+			return 1
+		fi
+	done
+
+	if [ "$STATE_TARGET" != "$expected_target" ] ||
+		[ "$STATE_MODULE" != "$expected_module" ] ||
+		[ "$STATE_REPLACE" != "$expected_replace" ]; then
+		echo "error: ownership state does not match the active replacement" >&2
+		return 1
+	fi
+}
+
+# require_active_override establishes a single exact replacement and then
+# validates its ownership record.  It is used by refresh/status/off.
+require_active_override() {
+	if ! inspect_active_replacement; then
+		if [ "$ACTIVE_COUNT" -eq 0 ]; then
+			echo "error: no active allowlisted toolkit override" >&2
+		fi
+		return 1
+	fi
+	validate_state "$ACTIVE_TARGET" "$ACTIVE_MODULE" "$ACTIVE_REPLACE"
+}
+
+# assert_on_target accepts no replacement or the same exact owned target.  A
+# different target, unknown replacement, second replacement, or unowned exact
+# replacement fails before source validation or rsync.
+assert_on_target() {
+	local target="$1"
+	local module
+	module="$(module_for_target "$target")" || return 1
+	if ! inspect_active_replacement; then
+		if [ "$ACTIVE_COUNT" -eq 0 ]; then
+			return 0
+		fi
+		return 1
+	fi
+	if [ "$ACTIVE_MODULE" != "$module" ]; then
+		echo "error: target $target cannot be enabled while $ACTIVE_MODULE is active" >&2
+		return 1
+	fi
+	validate_state "$ACTIVE_TARGET" "$ACTIVE_MODULE" "$ACTIVE_REPLACE"
+}
+
+# resolve_src finds a checkout containing the selected module.  An explicit
+# path wins, followed by TOOLKIT_SRC_DIR, an existing state source (for a
+# refresh/re-run), and the historical workspace guesses.
 resolve_src() {
 	local explicit="$1"
+	local target="$2"
+	local state_source="${3:-}"
 	local candidates=()
+	local c
 	if [ -n "$explicit" ]; then
 		candidates+=("$explicit")
 	fi
 	if [ -n "${TOOLKIT_SRC_DIR:-}" ]; then
 		candidates+=("$TOOLKIT_SRC_DIR")
+	fi
+	if [ -n "$state_source" ]; then
+		candidates+=("$state_source")
 	fi
 	candidates+=(
 		"$HOME/game-dev/rpg-toolkit"
@@ -87,60 +220,133 @@ resolve_src() {
 		"$REPO_ROOT/../../../rpg-toolkit"
 	)
 	for c in "${candidates[@]}"; do
-		if [ -f "$c/encounter/go.mod" ]; then
-			echo "$c"
+		if [ -f "$c/$target/go.mod" ]; then
+			(cd "$c" && pwd -P)
 			return 0
 		fi
 	done
-	echo "error: could not find an rpg-toolkit checkout with encounter/go.mod." >&2
-	echo "Pass --src <path>, or set TOOLKIT_SRC_DIR, e.g.:" >&2
-	echo "  TOOLKIT_SRC_DIR=/home/kirk/game-dev/rpg-toolkit $0 on" >&2
+	echo "error: could not find an rpg-toolkit checkout with $target/go.mod." >&2
+	echo "Pass --src <path>, or set TOOLKIT_SRC_DIR." >&2
 	return 1
 }
 
+validate_source_module() {
+	local src="$1"
+	local target="$2"
+	local module="$3"
+	local go_mod="$src/$target/go.mod"
+	local declared
+	declared="$(awk '$1 == "module" { print $2; exit }' "$go_mod")"
+	if [ "$declared" != "$module" ]; then
+		echo "error: $go_mod declares '$declared', expected 'module $module'" >&2
+		return 1
+	fi
+}
+
+source_revision() {
+	local src="$1"
+	if git -C "$src" rev-parse --verify HEAD 2>/dev/null; then
+		return 0
+	fi
+	printf '%s\n' unknown
+}
+
+write_state() {
+	local target="$1"
+	local module="$2"
+	local replace="$3"
+	local source="$4"
+	local revision="$5"
+	local synced_at
+	local state_tmp
+	synced_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	mkdir -p "$(dirname "$STATE_FILE")"
+	state_tmp="$(mktemp "$REPO_ROOT/local-toolkit/$STATE_BASENAME.tmp.XXXXXX")"
+	{
+		printf 'target=%s\n' "$target"
+		printf 'module=%s\n' "$module"
+		printf 'replace=%s\n' "$replace"
+		printf 'source=%s\n' "$source"
+		printf 'revision=%s\n' "$revision"
+		printf 'synced_at=%s\n' "$synced_at"
+	} >"$state_tmp"
+	mv -f "$state_tmp" "$STATE_FILE"
+}
+
+host_build() {
+	local message="$1"
+	if ! (cd "$REPO_ROOT" && go build ./...); then
+		echo "error: host build failed $message" >&2
+		return 1
+	fi
+}
+
+sync_target() {
+	local target="$1"
+	local module="$2"
+	local source="$3"
+	local apply_replace="$4"
+	local local_dir="$REPO_ROOT/local-toolkit/$target"
+	local replace="./local-toolkit/$target"
+	local revision
+
+	# This check is intentionally before mkdir/rsync.
+	validate_source_module "$source" "$target" "$module"
+	revision="$(source_revision "$source")"
+	echo "Syncing $source/$target/ -> $local_dir/ ..."
+	mkdir -p "$local_dir"
+	rsync -a --delete --exclude='.git' "$source/$target/" "$local_dir/"
+
+	if [ "$apply_replace" = yes ]; then
+		echo "Pointing go.mod at the local copy ..."
+		(cd "$REPO_ROOT" && go mod edit -replace "$module=$replace")
+	fi
+
+	# State is written only after sync and the exact JSON replacement check.
+	if ! inspect_active_replacement ||
+		[ "$ACTIVE_TARGET" != "$target" ] ||
+		[ "$ACTIVE_MODULE" != "$module" ] ||
+		[ "$ACTIVE_REPLACE" != "$replace" ]; then
+		echo "error: active replacement is not the exact selected target after sync" >&2
+		return 1
+	fi
+	write_state "$target" "$module" "$replace" "$source" "$revision"
+}
+
 cmd_on() {
-	local explicit=""
-	while [ $# -gt 0 ]; do
+	local target="$TARGET_ENCOUNTER"
+	local explicit=''
+	while [ "$#" -gt 0 ]; do
 		case "$1" in
+		--target)
+			[ "$#" -ge 2 ] || usage
+			target="$2"
+			shift 2
+			;;
 		--src)
+			[ "$#" -ge 2 ] || usage
 			explicit="$2"
 			shift 2
 			;;
-		*)
-			usage
-			;;
+		*) usage ;;
 		esac
 	done
+	local module
+	module="$(module_for_target "$target")" || exit 1
+	assert_on_target "$target"
 
-	assert_only_approved_override
-
-	local src
-	src="$(resolve_src "$explicit")"
-
-	local module_line
-	module_line="$(head -1 "$src/encounter/go.mod")"
-	if [ "$module_line" != "module $MODULE" ]; then
-		echo "error: $src/encounter/go.mod declares '$module_line', expected 'module $MODULE'" >&2
-		exit 1
+	local state_source=''
+	if [ "$ACTIVE_COUNT" -eq 1 ] && [ "$ACTIVE_TARGET" = "$target" ]; then
+		state_source="$STATE_SOURCE"
 	fi
-
-	echo "Syncing $src/encounter/ -> $LOCAL_DIR/ ..."
-	mkdir -p "$LOCAL_DIR"
-	rsync -a --delete --exclude='.git' "$src/encounter/" "$LOCAL_DIR/"
-
-	echo "Pointing go.mod at the local copy ..."
-	(cd "$REPO_ROOT" && go mod edit -replace "$MODULE=./local-toolkit/encounter")
-	assert_only_approved_override
-
-	echo "Sanity-building on the host ..."
-	if ! (cd "$REPO_ROOT" && go build ./...); then
-		echo "error: host build failed against the synced local copy — check the toolkit edit for compile errors." >&2
-		exit 1
-	fi
+	local source
+	source="$(resolve_src "$explicit" "$target" "$state_source")"
+	sync_target "$target" "$module" "$source" yes
+	host_build "against the synced local copy — check the toolkit edit for compile errors."
 
 	cat <<EOF
 
-Override ON. go.mod now replaces $MODULE with ./local-toolkit/encounter.
+Override ON. go.mod now replaces $module with ./local-toolkit/$target.
 
 Next steps:
   docker build -f Dockerfile.local-toolkit -t rpg-api:local $REPO_ROOT
@@ -149,54 +355,79 @@ Next steps:
                   -f docker-compose.local-api-src.yml \\
                   up -d rpg-api)
 
-Re-run '$0 on' after every toolkit edit to re-sync.
+Re-run '$0 on --target $target' after every toolkit edit to re-sync.
 Run '$0 off' when done — publish the toolkit change, bump the version tag,
 then remove the override (never leave it active on a branch you push).
 EOF
 }
 
-cmd_off() {
-	assert_only_approved_override
-
-	echo "Dropping the replace directive ..."
-	(cd "$REPO_ROOT" && go mod edit -dropreplace "$MODULE")
-
-	echo "Removing $LOCAL_DIR ..."
-	rm -rf "$REPO_ROOT/local-toolkit"
-
-	echo "Sanity-building against the published module ..."
-	if ! (cd "$REPO_ROOT" && go build ./...); then
-		echo "error: build failed after removing the override — go.mod/go.sum may need attention (git diff go.mod go.sum)." >&2
-		exit 1
-	fi
-
-	echo "Override OFF. go.mod/go.sum are back on the published pin, local-toolkit/ removed."
+cmd_refresh() {
+	local explicit=''
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--src)
+			[ "$#" -ge 2 ] || usage
+			explicit="$2"
+			shift 2
+			;;
+		*) usage ;;
+		esac
+	done
+	require_active_override
+	local source
+	source="$(resolve_src "$explicit" "$ACTIVE_TARGET" "$STATE_SOURCE")"
+	sync_target "$ACTIVE_TARGET" "$ACTIVE_MODULE" "$source" no
+	host_build "after refresh — check the toolkit edit for compile errors."
+	echo "Override refreshed for $ACTIVE_MODULE from $source."
 }
 
 cmd_status() {
-	local modules=()
-	mapfile -t modules < <(replace_modules)
-	if [ "${#modules[@]}" -eq 0 ]; then
-		echo "Active replace modules (0): none"
-		echo "Override OFF: $MODULE resolves to its published version."
+	if ! inspect_active_replacement; then
+		if [ "$ACTIVE_COUNT" -eq 0 ]; then
+			echo 'Active replace modules (0): none'
+			echo 'Override OFF: no allowlisted local replacement is active.'
+			return 0
+		fi
+		return 1
+	fi
+	validate_state "$ACTIVE_TARGET" "$ACTIVE_MODULE" "$ACTIVE_REPLACE"
+	echo "Active replace modules (1): $ACTIVE_MODULE"
+	echo "Override ON: $ACTIVE_MODULE => $ACTIVE_REPLACE"
+	echo "Target: $ACTIVE_TARGET"
+	echo "Source: $STATE_SOURCE"
+	if [ -d "$REPO_ROOT/local-toolkit/$ACTIVE_TARGET" ]; then
+		echo "local-toolkit/$ACTIVE_TARGET/ exists on disk."
 	else
-		echo "Active replace modules (${#modules[@]}): ${modules[*]}"
-		if ! assert_only_approved_override; then
+		echo "error: synced directory is missing: local-toolkit/$ACTIVE_TARGET" >&2
+		return 1
+	fi
+}
+
+cmd_off() {
+	if ! inspect_active_replacement; then
+		if [ "$ACTIVE_COUNT" -ne 0 ]; then
 			return 1
 		fi
-		local replace
-		replace="$(cd "$REPO_ROOT" && go list -m -f '{{if .Replace}}{{.Replace.Path}} => {{.Replace.Dir}}{{end}}' "$MODULE" 2>/dev/null || true)"
-		if [ -z "$replace" ]; then
-			echo "error: approved module is listed but has no resolvable replacement" >&2
+		if [ -e "$STATE_FILE" ]; then
+			echo "error: ownership state exists without an active replacement" >&2
 			return 1
 		fi
-		echo "Override ON: $MODULE => $replace"
+		host_build "with no active override."
+		echo 'Override already OFF: no active allowlisted local replacement.'
+		return 0
 	fi
-	if [ -d "$LOCAL_DIR" ]; then
-		echo "local-toolkit/encounter/ exists on disk ($(find "$LOCAL_DIR" -name '*.go' | wc -l | tr -d ' ') .go files)."
-	else
-		echo "local-toolkit/encounter/ does not exist."
-	fi
+	# All ownership checks happen before the first mutation.
+	validate_state "$ACTIVE_TARGET" "$ACTIVE_MODULE" "$ACTIVE_REPLACE"
+	local target_dir="$REPO_ROOT/local-toolkit/$ACTIVE_TARGET"
+	echo "Dropping the replace directive ..."
+	(cd "$REPO_ROOT" && go mod edit -dropreplace "$ACTIVE_MODULE")
+	echo "Removing $target_dir ..."
+	rm -rf "$target_dir"
+	rm -f "$STATE_FILE"
+	# Only empty structural parents are removed; an unrelated sibling survives.
+	rmdir "$(dirname "$target_dir")" 2>/dev/null || true
+	host_build "after removing the override — check go.mod/go.sum."
+	echo "Override OFF. $ACTIVE_MODULE is back on its published pin."
 }
 
 case "${1:-}" in
@@ -204,13 +435,19 @@ on)
 	shift
 	cmd_on "$@"
 	;;
-off)
-	cmd_off
+refresh)
+	shift
+	cmd_refresh "$@"
 	;;
 status)
+	shift
+	[ "$#" -eq 0 ] || usage
 	cmd_status
 	;;
-*)
-	usage
+off)
+	shift
+	[ "$#" -eq 0 ] || usage
+	cmd_off
 	;;
+*) usage ;;
 esac

--- a/scripts/toolkit-local-override.sh
+++ b/scripts/toolkit-local-override.sh
@@ -426,6 +426,7 @@ cmd_off() {
 	rm -f "$STATE_FILE"
 	# Only empty structural parents are removed; an unrelated sibling survives.
 	rmdir "$(dirname "$target_dir")" 2>/dev/null || true
+	rmdir "$REPO_ROOT/local-toolkit" 2>/dev/null || true
 	host_build "after removing the override — check go.mod/go.sum."
 	echo "Override OFF. $ACTIVE_MODULE is back on its published pin."
 }

--- a/scripts/toolkit-local-override.test.sh
+++ b/scripts/toolkit-local-override.test.sh
@@ -169,6 +169,7 @@ assert_file_contains 'rulebooks/dnd5e' "$WORK/status.txt"
 run_override "$api" off
 test ! -e "$api/local-toolkit/rulebooks/dnd5e"
 test ! -e "$api/local-toolkit/.toolkit-local-override-state"
+test ! -e "$api/local-toolkit"
 
 # The no-target encounter path remains supported.
 api="$WORK/api-default-encounter"

--- a/scripts/toolkit-local-override.test.sh
+++ b/scripts/toolkit-local-override.test.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# Hermetic contract tests for toolkit-local-override.sh.
+set -euo pipefail
+
+SCRIPT_SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/toolkit-local-override.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+assert_file_contains() {
+	local needle="$1"
+	local file="$2"
+	grep -Fq -- "$needle" "$file" || fail "expected '$needle' in $file"
+}
+
+assert_file_not_contains() {
+	local needle="$1"
+	local file="$2"
+	if grep -Fq -- "$needle" "$file"; then
+		fail "did not expect '$needle' in $file"
+	fi
+}
+
+make_toolkit() {
+	local root="$1"
+	mkdir -p "$root/encounter" "$root/rulebooks/dnd5e"
+	cat >"$root/encounter/go.mod" <<'EOF'
+module github.com/KirkDiggler/rpg-toolkit/encounter
+
+go 1.22
+EOF
+	cat >"$root/encounter/encounter.go" <<'EOF'
+package encounter
+
+const Name = "encounter"
+EOF
+	cat >"$root/rulebooks/dnd5e/go.mod" <<'EOF'
+module github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e
+
+go 1.22
+EOF
+	cat >"$root/rulebooks/dnd5e/dnd5e.go" <<'EOF'
+package dnd5e
+
+const Name = "dnd5e"
+EOF
+	git -C "$root" init -q
+	git -C "$root" config user.email test@example.com
+	git -C "$root" config user.name toolkit-test
+	git -C "$root" add .
+	git -C "$root" commit -qm fixture
+}
+
+make_api() {
+	local root="$1"
+	local target="$2"
+	local module
+	case "$target" in
+	encounter) module=github.com/KirkDiggler/rpg-toolkit/encounter ;;
+	rulebooks/dnd5e) module=github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e ;;
+	*) fail "unsupported fixture target $target" ;;
+	esac
+	mkdir -p "$root/scripts"
+	cp "$SCRIPT_SOURCE" "$root/scripts/toolkit-local-override.sh"
+	chmod +x "$root/scripts/toolkit-local-override.sh"
+	cat >"$root/go.mod" <<EOF
+module example.com/api
+
+go 1.22
+
+require $module v0.0.0
+EOF
+	cat >"$root/main.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+	git -C "$root" init -q
+	git -C "$root" config user.email test@example.com
+	git -C "$root" config user.name api-test
+	git -C "$root" add .
+	git -C "$root" commit -qm fixture
+}
+
+run_override() {
+	local api="$1"
+	shift
+	(cd "$api" && scripts/toolkit-local-override.sh "$@")
+}
+
+expect_failure() {
+	local label="$1"
+	shift
+	local output
+	if output=$("$@" 2>&1); then
+		echo "$output" >&2
+		fail "$label unexpectedly succeeded"
+	fi
+}
+
+snapshot_fixture() {
+	local api="$1"
+	local snapshot="$2"
+	cp "$api/go.mod" "$snapshot.go.mod"
+	if [ -e "$api/local-toolkit" ]; then
+		cp -a "$api/local-toolkit" "$snapshot.local-toolkit"
+	else
+		: >"$snapshot.no-local-toolkit"
+	fi
+}
+
+assert_snapshot_unchanged() {
+	local api="$1"
+	local snapshot="$2"
+	cmp -s "$snapshot.go.mod" "$api/go.mod" || fail "go.mod changed unexpectedly"
+	if [ -e "$snapshot.no-local-toolkit" ]; then
+		test ! -e "$api/local-toolkit" || fail "local-toolkit changed unexpectedly"
+	else
+		diff -ruN "$snapshot.local-toolkit" "$api/local-toolkit" >/dev/null || fail "local-toolkit changed unexpectedly"
+	fi
+}
+
+write_state() {
+	local api="$1"
+	local target="$2"
+	local module="$3"
+	local replace="$4"
+	local source="$5"
+	mkdir -p "$api/local-toolkit"
+	cat >"$api/local-toolkit/.toolkit-local-override-state" <<EOF
+target=$target
+module=$module
+replace=$replace
+source=$source
+revision=fixture-revision
+synced_at=2026-01-01T00:00:00Z
+EOF
+}
+
+seed_exact_override() {
+	local api="$1"
+	local target="$2"
+	local module
+	case "$target" in
+	encounter) module=github.com/KirkDiggler/rpg-toolkit/encounter ;;
+	rulebooks/dnd5e) module=github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e ;;
+	esac
+	mkdir -p "$api/local-toolkit/$target"
+	(cd "$api" && go mod edit -replace "$module=./local-toolkit/$target")
+	write_state "$api" "$target" "$module" "./local-toolkit/$target" "$WORK/toolkit"
+}
+
+# Primary D&D 5e lifecycle: on, refresh, status, and off.
+toolkit="$WORK/toolkit"
+make_toolkit "$toolkit"
+api="$WORK/api-dnd5e"
+make_api "$api" rulebooks/dnd5e
+run_override "$api" on --target rulebooks/dnd5e --src "$toolkit"
+assert_file_contains 'github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e => ./local-toolkit/rulebooks/dnd5e' "$api/go.mod"
+printf '\nconst Refreshed = true\n' >>"$toolkit/rulebooks/dnd5e/dnd5e.go"
+run_override "$api" refresh --src "$toolkit"
+grep -Fq 'const Refreshed = true' "$api/local-toolkit/rulebooks/dnd5e/dnd5e.go" || fail 'refresh did not sync source changes'
+run_override "$api" status >"$WORK/status.txt"
+assert_file_contains 'rulebooks/dnd5e' "$WORK/status.txt"
+run_override "$api" off
+test ! -e "$api/local-toolkit/rulebooks/dnd5e"
+test ! -e "$api/local-toolkit/.toolkit-local-override-state"
+
+# The no-target encounter path remains supported.
+api="$WORK/api-default-encounter"
+make_api "$api" encounter
+run_override "$api" on --src "$toolkit"
+assert_file_contains 'github.com/KirkDiggler/rpg-toolkit/encounter => ./local-toolkit/encounter' "$api/go.mod"
+run_override "$api" off
+
+# A source declaring a different module must fail before either sync or go.mod edit.
+bad_source="$WORK/bad-source"
+mkdir -p "$bad_source/rulebooks/dnd5e"
+cat >"$bad_source/rulebooks/dnd5e/go.mod" <<'EOF'
+module example.com/not-allowed
+
+go 1.22
+EOF
+snapshot_fixture "$api" "$WORK/bad-source-before"
+expect_failure bad-source run_override "$api" on --target rulebooks/dnd5e --src "$bad_source"
+assert_snapshot_unchanged "$api" "$WORK/bad-source-before"
+
+# Unknown and second active replacements are rejected before rsync.
+api="$WORK/api-unknown"
+make_api "$api" rulebooks/dnd5e
+(cd "$api" && go mod edit -replace example.com/unknown=./local-toolkit/unknown)
+snapshot_fixture "$api" "$WORK/unknown-before"
+expect_failure unknown-replace run_override "$api" on --target rulebooks/dnd5e --src "$toolkit"
+assert_snapshot_unchanged "$api" "$WORK/unknown-before"
+
+api="$WORK/api-second"
+make_api "$api" rulebooks/dnd5e
+run_override "$api" on --target rulebooks/dnd5e --src "$toolkit"
+mkdir -p "$api/local-toolkit/encounter"
+printf 'keep\n' >"$api/local-toolkit/encounter/keep.txt"
+(cd "$api" && go mod edit -replace example.com/second=./local-toolkit/second)
+snapshot_fixture "$api" "$WORK/second-before"
+expect_failure second-replace run_override "$api" on --target rulebooks/dnd5e --src "$toolkit"
+assert_snapshot_unchanged "$api" "$WORK/second-before"
+(cd "$api" && go mod edit -dropreplace example.com/second)
+run_override "$api" off
+[ -e "$api/local-toolkit/encounter/keep.txt" ] || fail 'off removed unrelated local-toolkit sibling'
+test "$(cd "$api" && go mod edit -json | jq -r '(.Replace // []) | length')" -eq 0 || fail 'replacement remained after off'
+
+# Every lifecycle command must refuse an unowned RHS, missing state, and
+# mismatched ownership without changing go.mod or local-toolkit.
+for operation in refresh status off; do
+	for bad_case in bad-rhs missing-state mismatched-state; do
+		api="$WORK/api-$operation-${bad_case//-/_}"
+		make_api "$api" rulebooks/dnd5e
+		seed_exact_override "$api" rulebooks/dnd5e
+		case "$bad_case" in
+		bad-rhs)
+			(cd "$api" && go mod edit -replace github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e=./local-toolkit/not-the-target)
+			;;
+		missing-state)
+			rm "$api/local-toolkit/.toolkit-local-override-state"
+			;;
+		mismatched-state)
+			write_state "$api" encounter github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e ./local-toolkit/rulebooks/dnd5e "$toolkit"
+			;;
+		esac
+		snapshot_fixture "$api" "$WORK/$operation-${bad_case//-/_}-before"
+		case "$operation" in
+		refresh) expect_failure "$operation/$bad_case" run_override "$api" refresh --src "$toolkit" ;;
+		status|off) expect_failure "$operation/$bad_case" run_override "$api" "$operation" ;;
+		esac
+		assert_snapshot_unchanged "$api" "$WORK/$operation-${bad_case//-/_}-before"
+	done
+done
+
+# Duplicate and missing keys are rejected without evaluating the state file.
+api="$WORK/api-state-parser"
+make_api "$api" rulebooks/dnd5e
+seed_exact_override "$api" rulebooks/dnd5e
+state="$api/local-toolkit/.toolkit-local-override-state"
+cat >>"$state" <<'EOF'
+target=rulebooks/dnd5e
+EOF
+snapshot_fixture "$api" "$WORK/duplicate-before"
+expect_failure duplicate-state run_override "$api" status
+assert_snapshot_unchanged "$api" "$WORK/duplicate-before"
+
+api="$WORK/api-state-missing"
+make_api "$api" rulebooks/dnd5e
+seed_exact_override "$api" rulebooks/dnd5e
+state="$api/local-toolkit/.toolkit-local-override-state"
+sed -i '/^revision=/d' "$state"
+snapshot_fixture "$api" "$WORK/missing-key-before"
+expect_failure missing-state-key run_override "$api" status
+assert_snapshot_unchanged "$api" "$WORK/missing-key-before"
+
+api="$WORK/api-state-no-source"
+make_api "$api" rulebooks/dnd5e
+seed_exact_override "$api" rulebooks/dnd5e
+state="$api/local-toolkit/.toolkit-local-override-state"
+marker="$WORK/state-evaluated"
+sed -i "s#^source=.*#source=\$(touch '$marker')#" "$state"
+run_override "$api" status >/dev/null
+test ! -e "$marker" || fail 'state file was evaluated as shell code'
+
+# Switching targets while one exact target is active is rejected before any
+# source validation, rsync, or go.mod mutation. Test both directions.
+api="$WORK/api-switch-from-dnd5e"
+make_api "$api" rulebooks/dnd5e
+run_override "$api" on --target rulebooks/dnd5e --src "$toolkit"
+snapshot_fixture "$api" "$WORK/switch-from-dnd5e-before"
+expect_failure switch-from-dnd5e run_override "$api" on --target encounter --src "$toolkit"
+assert_snapshot_unchanged "$api" "$WORK/switch-from-dnd5e-before"
+run_override "$api" off
+
+api="$WORK/api-switch-from-encounter"
+make_api "$api" encounter
+run_override "$api" on --src "$toolkit"
+snapshot_fixture "$api" "$WORK/switch-from-encounter-before"
+expect_failure switch-from-encounter run_override "$api" on --target rulebooks/dnd5e --src "$toolkit"
+assert_snapshot_unchanged "$api" "$WORK/switch-from-encounter-before"
+run_override "$api" off
+
+echo 'toolkit-local-override contract tests passed'


### PR DESCRIPTION
## Summary
- Safe one-module encounter/rulebooks-dnd5e local override.
- RPC-only fixed Fighter/Barbarian seeder and health CLI.
- Real idempotency/ownership integration.
- Narrow existing FightingStyles projection.

## Verification
- Fresh override contract, release-pin, CLI, focused converter, real seed integration, auth, lobby, and `go test ./...` all pass.

## Review
- Tasks 2 and 3 both Spec PASS / Quality APPROVED with no findings.

## Known baseline
- `make pre-commit` remains non-zero on 35 inherited unrelated lint findings; task-local lint and fresh full Go tests pass.

Closes #791

— asset-pipeline agent, on behalf of KirkDiggler