### PR TITLE
feat(deps): adopt rulebooks/dnd5e v0.97.0 (composable attack damage)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
@@ -33,7 +33,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 // indirect
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 // indirect
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,12 +24,12 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0 h1:2ElsBctjQGavG+EhUCkEcNBcsCJI2GbgBH0CMU7AOzY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 h1:ZBHWR+o9pwpTRSEEnkFPDsj+h5htLa8N8Ywhspglc44=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0/go.mod h1:wANmNP7YRPCvm2Qj/EpT0026fSX6TkqLk1xvkkNHF80=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0 h1:XAsyAGwk/HBioHartLPV4U1g873RplAK+tO3ZbmVVdI=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0/go.mod h1:vbwiTLf3bGBok+RHRFyz6BuKplq/psPtQ0LMOLaV+cw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -17,6 +17,7 @@ import (
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/fightingstyles"
@@ -1471,8 +1472,12 @@ func convertWeaponToProto(id weapons.WeaponID) dnd5ev1alpha1.Weapon {
 		return dnd5ev1alpha1.Weapon_WEAPON_HEAVY_CROSSBOW
 	case weapons.Longbow:
 		return dnd5ev1alpha1.Weapon_WEAPON_LONGBOW
-	case weapons.Net:
-		return dnd5ev1alpha1.Weapon_WEAPON_NET
+	// weapons.Net was removed from rpg-toolkit at dnd5e v0.97.0 (composable
+	// attack damage provider, rpg-toolkit#1146). WEAPON_NET stays defined on
+	// the wire -- deleting a proto enum value is its own, separate
+	// decision -- but nothing in the toolkit resolves to it any more, so no
+	// case here produces it; the switch's default (UNSPECIFIED) is correct
+	// for an ID this build no longer recognizes.
 	// Ammunition
 	case ammunition.Arrows20:
 		return dnd5ev1alpha1.Weapon_WEAPON_ARROWS_20
@@ -1927,8 +1932,10 @@ func convertProtoWeaponToToolkit(weapon dnd5ev1alpha1.Weapon) shared.SelectionID
 		return refs.Weapons.HeavyCrossbow().ID
 	case dnd5ev1alpha1.Weapon_WEAPON_LONGBOW:
 		return refs.Weapons.Longbow().ID
-	case dnd5ev1alpha1.Weapon_WEAPON_NET:
-		return refs.Weapons.Net().ID
+	// WEAPON_NET has no case here for the same reason convertWeaponToProto
+	// no longer produces it: refs.Weapons.Net() was removed at dnd5e v0.97.0
+	// (rpg-toolkit#1146). A caller that still sends WEAPON_NET falls through
+	// to this switch's default ("").
 	// Ammunition
 	case dnd5ev1alpha1.Weapon_WEAPON_ARROWS_20:
 		return shared.SelectionID(ammunition.Arrows20)
@@ -2866,6 +2873,29 @@ func convertArmorCategoryToEquipmentCategory(cat armor.ArmorCategory) dnd5ev1alp
 	}
 }
 
+// baseWeaponDamage projects a weapon's composable damage pool (rpg-toolkit
+// ADR-0040, the "composable attack damage provider" landed at dnd5e
+// v0.97.0 / rpg-toolkit#1146) onto the legacy v1alpha1 wire's single
+// damage_dice/damage_type pair.
+//
+// The FIRST pool is the base weapon damage -- exactly what the old bare
+// string+DamageType field always meant -- and is the only one this legacy
+// wire carries. Any rider pool (an additional damage component a property
+// or feature confers) is invisible here BY DESIGN: this is a translation
+// to a wire shape that predates composable damage and has no field to put
+// a second pool in, not an omission to fix later on this same message.
+//
+// An empty pool returns the zero value rather than indexing pools[0] --
+// this is translation code reading data it did not validate, and a
+// registry weapon with no damage at all should surface as "no damage
+// reported" on the wire, not a panic.
+func baseWeaponDamage(pools []damage.Damage) (dice string, damageType string) {
+	if len(pools) == 0 {
+		return "", ""
+	}
+	return pools[0].Dice, string(pools[0].Type)
+}
+
 // convertWeaponData converts weapon-specific data to proto
 func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 	if weapon == nil {
@@ -2880,10 +2910,11 @@ func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 		weaponCategory = dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_MARTIAL
 	}
 
+	dice, dtype := baseWeaponDamage(weapon.Damage)
 	result := &dnd5ev1alpha1.WeaponData{
 		WeaponCategory: weaponCategory,
-		DamageDice:     weapon.Damage,
-		DamageType:     convertDamageTypeToProto(string(weapon.DamageType)),
+		DamageDice:     dice,
+		DamageType:     convertDamageTypeToProto(dtype),
 		Properties:     convertWeaponProperties(weapon.Properties),
 	}
 	applyWeaponRange(result, weapon.Range)
@@ -2942,10 +2973,11 @@ func convertEquipmentDetailToProto(detail *equipment.EquipmentDetail) *dnd5ev1al
 		} else {
 			result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_SIMPLE_WEAPON
 		}
+		dice, dtype := baseWeaponDamage(detail.Weapon.Damage)
 		weaponData := &dnd5ev1alpha1.WeaponData{
 			WeaponCategory: weaponCategory,
-			DamageDice:     detail.Weapon.Damage,
-			DamageType:     convertDamageTypeToProto(string(detail.Weapon.DamageType)),
+			DamageDice:     dice,
+			DamageType:     convertDamageTypeToProto(dtype),
 			Properties:     convertWeaponProperties(detail.Weapon.Properties),
 		}
 		applyWeaponRange(weaponData, detail.Weapon.Range)

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2507,7 +2507,15 @@ func setEquipmentItemTypeHint(item *dnd5ev1alpha1.EquipmentItem, itemID string) 
 		"hand-crossbow":  dnd5ev1alpha1.Weapon_WEAPON_HAND_CROSSBOW,
 		"heavy-crossbow": dnd5ev1alpha1.Weapon_WEAPON_HEAVY_CROSSBOW,
 		"longbow":        dnd5ev1alpha1.Weapon_WEAPON_LONGBOW,
-		"net":            dnd5ev1alpha1.Weapon_WEAPON_NET,
+		// No "net" entry: rpg-toolkit#1146 (dnd5e v0.97.0) deleted the Net
+		// weapon from the toolkit's registry, so itemID can no longer
+		// legitimately be "net" -- and convertProtoWeaponToToolkit can no
+		// longer resolve WEAPON_NET back to anything (its Net case was
+		// dropped for the same reason). Keeping this entry would let a
+		// stale or hand-built item still advertise a weapon type hint this
+		// build cannot round-trip; an unrecognized itemID falls through to
+		// the tool lookup below and, failing that, sets no hint at all --
+		// consistent with every other unrecognized ID.
 	}
 
 	if weapon, ok := weaponMap[itemID]; ok {

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -268,6 +268,21 @@ func (s *ConvertersTestSuite) TestBaseWeaponDamage_EmptyPool_ReturnsZeroValueNot
 	assert.Empty(s.T(), dtype)
 }
 
+// TestSetEquipmentItemTypeHint_NetIsNoLongerAWeapon is the discriminator for
+// the OTHER Net remnant Copilot caught on PR #808's review of this same
+// file (setEquipmentItemTypeHint's weaponMap, distinct from the two switch
+// cases dropped above): itemID "net" must not produce WEAPON_NET any more.
+// convertProtoWeaponToToolkit already cannot resolve WEAPON_NET back to a
+// toolkit ID -- leaving this map entry would advertise a weapon type hint
+// that dead-ends on the return trip. Also confirms "net" is not secretly a
+// tool ID either, so the whole item ends up with no type hint set, the same
+// as any other unrecognized ID.
+func (s *ConvertersTestSuite) TestSetEquipmentItemTypeHint_NetIsNoLongerAWeapon() {
+	item := &dnd5ev1alpha1.EquipmentItem{}
+	setEquipmentItemTypeHint(item, "net")
+	assert.Nil(s.T(), item.TypeHint)
+}
+
 func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOptionsOneToOne() {
 	fighter := convertClassDataToProto(classes.ClassData[classes.Fighter])
 	fighterMartial := findEquipmentCategoryChoice(s.T(), fighter, "fighter-weapons-primary", "fighter-weapon-a")

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -13,6 +13,7 @@ import (
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
@@ -239,6 +240,34 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail
 	assert.Contains(s.T(), weaponData.Properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_TWO_HANDED)
 }
 
+// TestBaseWeaponDamage_RiderPoolIsIgnored is the discriminator baseWeaponDamage
+// exists for: a weapon whose composable damage carries a base pool AND a
+// rider pool (rpg-toolkit ADR-0040) must project the BASE pool onto the
+// legacy wire's damage_dice/damage_type, not the rider and not some
+// combination of the two. A projection that returned the LAST pool, or
+// concatenated both, would pass every other test touching real registry
+// weapons (they all carry exactly one pool today) and fail only here.
+func (s *ConvertersTestSuite) TestBaseWeaponDamage_RiderPoolIsIgnored() {
+	pools := []damage.Damage{
+		{Dice: "1d8", Type: damage.Slashing},
+		{Dice: "1d4", Type: damage.Fire}, // a rider this legacy wire has no field for
+	}
+
+	dice, dtype := baseWeaponDamage(pools)
+	assert.Equal(s.T(), "1d8", dice)
+	assert.Equal(s.T(), string(damage.Slashing), dtype)
+}
+
+// TestBaseWeaponDamage_EmptyPool_ReturnsZeroValueNotPanic covers the other
+// half of baseWeaponDamage's contract: this is translation code reading
+// data it did not itself validate, so an empty pool must come back as an
+// empty string, not index pools[0] on nothing.
+func (s *ConvertersTestSuite) TestBaseWeaponDamage_EmptyPool_ReturnsZeroValueNotPanic() {
+	dice, dtype := baseWeaponDamage(nil)
+	assert.Empty(s.T(), dice)
+	assert.Empty(s.T(), dtype)
+}
+
 func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOptionsOneToOne() {
 	fighter := convertClassDataToProto(classes.ClassData[classes.Fighter])
 	fighterMartial := findEquipmentCategoryChoice(s.T(), fighter, "fighter-weapons-primary", "fighter-weapon-a")
@@ -249,9 +278,14 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOption
 		"fighter-weapons-primary",
 		"fighter-weapon-a",
 		[]string{
+			// weapons.Net dropped from this expected list: the toolkit's own
+			// weapon registry no longer offers it (rpg-toolkit#1146 removed
+			// the weapon entirely, not just its wire mapping), so the
+			// Fighter's martial-ranged registry choice this test compares
+			// against no longer includes it either.
 			weapons.Greatsword, weapons.Longsword, weapons.Rapier, weapons.Shortsword, weapons.Battleaxe, weapons.Flail, weapons.Glaive, weapons.Greataxe,
 			weapons.Halberd, weapons.Lance, weapons.Maul, weapons.Morningstar, weapons.Pike, weapons.Scimitar, weapons.Trident, weapons.WarPick,
-			weapons.Warhammer, weapons.Whip, weapons.HeavyCrossbow, weapons.Longbow, weapons.Blowgun, weapons.HandCrossbow, weapons.Net,
+			weapons.Warhammer, weapons.Whip, weapons.HeavyCrossbow, weapons.Longbow, weapons.Blowgun, weapons.HandCrossbow,
 		},
 	)
 
@@ -391,7 +425,12 @@ func requireCategoryOptionsMatchToolkit(
 		require.NotNil(t, source.Detail.Weapon, "option %d must be a weapon", index)
 		weaponData := item.GetEquipmentDetail().GetWeaponData()
 		require.NotNil(t, weaponData, "option %d weapon detail", index)
-		assert.Equal(t, source.Detail.Weapon.Damage, weaponData.GetDamageDice(), "option %d damage dice", index)
+		// Weapon.Damage is a composable pool ([]damage.Damage) as of dnd5e
+		// v0.97.0; the legacy wire's damage_dice carries only the base pool
+		// (index 0) -- see baseWeaponDamage's own doc. Every registry weapon
+		// this loop walks has exactly one pool today, so [0] is safe here.
+		require.NotEmpty(t, source.Detail.Weapon.Damage, "option %d has no damage pool", index)
+		assert.Equal(t, source.Detail.Weapon.Damage[0].Dice, weaponData.GetDamageDice(), "option %d damage dice", index)
 	}
 }
 

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -704,9 +704,13 @@ func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptio
 		s.T(),
 		fighterMartial.GetOptions(),
 		[]string{
+			// "net" dropped: rpg-toolkit#1146 (composable attack damage
+			// provider, dnd5e v0.97.0) removed the Net weapon from the
+			// toolkit's registry entirely, so the real RPC this suite drives
+			// no longer offers it as a martial-ranged option.
 			"greatsword", "longsword", "rapier", "shortsword", "battleaxe", "flail", "glaive", "greataxe",
 			"halberd", "lance", "maul", "morningstar", "pike", "scimitar", "trident", "war-pick",
-			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow", "net",
+			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow",
 		},
 	)
 	longbow := equipmentItemByID(s.T(), fighterMartial.GetOptions(), "longbow")

--- a/internal/testsupport/monsterfixture/goblin.go
+++ b/internal/testsupport/monsterfixture/goblin.go
@@ -19,7 +19,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	// NewGoblin moved out of monster into monster/monsters at dnd5e v0.97.0
+	// (rpg-toolkit's composable-attack-damage-provider migration,
+	// rpg-toolkit#1146 / ADR-0040): the bare monster package holds only the
+	// runtime Monster type and Config now, and per-species factories live in
+	// this sibling package.
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 )
 
 // GoblinDataJSON returns valid, rehydratable monster.Data JSON for a real
@@ -27,7 +32,7 @@ import (
 // tkenc.MonsterInput.DataJSON in hand-built test fixtures.
 func GoblinDataJSON(tb testing.TB, id string) []byte {
 	tb.Helper()
-	b, err := json.Marshal(monster.NewGoblin(id).ToData())
+	b, err := json.Marshal(monsters.NewGoblin(id).ToData())
 	require.NoError(tb, err)
 	return b
 }


### PR DESCRIPTION
## Why

`rulebooks/dnd5e/session v0.21.2` (needed for [rpg-toolkit#1157](https://github.com/KirkDiggler/rpg-toolkit/issues/1157)'s typed `Seen` transcription, stacked on this PR) hard-requires `rulebooks/dnd5e v0.97.0` in its own go.mod. That version carries rpg-toolkit's composable attack damage provider migration (ADR-0040, rpg-toolkit#1146), which is a breaking change unrelated to session/Seen. This PR is the prerequisite: adopt v0.97.0 on its own, fix what it breaks, land it first.

## What changed

- `go.mod`: `rulebooks/dnd5e` v0.96.0 → v0.97.0; `rulebooks/dnd5e/resolution` v0.10.0 → v0.11.0 (the version already updated for the new weapon API — v0.10.0 does not compile against dnd5e v0.97.0). `rulebooks/dnd5e/encounter` and `rulebooks/dnd5e/session` deliberately left at their current pins (v0.28.0 / v0.21.0) — this PR is only the damage migration, not the session bump that follows on top of it.

- `Weapon.Damage` changed from a bare `string` to a composable pool (`[]damage.Damage`); `DamageType` was removed from `*weapons.Weapon`; the `Net` weapon was deleted from the toolkit's registry entirely.

- `internal/handlers/dnd5e/v1alpha1/character/converters.go`: new `baseWeaponDamage(pools []damage.Damage) (dice, damageType string)` helper projects the **first** pool — the base weapon damage, exactly what the old field always meant — onto the legacy v1alpha1 wire's `damage_dice`/`damage_type`. Riders (additional damage components a property confers) are not on this legacy wire by design; there's no field to put a second pool in. Wired into `convertWeaponData` and `convertEquipmentDetailToProto`. Dropped the two `Net` converter cases — `WEAPON_NET` stays defined on the proto (deleting an enum value is a separate decision), but nothing resolves to it any more; both switches fall through to their existing default.

- `internal/testsupport/monsterfixture/goblin.go`: `NewGoblin` moved from `monster` to `monster/monsters` at dnd5e v0.97.0 — updated the import and call site.

- Two tests hardcoded `"net"`/`weapons.Net` in expected weapon-choice lists (`converters_test.go`, `internal/integration/character/creation_test.go`) — dropped, since the toolkit's own registry no longer offers it as an option. Fixed `converters_test.go`'s `Damage[0].Dice` comparison for the new pool shape.

- New discriminating tests for `baseWeaponDamage`: a weapon with a base pool + a rider pool projects the base pool only; an empty pool returns `""` rather than panicking on `pools[0]`.

## Tests

- `go build ./...`, `go vet ./...`, `go test -race ./...` — all pass, repo-wide.
- `golangci-lint run ./...` reports 9 pre-existing issues in `internal/integration/harness/harness.go` and `internal/handlers/dnd5e/v1alpha1/character/handler.go` (errcheck/govet/staticcheck/unconvert). Confirmed via diff against `origin/dev` that both files are byte-identical to `dev` in the flagged regions — this predates this change and is out of its scope. GitHub Actions CI does not run golangci-lint (only `test.yml`/`Test and Coverage` and `docker.yml`), so this doesn't affect the merge-gating pipeline.
- `make ci-check` (`scripts/ci-checks.sh`) — release pins, EOF newlines, mock generation, formatting, imports, go.mod tidy all clean; only the pre-existing lint findings above remain.

Part of rpg-toolkit#1157 → rpg-dnd5e-web#762

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu