### PR TITLE
fix(encounter): serialize mutating verbs per encounter (#787)

### DIFF
--- a/internal/orchestrators/encounter/v2/activate_feature.go
+++ b/internal/orchestrators/encounter/v2/activate_feature.go
@@ -98,6 +98,11 @@ func (o *Orchestrator) ActivateFeature(
 		return nil, errors.New("encounter orchestrator: ActivateFeatureInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> ActivateFeature -> persist span
+	// per encounter (see keyed_mutex.go).
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,

--- a/internal/orchestrators/encounter/v2/drive_npc.go
+++ b/internal/orchestrators/encounter/v2/drive_npc.go
@@ -57,7 +57,7 @@ type DriveStalledNPCTurnOutput struct {
 // directly — right after its own SetMode, so the same fix covers both today's
 // out-of-process injection and tomorrow's real trigger.
 //
-// Single-flight per encounter (npcDriveLocks): StreamEncounter is a read path
+// Single-flight per encounter (encounterLocks): StreamEncounter is a read path
 // that up to N clients can hit concurrently (e.g. four players reconnecting at
 // once). Without serializing, each would independently load the same
 // NPC-active snapshot, and the toolkit's own "am I still the active actor"
@@ -93,7 +93,7 @@ func (o *Orchestrator) DriveStalledNPCTurn(
 		return nil, errors.New("encounter orchestrator: DriveStalledNPCTurnInput is required")
 	}
 
-	unlock := o.npcDriveLocks.Lock(in.EncounterID)
+	unlock := o.encounterLocks.Lock(in.EncounterID)
 	defer unlock()
 
 	data, err := o.encRepo.Get(ctx, in.EncounterID)

--- a/internal/orchestrators/encounter/v2/end_turn.go
+++ b/internal/orchestrators/encounter/v2/end_turn.go
@@ -110,6 +110,13 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 		return nil, errors.New("encounter orchestrator: EndTurnInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> EndTurn -> driveNPCChain ->
+	// persist span per encounter (see keyed_mutex.go). driveNPCChain is a
+	// plain helper called from inside this lock — it must never itself
+	// acquire encounterLocks (see its doc comment).
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,
@@ -147,7 +154,16 @@ func (o *Orchestrator) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnO
 
 // driveNPCChain runs the toolkit's NPCAct + EndTurn cycle while the active
 // actor is an NPC, until a player is active, the encounter ends, or the
-// roster-derived chain cap is reached. active/isNPC are the CURRENT active
+// roster-derived chain cap is reached.
+//
+// Lock-ordering invariant (rpg-api#787, keyed_mutex.go): this is a plain
+// helper — it must NEVER acquire o.encounterLocks. It is called only from
+// MoveEntity, EndTurn, and DriveStalledNPCTurn, all three of which already
+// hold the per-encounter lock for their own full call before reaching here.
+// Acquiring it again here would deadlock a single-per-key sync.Mutex.
+//
+// active/isNPC are the CURRENT active actor and whether it is an NPC —
+// EndTurn passes its own EndTurn call's
 // actor and whether it is an NPC — EndTurn passes its own EndTurn call's
 // result; the combat-entry kick (drive_npc.go) passes enc.ActiveActor() /
 // enc.IsNPC(...) from a freshly loaded encounter that has not (yet) had any

--- a/internal/orchestrators/encounter/v2/interact.go
+++ b/internal/orchestrators/encounter/v2/interact.go
@@ -68,6 +68,11 @@ func (o *Orchestrator) Interact(ctx context.Context, in *InteractInput) (*Intera
 		return nil, errors.New("encounter orchestrator: InteractInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> door verb -> persist span per
+	// encounter (see keyed_mutex.go).
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,

--- a/internal/orchestrators/encounter/v2/keyed_mutex.go
+++ b/internal/orchestrators/encounter/v2/keyed_mutex.go
@@ -2,19 +2,55 @@ package encounter
 
 import "sync"
 
-// keyedMutex serializes mutating operations per encounter ID. Used by
-// DriveStalledNPCTurn (drive_npc.go) so concurrent StreamEncounter/GetEncounter
-// connect-time kicks for the SAME encounter (e.g. four players reconnecting at
-// once, rpg-api#636) serialize instead of each loading the same NPC-active
-// snapshot independently and double-dispatching the NPC's turn.
+// keyedMutex serializes mutating operations per encounter ID. It is taken for
+// the FULL load -> toolkit-verb -> persist span of every mutating orchestrator
+// verb (MoveEntity, TakeAction, EndTurn, Interact, ActivateFeature,
+// SetReactionReady, SubmitCheck, SubmitReactionCheck, DriveStalledNPCTurn), so
+// two concurrent callers acting on the SAME encounter can never both load the
+// same pre-mutation snapshot and race their Saves.
+//
+// rpg-api#787: MoveEntity (and every other mutating verb) was load -> mutate a
+// private in-memory copy -> save the whole snapshot, with no lock and no
+// version compare. Two players moving concurrently in free roam both read the
+// same snapshot, each wrote back their own full copy, and the second Save
+// silently erased the first player's already-applied move (confirmed live:
+// the mover's own client believed it had moved; the server's persisted state
+// disagreed, permanently, until a resnapshot). Originally this mutex guarded
+// only DriveStalledNPCTurn (rpg-api#636, concurrent StreamEncounter/
+// GetEncounter connect-time kicks for the same encounter double-dispatching
+// an NPC turn); #787 generalized it to every mutating verb.
+//
+// Read-only paths (GetEncounter's snapshot read, StreamEncounter's equivalent)
+// do NOT take this lock: a single repo Get is an atomically consistent
+// point-in-time read (the repo's own internal mutex + JSON round-trip
+// guarantee that), so there is no read-modify-write to guard. Their one
+// side-effecting operation — the DriveStalledNPCTurn connect-time kick — is
+// itself a locked verb.
+//
+// Lock-ordering invariant: no locked verb may itself invoke another locking
+// entry point. driveNPCChain (end_turn.go), which MoveEntity/EndTurn/
+// DriveStalledNPCTurn call from inside their own already-held lock, is a
+// plain helper that never acquires this mutex — see its doc comment.
+// DriveStalledNPCTurn is only ever invoked from the outer RPC connect paths
+// (StreamEncounter, GetEncounter), never from inside another already-locked
+// verb, so it is always the SOLE lock acquisition on its call stack. Reaction
+// resume (SubmitCheck's take_reaction branch / SubmitReactionCheck) is always
+// a separate, later RPC call — never a callback invoked while the pausing
+// verb's lock is still held — so it acquires the lock fresh with no nesting.
+// Violating this invariant (a locked verb calling another locked entry point
+// on its own call stack) would deadlock a single-per-key sync.Mutex.
 //
 // rpg-api is single-process (mirrors the lobby orchestrator's identical
 // keyed_mutex.go, whose doc comment records the same assumption for the
 // broker wiring), so a per-process, per-encounter-ID sync.Mutex is sufficient
 // — no Redis WATCH/MULTI transaction is needed for a guarantee that only has
-// to hold within one process. Duplicated here rather than shared with the
-// lobby package's unexported type: both are ~20-line, package-private
-// concurrency primitives with no other reason to couple the two packages.
+// to hold within one process. Multi-process is a real follow-up (multiple
+// rpg-api replicas): the proper fix there is a CAS in Repository.Save — an
+// expected-version param using the persisted, monotonic Data.Sequence as the
+// token, with a conflict mapping to codes.Aborted for client retry — not
+// bigger locks. Duplicated here rather than shared with the lobby package's
+// unexported type: both are ~20-line, package-private concurrency primitives
+// with no other reason to couple the two packages.
 //
 // Known tradeoff: per-key *sync.Mutex entries are never evicted, so this map
 // grows by one entry per distinct encounter ID for the life of the process. An

--- a/internal/orchestrators/encounter/v2/move_entity.go
+++ b/internal/orchestrators/encounter/v2/move_entity.go
@@ -77,6 +77,14 @@ func (o *Orchestrator) MoveEntity(ctx context.Context, in *MoveEntityInput) (*Mo
 		return nil, errors.New("encounter orchestrator: MoveEntityInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> Move -> persist span per
+	// encounter so two players moving concurrently in free roam can never both
+	// load the same pre-move snapshot and race their Saves (the second Save
+	// silently erasing the first player's already-applied move). See
+	// keyed_mutex.go for the full rationale and the lock-ordering invariant.
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,

--- a/internal/orchestrators/encounter/v2/move_entity_concurrency_test.go
+++ b/internal/orchestrators/encounter/v2/move_entity_concurrency_test.go
@@ -1,0 +1,188 @@
+package encounter_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	encounterorch "github.com/KirkDiggler/rpg-api/internal/orchestrators/encounter/v2"
+	encountersv2 "github.com/KirkDiggler/rpg-api/internal/repositories/encounters/v2"
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// MoveEntity concurrency test (rpg-api#787). This is the headline proof for
+// the fix: the per-encounter keyedMutex (encounterLocks) closes the
+// unguarded read-modify-write race that let a fast concurrent free-roam move
+// silently erase a slower one's already-applied move — confirmed live
+// (issue #787's linked repro): the mover's own client believed it had moved
+// to its destination; the server's persisted state disagreed, permanently,
+// until a resnapshot.
+
+const (
+	mcEncID     = "enc-move-concurrent"
+	mcPlayerAmy = "amy-mc"
+	mcEntityAmy = "char-amy-mc"
+	mcPlayerBob = "bob-mc"
+	mcEntityBob = "char-bob-mc"
+)
+
+// delayedGetRepo wraps a Repository and sleeps briefly after each Get
+// returns from the underlying store, widening the window a mutating verb's
+// load phase opens between reading the snapshot and persisting the result.
+// This deterministically reproduces the #787 lost-update race without a
+// hard mutual barrier: two concurrent callers whose Get calls land within
+// the delay window are guaranteed to both read the same pre-mutation
+// snapshot before either has a chance to Save.
+//
+// This cannot deadlock the FIXED (locked) code: encounterLocks.Lock is taken
+// as the first line of every mutating verb, before load() ever reaches Get.
+// A second caller blocked at Lock() has not called Get at all yet — its
+// (delayed) Get only runs after the first caller's entire
+// load->verb->persist span, delay included, has already completed and
+// released the lock. The delay is a one-way tax on the now-serialized case,
+// not a mutual wait between the two callers' Get calls — so nothing can
+// deadlock either way, unlike a "wait for both Gets" barrier would (which
+// would hang forever once the lock prevents the second Get from ever being
+// reached concurrently).
+type delayedGetRepo struct {
+	encountersv2.Repository
+	delay time.Duration
+}
+
+func (r *delayedGetRepo) Get(ctx context.Context, id string) (*tkenc.Data, error) {
+	data, err := r.Repository.Get(ctx, id)
+	time.Sleep(r.delay)
+	return data, err
+}
+
+type MoveEntityConcurrencySuite struct {
+	suite.Suite
+
+	ctx      context.Context
+	broker   *tkenc.Broker
+	baseRepo encountersv2.Repository // undelayed — used for seeding/final assertions
+	repo     encountersv2.Repository // delayedGetRepo wrapping baseRepo; wired into the orchestrator
+	orch     *encounterorch.Orchestrator
+}
+
+func (s *MoveEntityConcurrencySuite) SetupTest() {
+	s.ctx = context.Background()
+	s.broker = tkenc.NewBroker(tkenc.NewInMemoryTransport())
+	s.baseRepo = encountersv2.NewInMemory()
+	s.repo = &delayedGetRepo{Repository: s.baseRepo, delay: 20 * time.Millisecond}
+
+	orch, err := encounterorch.New(&encounterorch.Config{
+		Broker:                 s.broker,
+		EncounterRepo:          s.repo,
+		BuildCharacterResolver: constCharacterResolver(stubCharacterResolver{}),
+		BuildCombatResolver: func(_ *tkenc.Data) encounterorch.CombatResolver {
+			return nil
+		},
+		// nil movement resolver: the toolkit Move takes the legacy single-jump
+		// branch (no per-step chain, no OAs) — isolates the load -> Move ->
+		// persist race from rulebook combat math, matching MoveEntitySuite's
+		// own choice in move_entity_test.go.
+		BuildMovementResolver: func(_ *tkenc.Data) tkenc.MovementResolver {
+			return nil
+		},
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	s.Require().NoError(err)
+	s.orch = orch
+}
+
+// seedTwoMovers persists a free-roam encounter with two players far enough
+// apart (distance 10 hexes, well outside either's sight range) that their
+// paths never share a hex and neither sights the other — no occupancy
+// interaction or combat-entry side effect to confound the race assertion.
+func (s *MoveEntityConcurrencySuite) seedTwoMovers(encID string) {
+	enc := tkenc.New(s.ctx, core.EncounterID(encID), s.broker)
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   mcPlayerAmy,
+		EntityID:   mcEntityAmy,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		SightRange: 4,
+		HP:         14,
+		MaxHP:      14,
+		AC:         14,
+	}))
+	s.Require().NoError(enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID:   mcPlayerBob,
+		EntityID:   mcEntityBob,
+		Position:   core.Hex{Q: 10, R: 0, S: -10},
+		SightRange: 4,
+		HP:         14,
+		MaxHP:      14,
+		AC:         14,
+	}))
+	s.Require().NoError(s.baseRepo.Save(s.ctx, enc.ToData()))
+}
+
+// TestMoveEntity_ConcurrentDifferentPlayers_BothMovesSurvive is the rpg-api#787
+// headline proof: two players moving concurrently in the SAME free-roam
+// encounter must both persist, not just whichever caller's Save lands last.
+//
+// Without encounterLocks, MoveEntity is load -> mutate a private in-memory
+// copy -> save the whole snapshot: both goroutines' delayedGetRepo.Get calls
+// return within the artificial delay window, well before either has reached
+// Save, so both read the SAME pre-move snapshot. Whichever Save commits
+// second overwrites the first mover's already-applied position change with
+// its own stale copy of it — one of the two position assertions below fails,
+// reproducing the live desync from the issue.
+//
+// With encounterLocks (the fix), the second caller blocks at Lock() before
+// ever reaching Get, so its load necessarily observes the first caller's
+// already-persisted move — both survive.
+func (s *MoveEntityConcurrencySuite) TestMoveEntity_ConcurrentDifferentPlayers_BothMovesSurvive() {
+	s.seedTwoMovers(mcEncID)
+
+	amyDest := core.Hex{Q: 1, R: -1, S: 0}
+	bobDest := core.Hex{Q: 11, R: -1, S: -10}
+
+	var wg sync.WaitGroup
+	var errAmy, errBob error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errAmy = s.orch.MoveEntity(s.ctx, &encounterorch.MoveEntityInput{
+			EncounterID: mcEncID,
+			PlayerID:    mcPlayerAmy,
+			EntityID:    core.EntityID(mcEntityAmy),
+			Path: []core.Hex{
+				{Q: 0, R: 0, S: 0},
+				amyDest,
+			},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		_, errBob = s.orch.MoveEntity(s.ctx, &encounterorch.MoveEntityInput{
+			EncounterID: mcEncID,
+			PlayerID:    mcPlayerBob,
+			EntityID:    core.EntityID(mcEntityBob),
+			Path: []core.Hex{
+				{Q: 10, R: 0, S: -10},
+				bobDest,
+			},
+		})
+	}()
+	wg.Wait()
+
+	s.Require().NoError(errAmy, "amy's concurrent move must not error")
+	s.Require().NoError(errBob, "bob's concurrent move must not error")
+
+	loaded, err := s.baseRepo.Get(s.ctx, mcEncID)
+	s.Require().NoError(err)
+	s.Equal(amyDest, loaded.Players[mcPlayerAmy].View.Position,
+		"amy's move must survive a concurrent move by a different player")
+	s.Equal(bobDest, loaded.Players[mcPlayerBob].View.Position,
+		"bob's move must survive a concurrent move by a different player")
+}
+
+func TestMoveEntityConcurrencySuite(t *testing.T) {
+	suite.Run(t, new(MoveEntityConcurrencySuite))
+}

--- a/internal/orchestrators/encounter/v2/orchestrator.go
+++ b/internal/orchestrators/encounter/v2/orchestrator.go
@@ -210,10 +210,12 @@ type Orchestrator struct {
 	// roller overrides LoadFromData's dice.Roller when non-nil (rpg-api#659,
 	// test-only determinism seam — see Config.Roller).
 	roller dice.Roller
-	// npcDriveLocks single-flights DriveStalledNPCTurn per encounter ID
-	// (rpg-api#636) so concurrent connect-time kicks for the same encounter
-	// don't each load the same NPC-active snapshot and double-dispatch.
-	npcDriveLocks *keyedMutex
+	// encounterLocks serializes every mutating verb's full load -> verb ->
+	// persist span per encounter ID (rpg-api#787), generalized from its
+	// original single-flight use guarding DriveStalledNPCTurn (rpg-api#636).
+	// See keyed_mutex.go's doc comment for the full rationale and the
+	// lock-ordering invariant every locked verb must uphold.
+	encounterLocks *keyedMutex
 }
 
 // New constructs an Orchestrator from cfg. Returns an error (never a nil
@@ -251,6 +253,6 @@ func New(cfg *Config) (*Orchestrator, error) {
 		reactionResume:         cfg.ReactionResume,
 		now:                    now,
 		roller:                 cfg.Roller,
-		npcDriveLocks:          newKeyedMutex(),
+		encounterLocks:         newKeyedMutex(),
 	}, nil
 }

--- a/internal/orchestrators/encounter/v2/set_reaction_ready.go
+++ b/internal/orchestrators/encounter/v2/set_reaction_ready.go
@@ -70,6 +70,11 @@ func (o *Orchestrator) SetReactionReady(
 		return nil, errors.New("encounter orchestrator: SetReactionReadyInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> SetReactionReady -> persist
+	// span per encounter (see keyed_mutex.go).
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,

--- a/internal/orchestrators/encounter/v2/submit_check.go
+++ b/internal/orchestrators/encounter/v2/submit_check.go
@@ -75,6 +75,11 @@ func (o *Orchestrator) SubmitCheck(ctx context.Context, in *SubmitCheckInput) (*
 		return nil, errors.New("encounter orchestrator: SubmitCheckInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> SubmitCheck -> persist span per
+	// encounter (see keyed_mutex.go).
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,

--- a/internal/orchestrators/encounter/v2/submit_check_reaction.go
+++ b/internal/orchestrators/encounter/v2/submit_check_reaction.go
@@ -73,6 +73,14 @@ func (o *Orchestrator) SubmitReactionCheck(
 		return nil, errors.New("encounter orchestrator: ReactionResume funcs are required for SubmitReactionCheck")
 	}
 
+	// rpg-api#787: serialize the full load -> CompleteTakeAction -> persist
+	// span per encounter (see keyed_mutex.go). This is the resume half of the
+	// TakeAction/NPCAct pause — a separate, later RPC call, never a callback
+	// invoked while the pausing verb's own lock is still held, so acquiring
+	// fresh here does not nest.
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID:       in.EncounterID,
 		PlayerID:          in.PlayerID,

--- a/internal/orchestrators/encounter/v2/take_action.go
+++ b/internal/orchestrators/encounter/v2/take_action.go
@@ -82,6 +82,15 @@ func (o *Orchestrator) TakeAction(ctx context.Context, in *TakeActionInput) (*Ta
 		return nil, errors.New("encounter orchestrator: TakeActionInput is required")
 	}
 
+	// rpg-api#787: serialize the full load -> verb -> persist span per
+	// encounter (see keyed_mutex.go). This is a single self-contained call —
+	// the phase-1 pause below persists the pending prompt and returns; it
+	// does not block waiting for the reaction, so this lock is held only for
+	// this call's own duration, never across the later SubmitReactionCheck
+	// resume RPC.
+	unlock := o.encounterLocks.Lock(in.EncounterID)
+	defer unlock()
+
 	enc, err := o.load(ctx, loadInput{
 		EncounterID: in.EncounterID,
 		PlayerID:    in.PlayerID,


### PR DESCRIPTION
## The race

Every mutating encounter verb (`MoveEntity`, `TakeAction`, `EndTurn`, `Interact`, `ActivateFeature`, `SetReactionReady`, `SubmitCheck`, `SubmitReactionCheck`) was `load -> mutate a private in-memory copy -> save the whole snapshot`, with no lock and no version compare — `internal/repositories/encounters/v2/redis.go`'s `Save` is an unconditional `SET` on `enc:v2:<id>`.

Two players moving concurrently in free roam (routine in normal play, not an edge case): both read the same snapshot, each writes back its own full copy, and the second `Save` silently erases the first player's already-applied move. Confirmed live in #787's linked repro comment: the mover's own client believed it had moved to its destination; the server's persisted state (Redis, seq 181) disagreed — permanently, until a resnapshot — with no error surfaced to either client.

Secondary damage from the same unguarded race, closed by this fix since it now runs inside the same per-encounter critical section: `Data.Sequence` regression/duplicate event stamps, cross-player character-blob clobber via `persistPlayerCharacterData` (writes *every* player's blob from a stale read), and `driveNPCChain` from `MoveEntity` racing a concurrent connect-time `DriveStalledNPCTurn`.

## The fix

The per-encounter `keyedMutex` already existed (`internal/orchestrators/encounter/v2/keyed_mutex.go`), single-flighting exactly one verb (`DriveStalledNPCTurn`, rpg-api#636). This PR generalizes it — renamed `npcDriveLocks` -> `encounterLocks` — and takes it across the **full load -> toolkit-verb -> persist span** of all 8 mutating verbs. Read-only paths (`GetEncounter`'s snapshot read, `StreamEncounter`'s equivalent) stay lock-free: a single repo `Get` is an atomically consistent point-in-time read, so there's no read-modify-write to guard.

**Lock-ordering invariant** (documented on `keyedMutex` and on `driveNPCChain`): no locked verb may itself invoke another locking entry point.
- `driveNPCChain` (end_turn.go) is a plain helper called from `MoveEntity`, `EndTurn`, and `DriveStalledNPCTurn` — all three already hold the lock before reaching it; it never acquires the mutex itself.
- `DriveStalledNPCTurn` is only ever invoked from the outer RPC connect paths (`StreamEncounter`, `GetEncounter`), never from inside another already-locked verb.
- Reaction resume (`SubmitCheck`'s `take_reaction` branch / `SubmitReactionCheck`) is always a separate, later RPC call — never a callback invoked while the pausing verb's lock is still held — so it acquires fresh with no nesting.

Verified by tracing every caller of `driveNPCChain`/`DriveStalledNPCTurn` — no two lock acquisitions ever nest on one call stack, so this can't deadlock a single-per-key `sync.Mutex`.

## Test: fails without the lock, passes with it

New `move_entity_concurrency_test.go`: two players move concurrently in the same free-roam encounter; both moves must survive. A thin `Repository` decorator delays `Get` by 20ms to widen the read-modify-write window deterministically (raw goroutine scheduling against an in-memory map is too fast to reliably interleave a 2-party race otherwise). This can't deadlock the fixed code — the lock is acquired *before* `load()` ever reaches `Get`, so a blocked second caller's `Get` only runs after the first caller's entire span (delay included) has already completed and released.

Manually verified both directions by temporarily disabling the lock and re-running:

```
--- FAIL: TestMoveEntityConcurrencySuite (0.04s)
    --- FAIL: TestMoveEntityConcurrencySuite/TestMoveEntity_ConcurrentDifferentPlayers_BothMovesSurvive (0.03s)
        Error: Not equal:
          expected: core.Hex{Q:11, R:-1, S:-10}
          actual  : core.Hex{Q:10, R:0, S:-10}
        Messages: bob's move must survive a concurrent move by a different player
```

Bob's move was silently discarded back to his origin position by amy's concurrent `Save` — the exact bug from the issue. Restoring the lock (the committed state) passes deterministically. Full `go test ./... -race` is green; `make ci-check` is clean except for pre-existing lint debt in files this PR does not touch (confirmed via `golangci-lint run ./internal/orchestrators/encounter/v2/...` -> `0 issues`), and the repo's actual `test.yml` CI workflow runs no lint gate at all.

## Not in scope (follow-up)

Multi-process CAS: this fix only guards a single process's goroutines (documented in the `keyedMutex` doc comment as the existing single-process assumption). Multiple `rpg-api` replicas would still race across processes. The proper follow-up is a `Repository.Save` expected-version parameter keyed on the persisted, monotonic `Data.Sequence` as the version token, with a conflict mapping to `codes.Aborted` for client retry. Toolkit-side occupancy/turn-gating is likewise out of scope.

## Related

- Live desync evidence: #787 (comment with the three-way state divergence repro, `enc:v2:aa21fdfe`, seq 181)
- Companion client-side fix: rpg-dnd5e-web#745

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB1QSaqAphp5J3rdREPR5