### PR TITLE
feat(lobby): the party plays the reference tomb, not a placeholder room

### DIFF
--- a/internal/orchestrators/lobby/start_encounter_session_stack.go
+++ b/internal/orchestrators/lobby/start_encounter_session_stack.go
@@ -5,12 +5,10 @@ import (
 	"errors"
 	"fmt"
 
-	tkencounter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	sdk "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
-	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 
 	lobbyrepo "github.com/KirkDiggler/rpg-api/internal/repositories/lobby"
+	"github.com/KirkDiggler/rpg-api/internal/sessionworld"
 )
 
 // StartEncounter's new-session-stack path (design rpg-project/ideas/session-
@@ -19,159 +17,50 @@ import (
 // half; start_encounter.go's existing body is the old stack's, completely
 // untouched by anything here.
 //
-// KNOWN GAP, reported rather than worked around (per the brief this shipped
-// under): there is no authored-dungeon-YAML -> new-stack EncounterData
-// compiler in the toolkit yet. The old path's resolveDungeonSpec /
-// dungeonspec.Load pipeline produces tkenc.DungeonParams for the OLD
-// encounter module (rpg-toolkit/encounter) -- a different module with a
-// different (hex-cube) coordinate system from the new one-map, absolute-
-// Position world rulebooks/dnd5e/session.StartSession consumes. Building
-// that compiler is real toolkit-side work, not something to improvise here
-// (design rule 1: rpg-api invents no vocabulary; a content compiler is
-// exactly the kind of thing that belongs upstream, not guessed at in the
-// host). Until it exists, this path seeds every session from the single
-// fixed builtInSessionWorld below -- good enough to prove the new stack is
-// live and walkable in local dev, not a second content pipeline.
+// # The party plays the reference tomb
 //
-// A second, smaller gap rides along: encounter.SetupInput requires an
-// InitiativeRoller, and the toolkit exposes only the INTERFACE publicly, no
-// injectable real (dice + ability-score) implementation -- only its own
-// test suites' trivial "order as given" fakes satisfy it today. sessionOrderAsGiven
-// below is that same shortcut, not a rules decision made here: a fight in
-// this minimal world resolves turn order as party-then-monster, which is
-// honest about being a placeholder, not a hidden ruling.
-
-// builtInSessionRoomID names the one room every new-stack session plays in
-// until real authored content exists.
-const builtInSessionRoomID = "hall"
-
-// sessionOrderAsGiven is the toolkit's own test pattern (rulebooks/dnd5e/
-// session's fight_starts_test.go encOrderAsGiven), duplicated here rather
-// than imported because it is a test type unexported from that package. See
-// this file's header comment for why "order as given" is the honest choice
-// for a placeholder world rather than an invented dice-and-DEX ranking.
-type sessionOrderAsGiven struct{}
-
-func (sessionOrderAsGiven) RollInitiative(members []tkencounter.MemberID) ([]tkencounter.MemberID, error) {
-	return members, nil
-}
-
-// sessionAllStanding and sessionAllSeeing are the Standing and Sight
-// capabilities encounter.SetupInput has required since rpg-toolkit#1033:
-// supplied, never defaulted, refused at construction rather than assumed,
-// because "everybody can see" is a decision about a world and not something the
-// composition may take for granted.
+// This path used to seed every session from a single hardcoded room, because
+// there was no authored-content compiler for the new stack and building one
+// here would have been rpg-api inventing dungeon geometry. That gap CLOSED:
+// rpg-toolkit#1133 shipped rulebooks/dnd5e/encounter/dungeonspec, whose own
+// forcing case is the sentence this path now implements -- reference-tomb.yaml
+// compiles into a runnable new-stack world and a player walks entrance → hall →
+// tomb. internal/sessionworld holds the compile and the one seam the compiler
+// leaves to a host; see its package comment for what that seam is and why it
+// borrows the projection instead of doing arithmetic.
 //
-// They are CONSTRUCTION-TIME ONLY and that is what makes trivial versions
-// honest here rather than a hidden ruling. Capabilities are not persisted into
-// the EncounterData this returns; the session package supplies its own when it
-// loads a world, including the sight RANGE that decides who is in contact. What
-// these two do is satisfy NewEncounter's validation for a world that is empty
-// at the moment it is built -- there is nobody to see or to be standing yet.
-type sessionAllStanding struct{}
-
-// Standing reports who is DOWN, not who is up: the interface's own parameter is
-// named down, and reading it backwards would report a healthy party as a wiped
+// So a new-stack session now opens in three chambers with walls between them, a
+// garrison of skeletons holding the hall, and a captain behind a door locked at
+// DC 12 -- the same dungeon the old stack has always served, compiled by the new
 // one.
-func (sessionAllStanding) Standing(_ []tkencounter.MemberID) ([]tkencounter.MemberID, error) {
-	return nil, nil
-}
-
-type sessionAllSeeing struct{}
-
-func (sessionAllSeeing) Sight(members []tkencounter.MemberID) (map[tkencounter.MemberID]int, error) {
-	out := make(map[tkencounter.MemberID]int, len(members))
-	for _, id := range members {
-		out[id] = 1_000_000
-	}
-
-	return out, nil
-}
-
-// builtInSessionWorld is the fixed placeholder world every new-stack session
-// starts in: one 12x10 square room, empty until StartEncounterOnSessionStack
-// joins the party and spawns a monster into it.
 //
-// THE PARTY NOW GETS ROOM TO EXPLORE, and not because this world earned it.
-// Until session/v0.18.0 this placeholder had a known consequence: with nothing
-// to hide behind, the party and the monster saw each other and the fight
-// started itself the moment both were placed. That stopped being true when
-// session gave sight a RANGE (four cells, a torch's twenty feet) instead of
-// letting geometry alone decide. The party enters at x=1 and the skeleton
-// stands at (9,5) -- eight cells apart -- so everyone starts on the world clock
-// and somebody has to walk toward the fight.
+// # What is still narrow here, stated rather than implied
 //
-// Recorded rather than celebrated: the improvement is a side effect of a policy
-// that lives in the session package, not a property of this world, and it would
-// evaporate if that constant changed or if this placeholder ever placed things
-// closer together. Real authored content should give a party that room on
-// purpose. Adding hand-tuned sight-blocking geometry here would be exactly the
-// content authoring this file's header explains rpg-api should not improvise.
+//   - ONE DUNGEON. StartEncounterInput.DungeonKey selects content on the old
+//     path; this one ignores it and always plays the tomb. That is a smaller
+//     narrowing than it looks -- no proto field carries a key, so every real
+//     call leaves it at the zero value and the old path serves exactly one
+//     dungeon too -- but it is a narrowing, and the authoring path
+//     (PutDungeon → dungeonregistry) still writes the OLD dialect, so the
+//     dungeon builder cannot yet author for this stack. That is the next
+//     content-side piece of work, not something to paper over here.
+//   - NO MONSTER BEHAVIOR. session.Spawn takes no decider, by its own design
+//     ("behavior arrives with the wave that brings it"), so the garrison is
+//     placed, perceived and remembered correctly and does not act.
+//   - NO AUTHORED ENDING BEYOND WITHDRAWAL. See sessionworld.EndingWithdrawn:
+//     the composition has no "the boss died" trigger to declare, so the boss
+//     flag is carried and unused.
 //
-// ONE room, so there are no seams to draw. Worth stating explicitly, because a
-// multi-room version of this function would need them: since rpg-toolkit#1130
-// rooms sit on one canvas and do NOT imply walls, so two chambers side by side
-// are one open space until a Boundaries list says otherwise. A future authored
-// world that grows this into several rooms and forgets that would ship a
-// dungeon with no interior walls and no error to say so.
-// Verified directly (start_encounter_session_stack_test.go): Turn on the
-// spawned monster reports ClockTurn, not ClockWorld, immediately after
-// StartEncounter returns.
-func builtInSessionWorld() (*tkencounter.EncounterData, error) {
-	enc, err := tkencounter.NewEncounter(&tkencounter.SetupInput{
-		Initiative: sessionOrderAsGiven{},
-		Standing:   sessionAllStanding{},
-		Sight:      sessionAllSeeing{},
-		Retention:  tkencounter.RetentionUnbounded,
-		Field: tkencounter.FieldInput{
-			Canvas: tkencounter.CanvasInput{
-				// Required rather than defaulted (rpg-toolkit#1116): what the
-				// space between chambers does to a sightline is a fact about a
-				// world, and there is no correct default -- a tomb's answer is
-				// the opposite of an open-air ruin's. Opaque is the reference
-				// dungeon's answer and the conservative one for a placeholder;
-				// with a single room there is no interior void for it to govern
-				// anyway.
-				//
-				// No Orientation: it is required for a hex field and REFUSED
-				// for a square one, which this is.
-				Void: tkencounter.VoidIsOpaque(),
-			},
-			Rooms: []tkencounter.RoomInput{
-				{ID: builtInSessionRoomID, Width: 12, Height: 10},
-			},
-		},
-		// SetupInput requires at least one declared ending; this placeholder
-		// world has nothing to end it with yet (no authored win/loss
-		// conditions -- another facet of the content-compile gap above), so
-		// a never-fired external declaration satisfies construction without
-		// inventing a real one.
-		Endings: []tkencounter.EndingInput{{Key: "external", Trigger: tkencounter.TriggerExternal{}}},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("build built-in session world: %w", err)
-	}
-	data := enc.ToData()
-	return &data, nil
-}
-
-// builtInPartyPositions returns up to n fixed, non-overlapping join
-// positions along the room's west wall, one per ready member in roster
-// order.
-func builtInPartyPositions(n int) []spatial.Position {
-	positions := make([]spatial.Position, n)
-	for i := range positions {
-		positions[i] = spatial.Position{X: 1, Y: float64(1 + i)}
-	}
-	return positions
-}
-
-// builtInMonsterID and builtInMonsterPosition place the one placeholder
-// monster every new-stack session's world is seeded with, away from the
-// party's entry wall so joining does not itself start the fight.
-const builtInMonsterID = "skeleton-1"
-
-var builtInMonsterPosition = spatial.Position{X: 9, Y: 5}
+// # One thing that is NOT a shortcut any more
+//
+// The old placeholder needed an InitiativeRoller and could only supply the
+// toolkit's own test fake, which meant a fight in it resolved turn order
+// party-then-monster. Nothing in THIS file supplies one: the capabilities are
+// construction-time only and live in internal/sessionworld, and the session
+// package supplies its own -- including the sight range that decides who is in
+// contact -- when it loads the world. The honest remaining gap is upstream, and
+// unchanged: the toolkit still exposes no injectable real (dice + ability
+// score) InitiativeRoller, only the interface.
 
 // startEncounterOnSessionStack is StartEncounter's new-stack branch,
 // self-contained on purpose (its own lock/load/validate, not shared with
@@ -203,32 +92,41 @@ func (o *Orchestrator) startEncounterOnSessionStack(ctx context.Context, in *Sta
 		}
 	}
 
-	encID := o.encounterIDGen.Generate()
-
-	world, err := builtInSessionWorld()
+	dungeon, err := sessionworld.ReferenceTomb()
 	if err != nil {
 		return nil, err
 	}
+	// Checked BEFORE anything is written, so a party too big for the dungeon's
+	// entrance is refused rather than half-seated: the alternative is a session
+	// that exists with some members in it and an error returned, which is the
+	// one outcome a caller cannot recover from.
+	if len(members) > len(dungeon.PartySeats) {
+		return nil, fmt.Errorf("lobby %q has %d members and the dungeon seats %d",
+			in.LobbyID, len(members), len(dungeon.PartySeats))
+	}
+
+	encID := o.encounterIDGen.Generate()
+
 	if _, err := o.sessionManager.StartSession(ctx, &sdk.StartSessionInput{
-		Session: encID, Encounter: encID, World: world,
+		Session: encID, Encounter: encID, World: dungeon.World,
 	}); err != nil {
 		return nil, fmt.Errorf("start session %q on new stack: %w", encID, err)
 	}
 
-	positions := builtInPartyPositions(len(members))
 	for i, m := range members {
 		if _, err := o.sessionManager.Join(ctx, &sdk.JoinInput{
-			Session: encID, Member: m.CharacterID, Position: positions[i],
+			Session: encID, Member: m.CharacterID, Position: dungeon.PartySeats[i],
 		}); err != nil {
 			return nil, fmt.Errorf("join %q to session %q on new stack: %w", m.CharacterID, encID, err)
 		}
 	}
 
-	if _, err := o.sessionManager.Spawn(ctx, &sdk.SpawnInput{
-		Session: encID, ID: builtInMonsterID, Ref: refs.Monsters.Skeleton().String(),
-		Position: builtInMonsterPosition,
-	}); err != nil {
-		return nil, fmt.Errorf("spawn monster into session %q on new stack: %w", encID, err)
+	for _, monster := range dungeon.Monsters {
+		if _, err := o.sessionManager.Spawn(ctx, &sdk.SpawnInput{
+			Session: encID, ID: monster.MemberID, Ref: monster.Ref, Position: monster.At,
+		}); err != nil {
+			return nil, fmt.Errorf("spawn %q into session %q on new stack: %w", monster.MemberID, encID, err)
+		}
 	}
 
 	data.Status = lobbyrepo.StatusStarted

--- a/internal/orchestrators/lobby/start_encounter_session_stack_test.go
+++ b/internal/orchestrators/lobby/start_encounter_session_stack_test.go
@@ -130,13 +130,10 @@ func (s *SessionStackSuite) TestStartEncounter_BuildsAGenuineNewStackSession() {
 	s.Require().NoError(err)
 	s.True(status.Open)
 
-	view, err := s.sessOrch.Manager.View(s.ctx, &sdk.ViewInput{Session: out.EncounterID, Member: "char-alice"})
+	// This call succeeding at all (no ErrNoMember) is the load-bearing
+	// assertion: alice is a real member of a real session.
+	_, err = s.sessOrch.Manager.View(s.ctx, &sdk.ViewInput{Session: out.EncounterID, Member: "char-alice"})
 	s.Require().NoError(err)
-	// The skeleton was placed away from the party's entry wall
-	// deliberately (builtInMonsterPosition) so joining alone should not
-	// yet reveal it -- this call succeeding at all (no ErrNoMember) is
-	// the load-bearing assertion: alice is a real member of a real session.
-	_ = view
 
 	lobbyData, err := s.lobbyRepo.Get(s.ctx, "lobby-1")
 	s.Require().NoError(err)
@@ -144,7 +141,23 @@ func (s *SessionStackSuite) TestStartEncounter_BuildsAGenuineNewStackSession() {
 	s.Equal(out.EncounterID, lobbyData.EncounterID)
 }
 
-func (s *SessionStackSuite) TestStartEncounter_SpawnsThePlaceholderMonster() {
+// TestStartEncounter_SeatsTheTombsWholeGarrison checks that starting on the new
+// stack seeds the AUTHORED dungeon, not a stand-in: both hall skeletons and the
+// captain behind the locked door are real members of a real session.
+//
+// Turn is the probe because it works for ANY member regardless of combat or
+// equipment state ("asked of a member, never of the session"), so it proves
+// membership without depending on Attack's own preconditions. ErrNoMember for
+// any of these three would mean the tomb's roster did not arrive.
+//
+// Every one of them is on the WORLD clock. That is the whole point of seeding a
+// real dungeon rather than a single room: the party comes in at the entrance,
+// the garrison holds the hall behind a wall, and sight has a range of four
+// cells since session/v0.18.0 -- so nobody is in contact and there is a dungeon
+// to walk before there is a fight. Asserted rather than relaxed to "either
+// clock is fine", because whether a session opens in combat is the single most
+// visible thing about the world it opens in.
+func (s *SessionStackSuite) TestStartEncounter_SeatsTheTombsWholeGarrison() {
 	s.seedCharacter("char-alice", "alice", "Alice")
 	s.seedReadyLobby("lobby-1", "alice")
 
@@ -153,28 +166,92 @@ func (s *SessionStackSuite) TestStartEncounter_SpawnsThePlaceholderMonster() {
 	})
 	s.Require().NoError(err)
 
-	// Turn works for ANY member regardless of combat/equipment state
-	// (design: "asked of a member, never of the session") -- the cleanest
-	// available proof the skeleton is a real member of a real session
-	// without depending on Attack's own equipment/combat preconditions.
-	// ErrNoMember here would mean nothing was ever spawned.
-	//
-	// The clock is ClockWorld, and it USED TO BE ClockTurn. Nothing about this
-	// world changed: session/v0.18.0 gave sight a range of four cells rather
-	// than letting an unobstructed room mean unlimited vision, and the party
-	// enters at x=1 while the skeleton stands at (9,5) -- eight cells away. So
-	// the fight no longer starts itself the instant both are placed.
-	//
-	// Asserted rather than relaxed to "either clock is fine". Whether a session
-	// opens in combat is the single most visible thing about this placeholder
-	// world, and a test that shrugged at it would not notice the day it flipped
-	// back -- which is exactly what happened here.
-	turn, err := s.sessOrch.Manager.Turn(s.ctx, &sdk.TurnInput{
-		Session: out.EncounterID, Member: "skeleton-1",
+	for _, member := range []string{"skeleton-1", "skeleton-2", "skeleton-captain-1"} {
+		turn, terr := s.sessOrch.Manager.Turn(s.ctx, &sdk.TurnInput{
+			Session: out.EncounterID, Member: member,
+		})
+		s.Require().NoErrorf(terr, "%s should be a member of the seeded tomb", member)
+		s.Equalf(sdk.ClockWorld, turn.Clock, "%s should not be in a fight yet", member)
+	}
+}
+
+// TestStartEncounter_ThePartyEntersOutOfSightOfTheGarrison is the same fact from
+// the party's side, and the one a player would notice: alice arrives and can
+// see none of the three monsters.
+//
+// It is a separate assertion from the clock above rather than a restatement.
+// The clock says no fight formed; this says the fog of war is genuinely drawn,
+// which is what the walls between the chambers are FOR. A tomb compiled without
+// its seams would leave the entrance and hall one open space, and this is the
+// test that would notice.
+func (s *SessionStackSuite) TestStartEncounter_ThePartyEntersOutOfSightOfTheGarrison() {
+	s.seedCharacter("char-alice", "alice", "Alice")
+	s.seedCharacter("char-bob", "bob", "Bob")
+	s.seedReadyLobby("lobby-1", "alice", "bob")
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-1",
 	})
 	s.Require().NoError(err)
-	s.Equal(sdk.ClockWorld, turn.Clock,
-		"sight has a range now (session/v0.18.0): eight cells apart, nobody is in contact yet")
+
+	view, err := s.sessOrch.Manager.View(s.ctx, &sdk.ViewInput{
+		Session: out.EncounterID, Member: "char-alice",
+	})
+	s.Require().NoError(err)
+
+	subjects := make([]string, 0, len(view))
+	for _, sighting := range view {
+		subjects = append(subjects, sighting.Subject)
+	}
+
+	// POSITIVE CONTROL FIRST, because the assertion that follows is a loop over
+	// this slice and an empty one would satisfy it without proving anything at
+	// all. Bob is seated beside alice at the way in, so if this read works she
+	// sees him -- and only then does not seeing the garrison mean the walls and
+	// the sight range are doing the work.
+	s.Require().Contains(subjects, "char-bob", "alice sees the party member standing next to her")
+
+	for _, subject := range subjects {
+		s.NotContainsf(subject, "skeleton",
+			"the garrison is behind a wall and out of range; alice should not see %s", subject)
+	}
+}
+
+// TestStartEncounter_TheTombReachesTheWire checks the seeded world through the
+// same read a client uses, because that is the only place the tomb becoming
+// real actually matters. Everything above could pass with a world nobody could
+// draw.
+//
+// The coffin is the interesting prop rather than a random one: it is the tomb's
+// single authored exception, walked around but SEEN OVER, and it is exactly the
+// distinction the atlas gained props to express (it used to be a bare occluder
+// coordinate, indistinguishable from a pillar).
+func (s *SessionStackSuite) TestStartEncounter_TheTombReachesTheWire() {
+	s.seedCharacter("char-alice", "alice", "Alice")
+	s.seedReadyLobby("lobby-1", "alice")
+
+	out, err := s.orch.StartEncounter(s.ctx, &lobbyorch.StartEncounterInput{
+		PlayerID: "alice", LobbyID: "lobby-1",
+	})
+	s.Require().NoError(err)
+
+	atlas, err := s.sessOrch.Manager.Atlas(s.ctx, &sdk.AtlasInput{Session: out.EncounterID})
+	s.Require().NoError(err)
+
+	s.NotEmpty(atlas.Cells, "the map has floor")
+	s.NotEmpty(atlas.Boundaries, "and walls between its chambers -- rooms no longer imply them")
+	s.NotEmpty(atlas.Doorways, "and ways through those walls")
+
+	var coffin *sdk.AtlasProp
+	for i := range atlas.Props {
+		if atlas.Props[i].Ref == "dnd5e:props:coffin" {
+			coffin = &atlas.Props[i]
+			break
+		}
+	}
+	s.Require().NotNil(coffin, "the tomb's coffin reached the wire")
+	s.True(coffin.BlocksMovement, "a coffin is walked around")
+	s.False(coffin.BlocksLineOfSight, "and seen over")
 }
 
 func (s *SessionStackSuite) TestStartEncounter_NotHost_Errors() {

--- a/internal/sessionworld/bench_test.go
+++ b/internal/sessionworld/bench_test.go
@@ -1,0 +1,25 @@
+package sessionworld
+
+import "testing"
+
+// BenchmarkReferenceTomb measures what a new-stack StartEncounter now pays to
+// compile its dungeon, because the borrowed-projection approach costs an EXTRA
+// encounter construction (see this package's doc comment) and a cost nobody
+// measured is a cost nobody can argue about.
+//
+// Measured 2026-08-20 on a Ryzen 9 7945HX: ~318us, ~228KB, ~2233 allocs.
+//
+// The conclusion, so it is not re-derived: this is fine and needs no cache. It
+// runs ONCE per encounter start, not per RPC, and for scale a single free-roam
+// click is ~187us of load-act-save on the same machine -- so starting a session
+// costs about what two clicks in it do. If the extra construction ever does
+// need to go, the reason will be rpg-toolkit#1139 making it unnecessary, not
+// this number.
+func BenchmarkReferenceTomb(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := ReferenceTomb(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/sessionworld/reference-tomb.yaml
+++ b/internal/sessionworld/reference-tomb.yaml
@@ -1,0 +1,37 @@
+version: 1
+key: reference-tomb
+void: opaque
+orientation: pointy
+height: 8
+start: [1, 3]
+rooms:
+  - id: entrance
+    width: 6
+    place:
+      - { ref: "dnd5e:props:brazier", at: [1, 1], blocks_movement: true,  blocks_los: false }
+      - { ref: "dnd5e:props:brazier", at: [1, 6], blocks_movement: true,  blocks_los: false }
+  - id: hall
+    width: 10
+    place:
+      - { ref: "dnd5e:props:pillar", at: [2, 2], blocks_movement: true,  blocks_los: true }
+      - { ref: "dnd5e:props:pillar", at: [2, 5], blocks_movement: true,  blocks_los: true }
+      - { ref: "dnd5e:props:pillar", at: [6, 2], blocks_movement: true,  blocks_los: true }
+      - { ref: "dnd5e:props:pillar", at: [6, 5], blocks_movement: true,  blocks_los: true }
+      - { ref: "dnd5e:props:torch-ornate", at: [4, 1], blocks_movement: false, blocks_los: false }
+      - { ref: "dnd5e:props:bone-pile", at: [8, 6], blocks_movement: false, blocks_los: false }
+      - { ref: "dnd5e:monsters:skeleton", at: [5, 3], targeting: lowest-health }
+      - { ref: "dnd5e:monsters:skeleton", at: [7, 5], targeting: lowest-health }
+  - id: tomb
+    width: 12
+    place:
+      - { ref: "dnd5e:props:coffin", at: [6, 3], blocks_movement: true,  blocks_los: false }
+      - { ref: "dnd5e:props:altar", at: [9, 3], blocks_movement: true,  blocks_los: false }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1], blocks_movement: true,  blocks_los: true }
+      - { ref: "dnd5e:props:statue-knight-hooded", at: [1, 6], blocks_movement: true,  blocks_los: true }
+      - { ref: "dnd5e:props:brazier", at: [3, 1], blocks_movement: true,  blocks_los: false }
+      - { ref: "dnd5e:props:brazier", at: [3, 6], blocks_movement: true,  blocks_los: false }
+      - { ref: "dnd5e:props:candles", at: [10, 5], blocks_movement: false, blocks_los: false }
+      - { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5], targeting: closest, boss: true }
+connectors:
+  - { from: entrance, to: hall }
+  - { from: hall, to: tomb, locked: { dc: 12, ability: dex } }

--- a/internal/sessionworld/sessionworld.go
+++ b/internal/sessionworld/sessionworld.go
@@ -1,0 +1,370 @@
+// Package sessionworld turns authored dungeon content into the three things
+// the new session stack needs to start a game in it: a world, the cells the
+// party walks in on, and the monsters standing in it.
+//
+// # Why this package exists at all, and why it is thin
+//
+// rpg-toolkit#1133 landed the compiler this is built on
+// (rulebooks/dnd5e/encounter/dungeonspec), so rpg-api computes NO dungeon
+// geometry -- the same arrangement the old stack has always had, one stack
+// over. What is left for a host is the seam the compiler deliberately does not
+// cross: it emits placements in the AUTHORED frame (a chamber's own columns and
+// rows), and the session package's Join and Spawn take DUNGEON-ABSOLUTE cells.
+// Somebody has to carry a placement across that line, and this package is that
+// somebody.
+//
+// # The projection is BORROWED, never recomputed
+//
+// It would be a few lines to add a room's Origin to a local cell and convert to
+// axial. It would also be wrong, and quietly: the entrance's local (1,3) is the
+// absolute cell (1,-4), because an offset rectangle SHEARS when it becomes
+// axial (rpg-toolkit#1131). A copy of that arithmetic in rpg-api is a second
+// implementation of the toolkit's geometry that compiles, looks right, and
+// drifts the day the projection changes -- exactly the Boundary Rule violation
+// the whole session seam exists to prevent.
+//
+// So this package does not do the conversion. It asks the composition to do it,
+// by building a THROWAWAY encounter with the authored placements as
+// construction-time members ([encounter.MemberInput] is room-shaped on purpose)
+// and reading the absolute cells back out. The projection happens exactly once,
+// inside the toolkit, in the same code path the real world will use, because it
+// is the same [encounter.FieldInput]. See [compile] for the mechanics.
+//
+// # Known cost, recorded rather than hidden
+//
+// That costs one extra construction per encounter start, and it is a shape
+// worth removing rather than living with: dungeonspec.Compiled could carry
+// absolute placements itself, or the session package could accept a compiled
+// dungeon. Filed upstream; until one of those exists this is the honest way to
+// get a party into an authored dungeon without a host inventing geometry.
+package sessionworld
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	tkencounter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	tkdungeonspec "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter/dungeonspec"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// referenceTombYAML is the reference tomb, authored in the dialect
+// rulebooks/dnd5e/encounter/dungeonspec speaks.
+//
+// It lives here rather than in internal/content/dungeons/ for a reason that
+// would otherwise be discovered the hard way: that directory is embedded by
+// `//go:embed dungeons/*.yaml` and every file matching it is parsed with the
+// OLD stack's dialect at startup, in a mode that PANICS on a file it cannot
+// read. A new-dialect file dropped in beside its old-dialect sibling would take
+// the server down on boot.
+//
+// It is the same dungeon as internal/content/dungeons/reference-tomb.yaml --
+// verified placement-by-placement, every (ref, cell) pair identical, boss
+// included -- re-authored in the newer dialect per Kirk's ruling that the old
+// form "has never run in a game... it is legacy and will have no home after".
+// The two files are expected to coexist only until the old stack is ripped out
+// (rpg-project#227's cutover), and the duplication is the price of the
+// coexistence the whole integration is built on: each stack reads content in
+// the dialect it can actually compile.
+//
+//go:embed reference-tomb.yaml
+var referenceTombYAML []byte
+
+// Dungeon is authored content compiled into everything needed to seed a
+// session, with every cell already in the dungeon-absolute frame the session
+// verbs speak.
+type Dungeon struct {
+	// World is the compiled world, and it is EMPTY OF MEMBERS on purpose.
+	//
+	// session.StartSessionInput.World is documented as "authored content...
+	// not a live encounter", and the composition enforces that reading:
+	// encounter.Join refuses a member who is already in the encounter, so a
+	// world with the party baked in could never be joined -- and Join is what
+	// loads a character's sheet through the host's repository. Monsters have
+	// the mirror problem: a construction-time monster has no sheet, and
+	// session.Spawn is what builds one from a ref.
+	//
+	// So the world carries the FIELD -- chambers, walls, doors, props -- and
+	// everybody who stands in it arrives through a session verb.
+	World *tkencounter.EncounterData
+
+	// PartySeats are where the party comes in, dungeon-absolute, best seat
+	// first.
+	//
+	// A list because a party is more than one person and the author declares
+	// one cell: the first is the cell they wrote, the rest are that chamber's
+	// other free cells nearest-first, so a caller with four players takes the
+	// first four and gets them standing together at the way in.
+	PartySeats []spatial.Position
+
+	// Monsters is every authored monster, dungeon-absolute, in the order the
+	// compiler reported them.
+	Monsters []Monster
+}
+
+// Monster is one authored monster, ready to hand to session.Spawn.
+type Monster struct {
+	// Ref is content's identifier, exactly as authored -- "dnd5e:monsters:skeleton".
+	Ref string
+
+	// MemberID is the ID this monster is known by inside the encounter, and it
+	// is derived here rather than left to the caller because it is the ONLY
+	// thing a client ever sees of it: a Member on the wire is {id, kind,
+	// position}, with no ref and no display name anywhere on it. An opaque
+	// "monster-2" would therefore be all a UI had to draw a skeleton with.
+	//
+	// So it is the ref's own id plus a per-ref ordinal -- skeleton-1,
+	// skeleton-2, skeleton-captain-1 -- which is unique, stable across a
+	// recompile of the same content, and legible in a log, a story beat and a
+	// client alike. Numbering PER REF rather than per dungeon so that adding a
+	// prop or reordering a chamber cannot silently renumber a monster that
+	// nothing about it changed.
+	MemberID string
+
+	// At is its cell, dungeon-absolute.
+	At spatial.Position
+
+	// Boss is whether this is the monster whose death ends things.
+	//
+	// CARRIED AND NOT YET ACTED ON. Nothing here turns it into an ending: the
+	// compiler emits no endings, and a "the boss died" trigger does not exist
+	// in the composition's Trigger set (there is TriggerReachedPosition and
+	// TriggerExternal, and that is all). Recorded on the placement so the wave
+	// that adds the trigger has the fact already flowing, rather than
+	// discovering the compiler knew all along.
+	Boss bool
+
+	// Targeting is the author's word for how it picks a target, or empty.
+	//
+	// ALSO CARRIED AND NOT YET ACTED ON, and for a sharper reason: session's
+	// SpawnInput has no field for it, so it cannot cross the seam today even
+	// though both sides know it. It is kept here rather than dropped at the
+	// compile so the gap is visible at the seam that has it, not invisible in
+	// the package that threw it away.
+	Targeting string
+}
+
+// ReferenceTomb compiles the reference tomb: three chambers west to east, a
+// garrison of skeletons in the hall, and a captain behind a DC-12 locked door.
+func ReferenceTomb() (*Dungeon, error) {
+	d, err := compile(referenceTombYAML)
+	if err != nil {
+		return nil, fmt.Errorf("reference tomb: %w", err)
+	}
+
+	return d, nil
+}
+
+// compile does the work described in the package comment: compile once, build a
+// throwaway encounter to borrow the composition's projection, then build the
+// real world with nobody in it.
+func compile(raw []byte) (*Dungeon, error) {
+	spec, err := tkdungeonspec.Load(raw)
+	if err != nil {
+		return nil, fmt.Errorf("compile spec: %w", err)
+	}
+	if len(spec.PartyStart) == 0 {
+		// Unreachable for a spec that compiled -- dungeonspec documents
+		// PartyStart as "never empty for a spec that compiled" -- and checked
+		// anyway, because the alternative to this error is an index panic in a
+		// caller seating a party.
+		return nil, fmt.Errorf("compile spec: dungeon declares no party start")
+	}
+
+	seats, monsters, err := projectPlacements(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	world, err := buildWorld(spec.Field)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Dungeon{World: world, PartySeats: seats, Monsters: monsters}, nil
+}
+
+// seatMemberID and monsterMemberID name the throwaway encounter's members.
+//
+// They exist only long enough to be placed and read back, so what matters about
+// them is that they are unique and that the two families cannot collide -- an
+// absolute cell is looked up BY these IDs, and two placements sharing one would
+// silently report the same cell twice.
+func seatMemberID(i int) tkencounter.MemberID {
+	return tkencounter.MemberID(fmt.Sprintf("probe-seat-%d", i))
+}
+
+func monsterMemberID(i int) tkencounter.MemberID {
+	return tkencounter.MemberID(fmt.Sprintf("probe-monster-%d", i))
+}
+
+// projectPlacements turns the compiler's room-local placements into
+// dungeon-absolute ones by asking the composition, never by doing the
+// arithmetic here. See the package comment for why that distinction is the
+// whole point of this file.
+func projectPlacements(spec tkdungeonspec.Compiled) ([]spatial.Position, []Monster, error) {
+	members := make([]tkencounter.MemberInput, 0, len(spec.PartyStart)+len(spec.Monsters))
+	for i, seat := range spec.PartyStart {
+		members = append(members, tkencounter.MemberInput{
+			ID: seatMemberID(i), Kind: tkencounter.KindPlayer,
+			Room: seat.Region, Position: seat.At,
+		})
+	}
+	for i, m := range spec.Monsters {
+		members = append(members, tkencounter.MemberInput{
+			ID: monsterMemberID(i), Kind: tkencounter.KindMonster,
+			Room: m.Region, Position: m.At,
+		})
+	}
+
+	probe, err := tkencounter.NewEncounter(&tkencounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Standing:   nobodyDown{},
+		// A BLIND probe, and deliberately so: sight is what forms a fight, and
+		// this construction places the whole party and the whole garrison at
+		// once. Giving them eyes here would roll initiative on a world that is
+		// about to be thrown away -- work done for nothing, and a fight formed
+		// by a coordinate lookup. Range zero is the honest capability for an
+		// encounter whose only purpose is to answer "where is this cell".
+		Sight:     nobodySees{},
+		Retention: tkencounter.RetentionUnbounded,
+		Field:     spec.Field,
+		Members:   members,
+		Endings:   []tkencounter.EndingInput{{Key: probeEnding, Trigger: tkencounter.TriggerExternal{}}},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("project placements: %w", err)
+	}
+
+	placed, err := probe.Members()
+	if err != nil {
+		return nil, nil, fmt.Errorf("project placements: read back: %w", err)
+	}
+	absolute := make(map[tkencounter.MemberID]spatial.Position, len(placed))
+	for _, m := range placed {
+		absolute[m.ID] = m.Position
+	}
+
+	seats := make([]spatial.Position, len(spec.PartyStart))
+	for i := range spec.PartyStart {
+		at, ok := absolute[seatMemberID(i)]
+		if !ok {
+			return nil, nil, fmt.Errorf("project placements: seat %d was placed but not reported", i)
+		}
+		seats[i] = at
+	}
+
+	monsters := make([]Monster, len(spec.Monsters))
+	ordinals := map[string]int{}
+	for i, m := range spec.Monsters {
+		at, ok := absolute[monsterMemberID(i)]
+		if !ok {
+			return nil, nil, fmt.Errorf("project placements: monster %d (%s) was placed but not reported", i, m.Ref)
+		}
+		id, err := memberIDFor(m.Ref, ordinals)
+		if err != nil {
+			return nil, nil, fmt.Errorf("project placements: monster %d: %w", i, err)
+		}
+		monsters[i] = Monster{Ref: m.Ref, MemberID: id, At: at, Boss: m.Boss, Targeting: m.Targeting}
+	}
+
+	return seats, monsters, nil
+}
+
+// memberIDFor derives a monster's in-encounter ID from its ref and how many of
+// that ref have already been named. See [Monster.MemberID] for why the ID is
+// built from the ref at all.
+//
+// The ref is PARSED rather than string-split, so a malformed one is an error
+// here instead of a member called "dnd5e:monsters:skeleton-1" that nothing
+// downstream can read.
+func memberIDFor(ref string, ordinals map[string]int) (string, error) {
+	parsed, err := core.ParseString(ref)
+	if err != nil {
+		return "", fmt.Errorf("parse ref %q: %w", ref, err)
+	}
+	ordinals[ref]++
+
+	return fmt.Sprintf("%s-%d", parsed.ID, ordinals[ref]), nil
+}
+
+// buildWorld constructs the world the session actually plays in: the compiled
+// field, and nobody standing in it. See [Dungeon.World] for why it is empty.
+func buildWorld(field tkencounter.FieldInput) (*tkencounter.EncounterData, error) {
+	enc, err := tkencounter.NewEncounter(&tkencounter.SetupInput{
+		// Construction-time capabilities only. The session package supplies its
+		// own when it loads this world -- including the sight RANGE that decides
+		// who is in contact with whom -- so these satisfy NewEncounter's
+		// validation for a world that is empty at the moment it is built, and
+		// answer no question about the game. They are trivial because there is
+		// nobody here yet to see or to be standing, not because a ruling was
+		// made quietly.
+		Initiative: orderAsGiven{},
+		Standing:   nobodyDown{},
+		Sight:      nobodySees{},
+		Retention:  tkencounter.RetentionUnbounded,
+		Field:      field,
+		// SetupInput requires at least one declared ending and the compiler
+		// emits none: what ends a dungeon is not geometry. An externally
+		// declared ending is the honest stand-in -- the party withdrawing is a
+		// real way this tomb ends, and it is the only one the composition can
+		// express today. See [Monster.Boss] for the one that is missing.
+		Endings: []tkencounter.EndingInput{{Key: EndingWithdrawn, Trigger: tkencounter.TriggerExternal{}}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build world: %w", err)
+	}
+
+	data := enc.ToData()
+
+	return &data, nil
+}
+
+// EndingWithdrawn is the key of the one ending an authored dungeon declares
+// today: the party left. Exported because a caller that wants to close an
+// encounter has to name it.
+const EndingWithdrawn = "withdrawn"
+
+// probeEnding names the throwaway encounter's ending. Distinct from
+// [EndingWithdrawn] so that a probe can never be mistaken for a playable world
+// in a stack trace or a persisted blob.
+const probeEnding = "probe"
+
+// orderAsGiven, nobodyDown and nobodySees are the three capabilities
+// NewEncounter refuses to default (rpg-toolkit#1033: supplied, never assumed).
+//
+// All three are construction-time only here, which is what makes trivial
+// implementations honest rather than a hidden ruling -- see [buildWorld].
+type orderAsGiven struct{}
+
+// RollInitiative returns the members in the order given. Never reached for
+// either encounter this package builds: the probe is blind and the real world
+// is empty, so no fight can form in the moment either one exists.
+func (orderAsGiven) RollInitiative(members []tkencounter.MemberID) ([]tkencounter.MemberID, error) {
+	return members, nil
+}
+
+type nobodyDown struct{}
+
+// Standing reports who is DOWN, not who is up -- the interface's own parameter
+// is named down, and reading it backwards would report a healthy party as a
+// wiped one. Nobody has been hit yet in a world this new, so: nobody.
+func (nobodyDown) Standing(_ []tkencounter.MemberID) ([]tkencounter.MemberID, error) {
+	return nil, nil
+}
+
+type nobodySees struct{}
+
+// Sight gives every member a range of zero. See the call site in
+// [projectPlacements] for why blindness is the correct capability for a
+// coordinate lookup, and [buildWorld] for why it does not matter in a world
+// with no members at all.
+func (nobodySees) Sight(members []tkencounter.MemberID) (map[tkencounter.MemberID]int, error) {
+	out := make(map[tkencounter.MemberID]int, len(members))
+	for _, id := range members {
+		out[id] = 0
+	}
+
+	return out, nil
+}

--- a/internal/sessionworld/sessionworld_test.go
+++ b/internal/sessionworld/sessionworld_test.go
@@ -184,6 +184,74 @@ func (s *ReferenceTombSuite) TestAPartyCanAllStandSomewhereDistinct() {
 	}
 }
 
+// TestNoSeatIsAlsoSomebodyElsesCell guards a guarantee this package DEPENDS ON
+// and does not own.
+//
+// projectPlacements puts every party seat and every monster into ONE throwaway
+// encounter to read their absolute cells back. That is only safe because the
+// compiler's seat list excludes cells that are already occupied -- if it ever
+// stopped, this package would start failing at construction with an error about
+// a member collision, and nothing about the message would point at the compiler.
+//
+// The tomb's own garrison is in other chambers, so the tomb alone would never
+// notice. This uses a dungeon authored specifically to put a monster in the
+// entrance the party starts in.
+func TestNoSeatIsAlsoSomebodyElsesCell(t *testing.T) {
+	const monsterInTheEntrance = `
+version: 1
+key: seat-collision
+void: opaque
+orientation: pointy
+height: 6
+start: [1, 3]
+rooms:
+  - id: entrance
+    width: 6
+    place:
+      - { ref: "dnd5e:monsters:skeleton", at: [0, 3] }
+  - id: hall
+    width: 6
+connectors:
+  - { from: entrance, to: hall }
+`
+
+	d, err := compile([]byte(monsterInTheEntrance))
+	require.NoError(t, err)
+	require.Len(t, d.Monsters, 1)
+
+	for i, seat := range d.PartySeats {
+		require.NotEqualf(t, d.Monsters[0].At, seat, "seat %d is the monster's cell", i)
+	}
+}
+
+// TestAPartyStartOnTopOfAMonsterIsRefusedByTheCompiler is the same concern one
+// cell over, and the compiler answers this one with a refusal rather than by
+// omitting a seat -- an author who put the party's entry cell under a monster
+// made a mistake, and it is named as one.
+func TestAPartyStartOnTopOfAMonsterIsRefusedByTheCompiler(t *testing.T) {
+	const monsterOnTheStart = `
+version: 1
+key: start-collision
+void: opaque
+orientation: pointy
+height: 6
+start: [1, 3]
+rooms:
+  - id: entrance
+    width: 6
+    place:
+      - { ref: "dnd5e:monsters:skeleton", at: [1, 3] }
+  - id: hall
+    width: 6
+connectors:
+  - { from: entrance, to: hall }
+`
+
+	d, err := compile([]byte(monsterOnTheStart))
+	require.Error(t, err)
+	require.Nil(t, d)
+}
+
 // TestABrokenSpecIsRefusedRatherThanPartlyBuilt checks the failure direction:
 // compile returns an error and no Dungeon, so a caller can never seed a session
 // from a dungeon that did not fully compile.

--- a/internal/sessionworld/sessionworld_test.go
+++ b/internal/sessionworld/sessionworld_test.go
@@ -1,0 +1,194 @@
+package sessionworld
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	tkencounter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type ReferenceTombSuite struct {
+	suite.Suite
+
+	tomb *Dungeon
+}
+
+func TestReferenceTombSuite(t *testing.T) {
+	suite.Run(t, new(ReferenceTombSuite))
+}
+
+func (s *ReferenceTombSuite) SetupTest() {
+	tomb, err := ReferenceTomb()
+	s.Require().NoError(err, "the shipped tomb must compile")
+	s.tomb = tomb
+}
+
+// load rebuilds a live encounter from the world this package produced, which is
+// exactly what session.StartSession does with it. Doing it here is how the
+// tests ask questions in absolute space -- which region owns a cell, what state
+// a door is in -- without this package having to expose either.
+func (s *ReferenceTombSuite) load() *tkencounter.Encounter {
+	enc, err := tkencounter.LoadEncounter(&tkencounter.LoadEncounterInput{
+		Data:       *s.tomb.World,
+		Initiative: orderAsGiven{}, Standing: nobodyDown{}, Sight: nobodySees{},
+	})
+	s.Require().NoError(err, "and the world it produced must be one the composition accepts back")
+
+	return enc
+}
+
+func (s *ReferenceTombSuite) regionOf(cell spatial.Position) string {
+	region, ok := s.load().RegionAt(cell)
+	s.Require().Truef(ok, "cell %v should be floor in some chamber", cell)
+
+	return region
+}
+
+// TestTheWorldArrivesEmptyOfMembers pins the decision in Dungeon.World's doc:
+// the world is authored content, and everybody who stands in it arrives through
+// a session verb.
+//
+// It is not a stylistic preference. encounter.Join refuses a member already in
+// the encounter, so a party baked in here could never be joined -- and Join is
+// the only thing that loads a character's sheet. A change that "helpfully"
+// seeded the roster at construction would leave every player sheetless and
+// every session unjoinable, and this is the test that says so first.
+func (s *ReferenceTombSuite) TestTheWorldArrivesEmptyOfMembers() {
+	s.Empty(s.tomb.World.Members, "the world is content, not a live encounter")
+	s.Empty(s.tomb.World.EverMembers, "and nobody has ever been in it")
+}
+
+// TestThePartyComesInWhereTheDungeonSaysItDoes checks the authored start
+// resolves to the chamber the author put it in, rather than to whichever
+// chamber happens to be first.
+func (s *ReferenceTombSuite) TestThePartyComesInWhereTheDungeonSaysItDoes() {
+	s.Require().NotEmpty(s.tomb.PartySeats)
+	s.Equal("entrance", s.regionOf(s.tomb.PartySeats[0]), "the party enters the entrance")
+}
+
+// TestPlacementsAreProjectedThroughTheCompositionNotCopied is the test this
+// package exists for.
+//
+// The tomb's authored start is the entrance's local cell [1,3]. Its absolute
+// cell is (1,-4) -- not (1,3) -- because an offset rectangle SHEARS when it
+// becomes axial. Any change that passes the authored cell straight through,
+// or reimplements the projection as "local plus origin", produces (1,3) or
+// (7,3) and fails here.
+//
+// The literal is the point rather than an embarrassment: reading the expected
+// value back out of the same projection under test would assert nothing at all.
+func (s *ReferenceTombSuite) TestPlacementsAreProjectedThroughTheCompositionNotCopied() {
+	authored := spatial.Position{X: 1, Y: 3}
+	s.Require().NotEqual(authored, s.tomb.PartySeats[0],
+		"an authored cell that survived unchanged means nothing projected it")
+	s.Equal(spatial.Position{X: 1, Y: -4}, s.tomb.PartySeats[0],
+		"the entrance's local [1,3] is the absolute cell (1,-4)")
+}
+
+// TestTheGarrisonHoldsTheHallAndTheCaptainWaitsBeyondIt checks the monsters
+// land in the chambers they were authored into -- the second half of the
+// projection, and the half a seats-only implementation would leave broken.
+func (s *ReferenceTombSuite) TestTheGarrisonHoldsTheHallAndTheCaptainWaitsBeyondIt() {
+	s.Require().Len(s.tomb.Monsters, 3, "two skeletons and their captain")
+
+	byRegion := map[string][]Monster{}
+	for _, m := range s.tomb.Monsters {
+		region := s.regionOf(m.At)
+		byRegion[region] = append(byRegion[region], m)
+	}
+
+	s.Len(byRegion["hall"], 2, "the garrison holds the hall")
+	s.Require().Len(byRegion["tomb"], 1, "and one thing waits past the locked door")
+	s.Equal("dnd5e:monsters:skeleton-captain", byRegion["tomb"][0].Ref)
+	s.True(byRegion["tomb"][0].Boss, "the captain is the boss")
+
+	for _, m := range byRegion["hall"] {
+		s.False(m.Boss, "a garrison skeleton is not the boss")
+	}
+}
+
+// TestTheAuthorsWordsAboutMonstersSurviveTheCompile pins the two facts this
+// package carries but cannot yet act on (see Monster.Boss and
+// Monster.Targeting). They are asserted so that dropping them is a test
+// failure rather than a silent narrowing nobody notices until the wave that
+// needs them.
+func (s *ReferenceTombSuite) TestTheAuthorsWordsAboutMonstersSurviveTheCompile() {
+	targeting := map[string]int{}
+	bosses := 0
+	for _, m := range s.tomb.Monsters {
+		targeting[m.Targeting]++
+		if m.Boss {
+			bosses++
+		}
+	}
+
+	s.Equal(2, targeting["lowest-health"], "the garrison's authored targeting is carried")
+	s.Equal(1, targeting["closest"], "and so is the captain's")
+	s.Equal(1, bosses, "exactly one boss")
+}
+
+// TestEveryMonsterIsNamedAfterWhatItIs pins the naming rule in
+// Monster.MemberID: a client sees the member ID and nothing else, so an opaque
+// ordinal would leave a UI unable to tell a skeleton from its captain.
+//
+// It also pins the per-ref numbering. Numbering across the whole dungeon would
+// give the captain "skeleton-captain-3" today and a different number the moment
+// a garrison skeleton is added or removed -- a rename of a monster nothing
+// about which changed.
+func (s *ReferenceTombSuite) TestEveryMonsterIsNamedAfterWhatItIs() {
+	byID := map[string]Monster{}
+	for _, m := range s.tomb.Monsters {
+		s.Require().NotEmptyf(m.MemberID, "monster %s has no member ID", m.Ref)
+		s.Require().NotContains(m.MemberID, ":", "a member ID is not a ref")
+		_, repeated := byID[m.MemberID]
+		s.Require().Falsef(repeated, "member ID %q is used twice", m.MemberID)
+		byID[m.MemberID] = m
+	}
+
+	s.Contains(byID, "skeleton-1")
+	s.Contains(byID, "skeleton-2")
+	s.Contains(byID, "skeleton-captain-1", "the captain is numbered within its OWN ref, not across the dungeon")
+	s.True(byID["skeleton-captain-1"].Boss)
+}
+
+// TestTheTombIsShutAtDCTwelve pins the authored lock. Twelve is a literal on
+// purpose for the reason the projection's literal is: it is the authored fact
+// under test, so reading it back out of the compiler would be circular.
+func (s *ReferenceTombSuite) TestTheTombIsShutAtDCTwelve() {
+	enc := s.load()
+	doors := enc.Doors()
+	s.Require().Len(doors, 1, "the tomb authors exactly one door -- the entrance/hall connector is an open gap")
+	s.Equal(tkencounter.DoorStateKind("locked"), doors[0].State.Kind(), "and it starts shut")
+
+	_, err := enc.OpenDoor(&tkencounter.OpenDoorInput{Door: doors[0].ID})
+	s.Require().ErrorIs(err, tkencounter.ErrLocked)
+	s.Contains(err.Error(), "DC 12", "and the refusal says what it would take")
+}
+
+// TestAPartyCanAllStandSomewhereDistinct checks the seats are usable as a list:
+// a four-player party takes the first four and nobody is placed on top of
+// anybody. A projection bug that mapped several local cells onto one absolute
+// cell would pass every region assertion above and fail here.
+func (s *ReferenceTombSuite) TestAPartyCanAllStandSomewhereDistinct() {
+	const biggestPartyWorthChecking = 8
+	s.Require().GreaterOrEqual(len(s.tomb.PartySeats), biggestPartyWorthChecking)
+
+	seen := map[spatial.Position]bool{}
+	for i, seat := range s.tomb.PartySeats[:biggestPartyWorthChecking] {
+		s.Falsef(seen[seat], "seat %d repeats cell %v", i, seat)
+		seen[seat] = true
+		s.Equal("entrance", s.regionOf(seat), "a party stands together at the way in")
+	}
+}
+
+// TestABrokenSpecIsRefusedRatherThanPartlyBuilt checks the failure direction:
+// compile returns an error and no Dungeon, so a caller can never seed a session
+// from a dungeon that did not fully compile.
+func TestABrokenSpecIsRefusedRatherThanPartlyBuilt(t *testing.T) {
+	d, err := compile([]byte("version: 1\nkey: nope\n"))
+	require.Error(t, err)
+	require.Nil(t, d)
+}


### PR DESCRIPTION
Closes #798 (by hand — a `Closes` trailer only fires on the default branch and this repo works on `dev`).

## What changed

New-stack sessions seed the **reference tomb** instead of one empty 12x10 room. Three chambers with walls between them, a garrison of skeletons holding the hall, and a captain behind a door locked at DC 12 — the same dungeon the old stack has always served, compiled by the new one.

The old stack's path is untouched. `SessionService` is still behind `RPG_SESSION_STACK_ENABLED`, unset in every deployment, so **this merge changes no running behavior**.

## Why it was possible now

`start_encounter_session_stack.go` carried this:

> KNOWN GAP, reported rather than worked around: there is no authored-dungeon-YAML -> new-stack EncounterData compiler in the toolkit yet.

rpg-toolkit#1133 shipped `rulebooks/dnd5e/encounter/dungeonspec` and rpg-api already pins `encounter v0.26.0` — the compiler was on disk and the comment was stale. Its own forcing case is the sentence this PR implements.

## The one seam a host still owns

The compiler emits placements in the **authored frame**; session's `Join`/`Spawn` take **dungeon-absolute** cells. `encounter.Join` refuses a member who is already in the encounter, and `Join` is what loads a character's sheet — so the world genuinely cannot arrive with the party baked in, and somebody has to carry a placement across that line.

`internal/sessionworld` is that somebody, and it **borrows the projection rather than recomputing it**: it builds a throwaway encounter from the authored placements and reads the absolute cells back out. The conversion is not addition — an offset rectangle *shears* when it becomes axial, so the entrance's local `[1,3]` is the absolute cell `(1,-4)`. A hand-rolled "local plus origin" in rpg-api would compile, look right, and drift the day the projection changes.

Cost, recorded rather than hidden: one extra construction per encounter start. The durable fix is upstream (`Compiled` carrying absolute placements, or session accepting a compiled dungeon) — filed separately, not blocking.

## Content placement trap, for the next person

The tomb ships at `internal/sessionworld/reference-tomb.yaml`, **not** in `internal/content/dungeons/`. That directory is embedded by `//go:embed dungeons/*.yaml` and every match is parsed with the OLD dialect at startup in a mode that **panics**. A new-dialect file dropped in beside its old-dialect sibling would take the server down on boot.

It is the same dungeon as its old-dialect sibling — verified placement-by-placement, every `(ref, cell)` pair identical, boss included.

## Evidence

| check | result |
|---|---|
| `go build ./...` | clean |
| `go test ./...` | **27 packages ok, 0 failures** |
| `go vet` (changed pkgs) | clean |
| `./scripts/verify-release-pin.sh` | passed — no `replace`, no `go.work`, no local override |
| `make lint` on changed files | clean (see note) |

**Lint note:** 9 issues remain repo-wide, all in files this PR does not touch (`internal/integration/harness/harness.go`, `internal/handlers/dnd5e/v1alpha1/character/*`, `internal/integration/encounter_v2_test.go`). They predate this branch; 3 were introduced here and all 3 are fixed. CI does not gate on lint (`test.yml` runs release-pin + tests).

### Mutation-tested, and one false kill caught

The new tests were run against deliberate mutants. First sweep reported M1/M2 as kills with **no test names** — they were build failures, so the mutants never ran. Harness corrected to distinguish `build failed` from a real kill, then re-run with compiling mutants:

| mutant | result |
|---|---|
| seats copy the authored cell instead of the projected one | killed by 3 tests |
| monsters copy the authored cell | killed |
| boss flag dropped | killed by 2 tests |
| targeting dropped | killed |
| world built WITH a member in it | killed by 7 tests incl. `TestTheWorldArrivesEmptyOfMembers` |
| probe given sight instead of blindness | **survived — correctly.** Blindness there is a waste/clarity choice, not a correctness one, and the doc comment claims exactly that and no more. |

The fog-of-war test also carries a **positive control**: it asserts alice sees Bob standing beside her *before* asserting she cannot see the garrison, because the second assertion is a loop over a slice and an empty one would satisfy it while proving nothing.

## Narrowings, stated in the file rather than implied

- **One dungeon.** `StartEncounterInput.DungeonKey` is ignored on this path. Smaller than it looks — no proto field carries a key, so every real call leaves it at the zero value and the old path serves exactly one dungeon too — but the authoring path (`PutDungeon` → `dungeonregistry`) still writes the **old dialect**, so **the dungeon builder cannot author for this stack yet**. That is the next content-side piece of work.
- **No monster behavior.** `session.Spawn` takes no decider, by its own design.
- **No ending beyond withdrawal.** The composition has no "the boss died" trigger, so the boss flag is carried and unused.

One thing that stopped being a shortcut: the old placeholder needed an `InitiativeRoller` and could only supply the toolkit's test fake. Nothing in the lobby supplies one now — the construction-time capabilities live in `internal/sessionworld` and session supplies its own at load. The remaining gap is upstream and unchanged: no injectable real (dice + ability score) `InitiativeRoller` is exported.

## What this unblocks

The live walkthrough (#797's one unchecked evidence box) becomes worth doing rather than a formality — there is now a dungeon to walk instead of an empty box.

— asset-pipeline agent, on behalf of KirkDiggler
