### PR TITLE
feat(session): transcribe Seen on Sighting/Report (ADR-0041)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
@@ -33,7 +33,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 // indirect
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 // indirect
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/KirkDiggler/rpg-api
 go 1.25.13
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821000306-14d8d4279743
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821203533-17e0d1f4df47
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821000306-14d8d4279743 h1:FRyHyee1GsPl7q+urgUI2BhchbGGvvyE0O8HYByJTHk=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821000306-14d8d4279743/go.mod h1:cwJ+M7K4SQTCMJHXvD8bQkIF4+lWB8w+OPWhDn+RCf8=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821203533-17e0d1f4df47 h1:ynZERFMRewPrFHsugDGcngCN1+OGZgoEXoUKDSalZiU=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821203533-17e0d1f4df47/go.mod h1:cwJ+M7K4SQTCMJHXvD8bQkIF4+lWB8w+OPWhDn+RCf8=
 github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
 github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
@@ -26,12 +26,12 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Y
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0 h1:2ElsBctjQGavG+EhUCkEcNBcsCJI2GbgBH0CMU7AOzY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0 h1:YyKFsJqczz3Ip18utScZdYZrukcwF8Cu+6Pem76xKwM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0 h1:XAsyAGwk/HBioHartLPV4U1g873RplAK+tO3ZbmVVdI=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0/go.mod h1:vbwiTLf3bGBok+RHRFyz6BuKplq/psPtQ0LMOLaV+cw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.2 h1:9mnx15oyT0BMRg+tQMh+uqVK32u4r6VtUIBbZMnvEzA=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.2/go.mod h1:b/3BS3zQXQYTgCTPC6VlEmz2aJwDTz6jmhipRZ77MOo=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/go.sum
+++ b/go.sum
@@ -24,12 +24,12 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2 h1:B7IrROe3GcPrzMeV0EQryA194Y7Yjl3E4kw/OBx4Ucc=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0 h1:2ElsBctjQGavG+EhUCkEcNBcsCJI2GbgBH0CMU7AOzY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 h1:ZBHWR+o9pwpTRSEEnkFPDsj+h5htLa8N8Ywhspglc44=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0/go.mod h1:wANmNP7YRPCvm2Qj/EpT0026fSX6TkqLk1xvkkNHF80=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0 h1:XAsyAGwk/HBioHartLPV4U1g873RplAK+tO3ZbmVVdI=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.0/go.mod h1:vbwiTLf3bGBok+RHRFyz6BuKplq/psPtQ0LMOLaV+cw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/internal/handlers/dnd5e/session/v1alpha1/convert.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/convert.go
@@ -157,8 +157,21 @@ func characterStateToProto(c *sdk.CharacterState) *sessionpb.CharacterState {
 	}
 }
 
+// seenToProto mirrors the sight channel's typed Seen sub-struct (ADR-0041,
+// rpg-toolkit#1157, session v0.21.2). A nil Seen -- channel provenance or
+// payload decoding didn't hold sight, or (on Report) the payload simply
+// didn't decode as one -- stays unset on the wire rather than a zero-valued
+// Seen, matching discoveriesToProto's own "absent means nothing to report"
+// convention on this seam.
+func seenToProto(s *sdk.Seen) *sessionpb.Seen {
+	if s == nil {
+		return nil
+	}
+	return &sessionpb.Seen{Position: positionToProto(s.Position)}
+}
+
 func reportToProto(r sdk.Report) *sessionpb.Report {
-	return &sessionpb.Report{Subject: r.Subject, Payload: r.Payload}
+	return &sessionpb.Report{Subject: r.Subject, Payload: r.Payload, Seen: seenToProto(r.Seen)}
 }
 
 func discoveryToProto(d sdk.Discovery) *sessionpb.Discovery {
@@ -197,6 +210,7 @@ func sightingToProto(s sdk.Sighting) *sessionpb.Sighting {
 		At:         s.At,
 		CurrentVia: s.CurrentVia,
 		Status:     s.Status,
+		Seen:       seenToProto(s.Seen),
 	}
 }
 

--- a/internal/handlers/dnd5e/session/v1alpha1/convert_test.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/convert_test.go
@@ -265,3 +265,49 @@ func TestSightingsToProto(t *testing.T) {
 	require.Equal(t, "goblin", got[0].GetSubject())
 	require.Equal(t, "live", got[0].GetStatus())
 }
+
+// TestSightingToProto_WithSeen and TestSightingToProto_WithoutSeen cover
+// ADR-0041's typed sight-channel position (rpg-toolkit#1157, session
+// v0.21.2): Seen is present iff channel provenance AND payload decoding both
+// held, so a converter that always sets or always omits it passes only one
+// of these two -- the discriminator the pair exists to catch. Payload stays
+// asserted alongside so a converter that stopped copying the passthrough
+// bytes while wiring in Seen would also fail here.
+func TestSightingToProto_WithSeen(t *testing.T) {
+	got := sightingToProto(sdk.Sighting{
+		Subject: "skeleton-1",
+		Payload: []byte("x"),
+		Channel: "sight",
+		Seen:    &sdk.Seen{Position: spatial.Position{X: 4, Y: 6}},
+	})
+	require.Equal(t, []byte("x"), got.GetPayload())
+	require.NotNil(t, got.GetSeen())
+	require.Equal(t, 4.0, got.GetSeen().GetPosition().GetX())
+	require.Equal(t, 6.0, got.GetSeen().GetPosition().GetY())
+}
+
+func TestSightingToProto_WithoutSeen(t *testing.T) {
+	got := sightingToProto(sdk.Sighting{Subject: "skeleton-1", Payload: []byte("x"), Channel: "memory"})
+	require.Nil(t, got.GetSeen())
+}
+
+// TestReportToProto_WithSeen and TestReportToProto_WithoutSeen cover the
+// same field on Report -- the shape Discovery.first_contact carries a
+// Report in (discoveryToProto delegates to reportToProto per entry, so this
+// exercises the Discovery path too without a fixture matrix).
+func TestReportToProto_WithSeen(t *testing.T) {
+	got := reportToProto(sdk.Report{
+		Subject: "skeleton-1",
+		Payload: []byte("x"),
+		Seen:    &sdk.Seen{Position: spatial.Position{X: 4, Y: 6}},
+	})
+	require.Equal(t, []byte("x"), got.GetPayload())
+	require.NotNil(t, got.GetSeen())
+	require.Equal(t, 4.0, got.GetSeen().GetPosition().GetX())
+	require.Equal(t, 6.0, got.GetSeen().GetPosition().GetY())
+}
+
+func TestReportToProto_WithoutSeen(t *testing.T) {
+	got := reportToProto(sdk.Report{Subject: "skeleton-1", Payload: []byte("x")})
+	require.Nil(t, got.GetSeen())
+}

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -17,6 +17,7 @@ import (
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/fightingstyles"
@@ -1471,8 +1472,12 @@ func convertWeaponToProto(id weapons.WeaponID) dnd5ev1alpha1.Weapon {
 		return dnd5ev1alpha1.Weapon_WEAPON_HEAVY_CROSSBOW
 	case weapons.Longbow:
 		return dnd5ev1alpha1.Weapon_WEAPON_LONGBOW
-	case weapons.Net:
-		return dnd5ev1alpha1.Weapon_WEAPON_NET
+	// weapons.Net was removed from rpg-toolkit at dnd5e v0.97.0 (composable
+	// attack damage provider, rpg-toolkit#1146). WEAPON_NET stays defined on
+	// the wire -- deleting a proto enum value is its own, separate
+	// decision -- but nothing in the toolkit resolves to it any more, so no
+	// case here produces it; the switch's default (UNSPECIFIED) is correct
+	// for an ID this build no longer recognizes.
 	// Ammunition
 	case ammunition.Arrows20:
 		return dnd5ev1alpha1.Weapon_WEAPON_ARROWS_20
@@ -1927,8 +1932,10 @@ func convertProtoWeaponToToolkit(weapon dnd5ev1alpha1.Weapon) shared.SelectionID
 		return refs.Weapons.HeavyCrossbow().ID
 	case dnd5ev1alpha1.Weapon_WEAPON_LONGBOW:
 		return refs.Weapons.Longbow().ID
-	case dnd5ev1alpha1.Weapon_WEAPON_NET:
-		return refs.Weapons.Net().ID
+	// WEAPON_NET has no case here for the same reason convertWeaponToProto
+	// no longer produces it: refs.Weapons.Net() was removed at dnd5e v0.97.0
+	// (rpg-toolkit#1146). A caller that still sends WEAPON_NET falls through
+	// to this switch's default ("").
 	// Ammunition
 	case dnd5ev1alpha1.Weapon_WEAPON_ARROWS_20:
 		return shared.SelectionID(ammunition.Arrows20)
@@ -2866,6 +2873,29 @@ func convertArmorCategoryToEquipmentCategory(cat armor.ArmorCategory) dnd5ev1alp
 	}
 }
 
+// baseWeaponDamage projects a weapon's composable damage pool (rpg-toolkit
+// ADR-0040, the "composable attack damage provider" landed at dnd5e
+// v0.97.0 / rpg-toolkit#1146) onto the legacy v1alpha1 wire's single
+// damage_dice/damage_type pair.
+//
+// The FIRST pool is the base weapon damage -- exactly what the old bare
+// string+DamageType field always meant -- and is the only one this legacy
+// wire carries. Any rider pool (an additional damage component a property
+// or feature confers) is invisible here BY DESIGN: this is a translation
+// to a wire shape that predates composable damage and has no field to put
+// a second pool in, not an omission to fix later on this same message.
+//
+// An empty pool returns the zero value rather than indexing pools[0] --
+// this is translation code reading data it did not validate, and a
+// registry weapon with no damage at all should surface as "no damage
+// reported" on the wire, not a panic.
+func baseWeaponDamage(pools []damage.Damage) (dice string, damageType string) {
+	if len(pools) == 0 {
+		return "", ""
+	}
+	return pools[0].Dice, string(pools[0].Type)
+}
+
 // convertWeaponData converts weapon-specific data to proto
 func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 	if weapon == nil {
@@ -2880,10 +2910,11 @@ func convertWeaponData(weapon *weapons.Weapon) *dnd5ev1alpha1.WeaponData {
 		weaponCategory = dnd5ev1alpha1.WeaponCategory_WEAPON_CATEGORY_MARTIAL
 	}
 
+	dice, dtype := baseWeaponDamage(weapon.Damage)
 	result := &dnd5ev1alpha1.WeaponData{
 		WeaponCategory: weaponCategory,
-		DamageDice:     weapon.Damage,
-		DamageType:     convertDamageTypeToProto(string(weapon.DamageType)),
+		DamageDice:     dice,
+		DamageType:     convertDamageTypeToProto(dtype),
 		Properties:     convertWeaponProperties(weapon.Properties),
 	}
 	applyWeaponRange(result, weapon.Range)
@@ -2942,10 +2973,11 @@ func convertEquipmentDetailToProto(detail *equipment.EquipmentDetail) *dnd5ev1al
 		} else {
 			result.Category = dnd5ev1alpha1.EquipmentCategory_EQUIPMENT_CATEGORY_SIMPLE_WEAPON
 		}
+		dice, dtype := baseWeaponDamage(detail.Weapon.Damage)
 		weaponData := &dnd5ev1alpha1.WeaponData{
 			WeaponCategory: weaponCategory,
-			DamageDice:     detail.Weapon.Damage,
-			DamageType:     convertDamageTypeToProto(string(detail.Weapon.DamageType)),
+			DamageDice:     dice,
+			DamageType:     convertDamageTypeToProto(dtype),
 			Properties:     convertWeaponProperties(detail.Weapon.Properties),
 		}
 		applyWeaponRange(weaponData, detail.Weapon.Range)

--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -2507,7 +2507,15 @@ func setEquipmentItemTypeHint(item *dnd5ev1alpha1.EquipmentItem, itemID string) 
 		"hand-crossbow":  dnd5ev1alpha1.Weapon_WEAPON_HAND_CROSSBOW,
 		"heavy-crossbow": dnd5ev1alpha1.Weapon_WEAPON_HEAVY_CROSSBOW,
 		"longbow":        dnd5ev1alpha1.Weapon_WEAPON_LONGBOW,
-		"net":            dnd5ev1alpha1.Weapon_WEAPON_NET,
+		// No "net" entry: rpg-toolkit#1146 (dnd5e v0.97.0) deleted the Net
+		// weapon from the toolkit's registry, so itemID can no longer
+		// legitimately be "net" -- and convertProtoWeaponToToolkit can no
+		// longer resolve WEAPON_NET back to anything (its Net case was
+		// dropped for the same reason). Keeping this entry would let a
+		// stale or hand-built item still advertise a weapon type hint this
+		// build cannot round-trip; an unrecognized itemID falls through to
+		// the tool lookup below and, failing that, sets no hint at all --
+		// consistent with every other unrecognized ID.
 	}
 
 	if weapon, ok := weaponMap[itemID]; ok {

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -268,6 +268,21 @@ func (s *ConvertersTestSuite) TestBaseWeaponDamage_EmptyPool_ReturnsZeroValueNot
 	assert.Empty(s.T(), dtype)
 }
 
+// TestSetEquipmentItemTypeHint_NetIsNoLongerAWeapon is the discriminator for
+// the OTHER Net remnant Copilot caught on PR #808's review of this same
+// file (setEquipmentItemTypeHint's weaponMap, distinct from the two switch
+// cases dropped above): itemID "net" must not produce WEAPON_NET any more.
+// convertProtoWeaponToToolkit already cannot resolve WEAPON_NET back to a
+// toolkit ID -- leaving this map entry would advertise a weapon type hint
+// that dead-ends on the return trip. Also confirms "net" is not secretly a
+// tool ID either, so the whole item ends up with no type hint set, the same
+// as any other unrecognized ID.
+func (s *ConvertersTestSuite) TestSetEquipmentItemTypeHint_NetIsNoLongerAWeapon() {
+	item := &dnd5ev1alpha1.EquipmentItem{}
+	setEquipmentItemTypeHint(item, "net")
+	assert.Nil(s.T(), item.TypeHint)
+}
+
 func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOptionsOneToOne() {
 	fighter := convertClassDataToProto(classes.ClassData[classes.Fighter])
 	fighterMartial := findEquipmentCategoryChoice(s.T(), fighter, "fighter-weapons-primary", "fighter-weapon-a")

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -13,6 +13,7 @@ import (
 	toolkitchar "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
@@ -239,6 +240,34 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_PopulatesEquipmentDetail
 	assert.Contains(s.T(), weaponData.Properties, dnd5ev1alpha1.WeaponProperty_WEAPON_PROPERTY_TWO_HANDED)
 }
 
+// TestBaseWeaponDamage_RiderPoolIsIgnored is the discriminator baseWeaponDamage
+// exists for: a weapon whose composable damage carries a base pool AND a
+// rider pool (rpg-toolkit ADR-0040) must project the BASE pool onto the
+// legacy wire's damage_dice/damage_type, not the rider and not some
+// combination of the two. A projection that returned the LAST pool, or
+// concatenated both, would pass every other test touching real registry
+// weapons (they all carry exactly one pool today) and fail only here.
+func (s *ConvertersTestSuite) TestBaseWeaponDamage_RiderPoolIsIgnored() {
+	pools := []damage.Damage{
+		{Dice: "1d8", Type: damage.Slashing},
+		{Dice: "1d4", Type: damage.Fire}, // a rider this legacy wire has no field for
+	}
+
+	dice, dtype := baseWeaponDamage(pools)
+	assert.Equal(s.T(), "1d8", dice)
+	assert.Equal(s.T(), string(damage.Slashing), dtype)
+}
+
+// TestBaseWeaponDamage_EmptyPool_ReturnsZeroValueNotPanic covers the other
+// half of baseWeaponDamage's contract: this is translation code reading
+// data it did not itself validate, so an empty pool must come back as an
+// empty string, not index pools[0] on nothing.
+func (s *ConvertersTestSuite) TestBaseWeaponDamage_EmptyPool_ReturnsZeroValueNotPanic() {
+	dice, dtype := baseWeaponDamage(nil)
+	assert.Empty(s.T(), dice)
+	assert.Empty(s.T(), dtype)
+}
+
 func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOptionsOneToOne() {
 	fighter := convertClassDataToProto(classes.ClassData[classes.Fighter])
 	fighterMartial := findEquipmentCategoryChoice(s.T(), fighter, "fighter-weapons-primary", "fighter-weapon-a")
@@ -249,9 +278,14 @@ func (s *ConvertersTestSuite) TestCreateEquipmentChoice_MapsCategoryChoiceOption
 		"fighter-weapons-primary",
 		"fighter-weapon-a",
 		[]string{
+			// weapons.Net dropped from this expected list: the toolkit's own
+			// weapon registry no longer offers it (rpg-toolkit#1146 removed
+			// the weapon entirely, not just its wire mapping), so the
+			// Fighter's martial-ranged registry choice this test compares
+			// against no longer includes it either.
 			weapons.Greatsword, weapons.Longsword, weapons.Rapier, weapons.Shortsword, weapons.Battleaxe, weapons.Flail, weapons.Glaive, weapons.Greataxe,
 			weapons.Halberd, weapons.Lance, weapons.Maul, weapons.Morningstar, weapons.Pike, weapons.Scimitar, weapons.Trident, weapons.WarPick,
-			weapons.Warhammer, weapons.Whip, weapons.HeavyCrossbow, weapons.Longbow, weapons.Blowgun, weapons.HandCrossbow, weapons.Net,
+			weapons.Warhammer, weapons.Whip, weapons.HeavyCrossbow, weapons.Longbow, weapons.Blowgun, weapons.HandCrossbow,
 		},
 	)
 
@@ -391,7 +425,12 @@ func requireCategoryOptionsMatchToolkit(
 		require.NotNil(t, source.Detail.Weapon, "option %d must be a weapon", index)
 		weaponData := item.GetEquipmentDetail().GetWeaponData()
 		require.NotNil(t, weaponData, "option %d weapon detail", index)
-		assert.Equal(t, source.Detail.Weapon.Damage, weaponData.GetDamageDice(), "option %d damage dice", index)
+		// Weapon.Damage is a composable pool ([]damage.Damage) as of dnd5e
+		// v0.97.0; the legacy wire's damage_dice carries only the base pool
+		// (index 0) -- see baseWeaponDamage's own doc. Every registry weapon
+		// this loop walks has exactly one pool today, so [0] is safe here.
+		require.NotEmpty(t, source.Detail.Weapon.Damage, "option %d has no damage pool", index)
+		assert.Equal(t, source.Detail.Weapon.Damage[0].Dice, weaponData.GetDamageDice(), "option %d damage dice", index)
 	}
 }
 

--- a/internal/integration/character/creation_test.go
+++ b/internal/integration/character/creation_test.go
@@ -704,9 +704,13 @@ func (s *CharacterCreationSuite) TestListClasses_MapsResolvedCategoryChoiceOptio
 		s.T(),
 		fighterMartial.GetOptions(),
 		[]string{
+			// "net" dropped: rpg-toolkit#1146 (composable attack damage
+			// provider, dnd5e v0.97.0) removed the Net weapon from the
+			// toolkit's registry entirely, so the real RPC this suite drives
+			// no longer offers it as a martial-ranged option.
 			"greatsword", "longsword", "rapier", "shortsword", "battleaxe", "flail", "glaive", "greataxe",
 			"halberd", "lance", "maul", "morningstar", "pike", "scimitar", "trident", "war-pick",
-			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow", "net",
+			"warhammer", "whip", "heavy-crossbow", "longbow", "blowgun", "hand-crossbow",
 		},
 	)
 	longbow := equipmentItemByID(s.T(), fighterMartial.GetOptions(), "longbow")

--- a/internal/integration/session/acceptance_test.go
+++ b/internal/integration/session/acceptance_test.go
@@ -360,6 +360,29 @@ func TestAcceptanceLoop_WalkFightDissolveResync(t *testing.T) {
 	require.Contains(t, formed.GetOrder(), "alice")
 	require.Contains(t, formed.GetOrder(), "skel-1")
 
+	// -- GetView reports the skeleton with its typed Seen position (ADR-0041,
+	// rpg-toolkit#1157, session v0.21.2) -- through the real handler's
+	// sightingToProto, not a mock. Sight is what just formed the fight above,
+	// so this is the ordinary case Seen exists for: a live sighting produced
+	// by the sight channel whose payload decoded. The position asserted is
+	// skel-1's Spawn position (X:19, Y:3) -- it has not moved, since nothing
+	// in this fixture drives monster AI.
+	viewResp, err := h.handler.GetView(ctx, &sessionpb.GetViewRequest{
+		Session: "acceptance-run", Member: "alice",
+	})
+	require.NoError(t, err)
+	var skeletonSighting *sessionpb.Sighting
+	for _, sighting := range viewResp.GetSightings() {
+		if sighting.GetSubject() == "skel-1" {
+			skeletonSighting = sighting
+			break
+		}
+	}
+	require.NotNil(t, skeletonSighting, "alice's view must include the skeleton she just formed a fight with")
+	require.NotNil(t, skeletonSighting.GetSeen(), "a live sight-channel sighting must carry its typed Seen position")
+	require.Equal(t, 19.0, skeletonSighting.GetSeen().GetPosition().GetX())
+	require.Equal(t, 3.0, skeletonSighting.GetSeen().GetPosition().GetY())
+
 	// -- attack, and damage applies --
 	attackResp, err := h.handler.Attack(ctx, &sessionpb.AttackRequest{
 		Session: "acceptance-run", Attacker: "alice", Target: "skel-1",

--- a/internal/testsupport/monsterfixture/goblin.go
+++ b/internal/testsupport/monsterfixture/goblin.go
@@ -19,7 +19,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	// NewGoblin moved out of monster into monster/monsters at dnd5e v0.97.0
+	// (rpg-toolkit's composable-attack-damage-provider migration,
+	// rpg-toolkit#1146 / ADR-0040): the bare monster package holds only the
+	// runtime Monster type and Config now, and per-species factories live in
+	// this sibling package.
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 )
 
 // GoblinDataJSON returns valid, rehydratable monster.Data JSON for a real
@@ -27,7 +32,7 @@ import (
 // tkenc.MonsterInput.DataJSON in hand-built test fixtures.
 func GoblinDataJSON(tb testing.TB, id string) []byte {
 	tb.Helper()
-	b, err := json.Marshal(monster.NewGoblin(id).ToData())
+	b, err := json.Marshal(monsters.NewGoblin(id).ToData())
 	require.NoError(tb, err)
 	return b
 }


### PR DESCRIPTION
**Stacked on #807 — merge #807 first.** This branch is rebased onto `feat/adopt-dnd5e-0.97`, so the diff shown here includes #807's commit until it merges into `dev`; once it does, this PR's diff will shrink to just the Seen transcription below and I'll re-target/rebase as needed.

## Why

rpg-toolkit ADR-0041 (rpg-toolkit#1157) adds a typed `Seen{Position spatial.Position}` sub-struct to `session.Sighting`/`session.Report`, tagged `rulebooks/dnd5e/session/v0.21.2`. rpg-api-protos#233 (merged, on `generated`) mirrors it: `message Seen { Position position = 1; }`, `Sighting.seen = 7`, `Report.seen = 3`. This PR transcribes it through rpg-api's session v1alpha1 handler.

`session v0.21.2`'s own go.mod hard-requires `rulebooks/dnd5e v0.97.0` — that's what #807 lands first.

## What changed

**Bumps** (go.mod): `rulebooks/dnd5e/session` v0.21.0 → v0.21.2; `rulebooks/dnd5e/encounter` v0.28.0 → v0.29.0 (a hard requirement of session v0.21.2's own go.mod); `rpg-api-protos/gen/go` → the `generated` branch's current head (carries protos#233).

**Code** — `internal/handlers/dnd5e/session/v1alpha1/convert.go`: new `seenToProto(*sdk.Seen) *sessionpb.Seen` helper (nil stays unset on the wire, matching every other "absent means nothing to report" convention on this seam), wired into `sightingToProto` and `reportToProto`. Payload stays passthrough, unchanged.

**Tests** (TDD, verified red→green):
- `convert_test.go`: `TestSightingToProto_WithSeen`/`WithoutSeen`, `TestReportToProto_WithSeen`/`WithoutSeen` — discriminating, `Payload` asserted alongside so a converter that dropped it while wiring in `Seen` would also fail.
- Extended the existing real-stack acceptance test `TestAcceptanceLoop_WalkFightDissolveResync` (`internal/integration/session/acceptance_test.go`) — real handler, real `session.Manager`, real miniredis, no mocks. After the walk forms a fight with a real skeleton (`skel-1`), asserts `GetView`'s `Sighting.Seen.Position` equals the skeleton's actual spawn position. Verified this fails without the wiring (stashed `convert.go`, reran) and passes with it.

## Tests run

- `go build ./...`, `go vet ./...` — clean, repo-wide.
- `go test -race ./...` — all pass, repo-wide.
- `golangci-lint run ./...` — same 9 pre-existing, unrelated findings as #807 (`internal/integration/harness/harness.go`, `internal/handlers/dnd5e/v1alpha1/character/handler.go`); nothing new from this diff. Not CI-gated (GitHub Actions only runs `test.yml`/`docker.yml`).
- Mock regeneration (`go generate ./...`) — no diff, mocks up to date; no interface changed.

Part of rpg-toolkit#1157 → rpg-dnd5e-web#762

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu