### PR TITLE
feat(session): Afford — project the toolkit's affordability read (protos v0.1.130, session/v0.21.3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/KirkDiggler/rpg-api
 go 1.25.13
 
 require (
-	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821203533-17e0d1f4df47
+	github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260822002817-34f67061d7d1
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.2
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.3
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821203533-17e0d1f4df47 h1:ynZERFMRewPrFHsugDGcngCN1+OGZgoEXoUKDSalZiU=
-github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260821203533-17e0d1f4df47/go.mod h1:cwJ+M7K4SQTCMJHXvD8bQkIF4+lWB8w+OPWhDn+RCf8=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260822002817-34f67061d7d1 h1:ryZf4AScQ0VapGB6qCp9ql6IgtIHEp4LWKNBzrMdL7s=
+github.com/KirkDiggler/rpg-api-protos/gen/go v0.0.0-20260822002817-34f67061d7d1/go.mod h1:cwJ+M7K4SQTCMJHXvD8bQkIF4+lWB8w+OPWhDn+RCf8=
 github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
 github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
@@ -30,8 +30,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0 h1:YyKFsJqc
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.2 h1:9mnx15oyT0BMRg+tQMh+uqVK32u4r6VtUIBbZMnvEzA=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.2/go.mod h1:b/3BS3zQXQYTgCTPC6VlEmz2aJwDTz6jmhipRZ77MOo=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.3 h1:GBMV9Ubt5Q5kkPY4CZexfUHxaiRr61uLsVxYEo/GYSc=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session v0.21.3/go.mod h1:b/3BS3zQXQYTgCTPC6VlEmz2aJwDTz6jmhipRZ77MOo=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/internal/handlers/dnd5e/session/v1alpha1/afford.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/afford.go
@@ -1,0 +1,34 @@
+package sessionv1alpha1
+
+import (
+	"context"
+
+	sdk "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+
+	sessionpb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/session/v1alpha1"
+)
+
+// Afford reports what one member can still declare this turn: can-or-cannot
+// per verb, the same currency-naming text a refused Attack would use. Asked
+// of a member, never of the session, for the same reason Turn is: the SDK
+// models several clocks running at once, and on the world clock the question
+// does not apply -- Declarations comes back empty, which IS the answer
+// (ADR-0042).
+func (h *Handler) Afford(ctx context.Context, req *sessionpb.AffordRequest) (*sessionpb.AffordResponse, error) {
+	if err := h.callerActingAs(ctx, req.GetMember()); err != nil {
+		return nil, err
+	}
+
+	out, err := h.manager.Afford(ctx, &sdk.AffordInput{
+		Session: req.GetSession(),
+		Member:  req.GetMember(),
+	})
+	if err != nil {
+		return nil, statusError(err)
+	}
+
+	return &sessionpb.AffordResponse{
+		Clock:        clockKindToProto(out.Clock),
+		Declarations: declarationsToProto(out.Declarations),
+	}, nil
+}

--- a/internal/handlers/dnd5e/session/v1alpha1/afford_test.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/afford_test.go
@@ -1,0 +1,93 @@
+package sessionv1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+
+	sdk "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+
+	sessionpb "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/session/v1alpha1"
+	"github.com/KirkDiggler/rpg-api/internal/auth"
+	sessionv1alpha1mock "github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/session/v1alpha1/mock"
+)
+
+func TestAfford_Unauthenticated_Errors(t *testing.T) {
+	h := &Handler{}
+	_, err := h.Afford(context.Background(), &sessionpb.AffordRequest{})
+	requireCode(t, err, codes.Unauthenticated)
+}
+
+// TestAfford_HappyPath_ProjectsDeclarations pins the turn-clock shape,
+// Affordable=false and its Shortfall carried verbatim -- the currency-naming
+// text is the SDK's own wording (ADR-0042), and this layer must not paraphrase
+// it away.
+func TestAfford_HappyPath_ProjectsDeclarations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := sessionv1alpha1mock.NewMockManager(ctrl)
+	mgr.EXPECT().Afford(gomock.Any(), &sdk.AffordInput{Session: "sess-1", Member: "char-1"}).Return(&sdk.AffordOutput{
+		Clock: sdk.ClockTurn,
+		Declarations: []sdk.Declaration{
+			{Verb: sdk.VerbAttack, Slot: sdk.SlotAction, Affordable: false, Shortfall: "action: 1 needed, 0 left"},
+		},
+	}, nil)
+
+	h := &Handler{manager: mgr, characters: anyMemberOwnedBy(ctrl, "alice")}
+	ctx := auth.WithPlayerID(context.Background(), "alice")
+	resp, err := h.Afford(ctx, &sessionpb.AffordRequest{Session: "sess-1", Member: "char-1"})
+	require.NoError(t, err)
+	require.Equal(t, sessionpb.ClockKind_CLOCK_KIND_TURN, resp.GetClock())
+	require.Len(t, resp.GetDeclarations(), 1)
+	decl := resp.GetDeclarations()[0]
+	require.Equal(t, sessionpb.Verb_VERB_ATTACK, decl.GetVerb())
+	require.Equal(t, sessionpb.Slot_SLOT_ACTION, decl.GetSlot())
+	require.False(t, decl.GetAffordable())
+	require.Equal(t, "action: 1 needed, 0 left", decl.GetShortfall())
+}
+
+// TestAfford_WorldClock_DeclarationsEmpty pins the other half of ADR-0042:
+// on the world clock the economy does not apply, and that arrives as an
+// EMPTY repeated field, never a null one -- a client reading "declarations":
+// [] must not mistake it for "unknown" or "ask again".
+func TestAfford_WorldClock_DeclarationsEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := sessionv1alpha1mock.NewMockManager(ctrl)
+	mgr.EXPECT().Afford(gomock.Any(), &sdk.AffordInput{Session: "sess-1", Member: "char-1"}).Return(&sdk.AffordOutput{
+		Clock:        sdk.ClockWorld,
+		Declarations: []sdk.Declaration{},
+	}, nil)
+
+	h := &Handler{manager: mgr, characters: anyMemberOwnedBy(ctrl, "alice")}
+	ctx := auth.WithPlayerID(context.Background(), "alice")
+	resp, err := h.Afford(ctx, &sessionpb.AffordRequest{Session: "sess-1", Member: "char-1"})
+	require.NoError(t, err)
+	require.Equal(t, sessionpb.ClockKind_CLOCK_KIND_WORLD, resp.GetClock())
+	require.NotNil(t, resp.GetDeclarations())
+	require.Empty(t, resp.GetDeclarations())
+}
+
+func TestAfford_ManagerError_TranslatesViaErrorTable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{name: "ErrNoMember", err: sdk.ErrNoMember, want: codes.NotFound},
+		{name: "ErrNoMemberID", err: sdk.ErrNoMemberID, want: codes.InvalidArgument},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mgr := sessionv1alpha1mock.NewMockManager(ctrl)
+			mgr.EXPECT().Afford(gomock.Any(), gomock.Any()).Return(nil, tt.err)
+
+			h := &Handler{manager: mgr, characters: anyMemberOwnedBy(ctrl, "alice")}
+			ctx := auth.WithPlayerID(context.Background(), "alice")
+			_, err := h.Afford(ctx, &sessionpb.AffordRequest{Session: "sess-1", Member: "char-1"})
+			requireCode(t, err, tt.want)
+		})
+	}
+}

--- a/internal/handlers/dnd5e/session/v1alpha1/convert.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/convert.go
@@ -422,3 +422,70 @@ func whereToProto(w *sdk.WhereOutput) *sessionpb.GetWhereResponse {
 	}
 	return &sessionpb.GetWhereResponse{Position: positionToProto(w.Position)}
 }
+
+// verbToProto mirrors session.Verb onto the wire enum. v1 has exactly one
+// entry (VerbAttack); a verb this build does not recognize -- in principle
+// only a future SDK value this handler package has not been updated for,
+// since the SDK's own Verb is a closed enum with no unknown-but-delivered
+// case the way EventKind carries -- maps to VERB_UNSPECIFIED, a producer
+// defect rather than an answer.
+func verbToProto(v sdk.Verb) sessionpb.Verb {
+	switch v {
+	case sdk.VerbAttack:
+		return sessionpb.Verb_VERB_ATTACK
+	default:
+		return sessionpb.Verb_VERB_UNSPECIFIED
+	}
+}
+
+// slotToProto mirrors session.Slot onto the wire enum.
+//
+// SlotNone ("") maps to the EXPLICIT SLOT_NONE, never left to fall through to
+// SLOT_UNSPECIFIED -- the one law this converter exists to keep. A
+// declaration that lights no economy shape (Extra Attack's second swing,
+// spending a banked attack rather than an action/bonus/reaction) is a FACT
+// about the price, the same way Declaration.Affordable=false is an answer and
+// not an absence (types.go). Collapsing it into UNSPECIFIED would tell a
+// client this layer forgot to set a slot, when the SDK answered on purpose.
+// Only a slot string this build does not recognize reaches UNSPECIFIED, a
+// producer defect.
+func slotToProto(s sdk.Slot) sessionpb.Slot {
+	switch s {
+	case sdk.SlotNone:
+		return sessionpb.Slot_SLOT_NONE
+	case sdk.SlotAction:
+		return sessionpb.Slot_SLOT_ACTION
+	case sdk.SlotBonus:
+		return sessionpb.Slot_SLOT_BONUS
+	case sdk.SlotReaction:
+		return sessionpb.Slot_SLOT_REACTION
+	default:
+		return sessionpb.Slot_SLOT_UNSPECIFIED
+	}
+}
+
+// declarationToProto mirrors session.Declaration field-for-field (design rule
+// 3): verb, slot, affordable, shortfall -- no omitempty on Affordable or
+// Shortfall on the wire side either, the same false-vs-absent law the SDK's
+// own doc keeps for both fields.
+func declarationToProto(d sdk.Declaration) *sessionpb.Declaration {
+	return &sessionpb.Declaration{
+		Verb:       verbToProto(d.Verb),
+		Slot:       slotToProto(d.Slot),
+		Affordable: d.Affordable,
+		Shortfall:  d.Shortfall,
+	}
+}
+
+// declarationsToProto mirrors a Declarations list. A nil or empty input
+// becomes a non-nil, zero-length slice, matching the SDK's own "empty IS the
+// answer" law for the world clock (AffordOutput.Declarations never marshals
+// as null) -- the same make-then-loop shape every other list converter in
+// this file keeps, so an empty result already comes out non-nil for free.
+func declarationsToProto(ds []sdk.Declaration) []*sessionpb.Declaration {
+	out := make([]*sessionpb.Declaration, len(ds))
+	for i, d := range ds {
+		out[i] = declarationToProto(d)
+	}
+	return out
+}

--- a/internal/handlers/dnd5e/session/v1alpha1/convert_test.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/convert_test.go
@@ -61,6 +61,57 @@ func TestClockKindToProto(t *testing.T) {
 	require.Equal(t, sessionpb.ClockKind_CLOCK_KIND_UNSPECIFIED, clockKindToProto(sdk.ClockKind("bogus")))
 }
 
+func TestVerbToProto(t *testing.T) {
+	require.Equal(t, sessionpb.Verb_VERB_ATTACK, verbToProto(sdk.VerbAttack))
+	require.Equal(t, sessionpb.Verb_VERB_UNSPECIFIED, verbToProto(sdk.Verb("bogus")))
+}
+
+// TestSlotToProto pins the one law this converter exists to keep: SlotNone
+// ("") is an EXPLICIT SLOT_NONE, never left to fall through to
+// SLOT_UNSPECIFIED. A declaration that lights no economy shape (a banked
+// Extra Attack swing) is a fact about the price, not a producer defect --
+// only an unrecognized slot string reaches UNSPECIFIED.
+func TestSlotToProto(t *testing.T) {
+	require.Equal(t, sessionpb.Slot_SLOT_NONE, slotToProto(sdk.SlotNone))
+	require.Equal(t, sessionpb.Slot_SLOT_ACTION, slotToProto(sdk.SlotAction))
+	require.Equal(t, sessionpb.Slot_SLOT_BONUS, slotToProto(sdk.SlotBonus))
+	require.Equal(t, sessionpb.Slot_SLOT_REACTION, slotToProto(sdk.SlotReaction))
+	require.Equal(t, sessionpb.Slot_SLOT_UNSPECIFIED, slotToProto(sdk.Slot("bogus")))
+}
+
+func TestDeclarationToProto(t *testing.T) {
+	out := declarationToProto(sdk.Declaration{
+		Verb: sdk.VerbAttack, Slot: sdk.SlotAction, Affordable: false, Shortfall: "action: 1 needed, 0 left",
+	})
+	require.Equal(t, sessionpb.Verb_VERB_ATTACK, out.GetVerb())
+	require.Equal(t, sessionpb.Slot_SLOT_ACTION, out.GetSlot())
+	require.False(t, out.GetAffordable())
+	require.Equal(t, "action: 1 needed, 0 left", out.GetShortfall())
+}
+
+// TestDeclarationsToProto_NilOrEmpty_StaysNonNilEmpty pins the "no null,
+// just an empty repeated" law: proto has no null-vs-empty distinction on a
+// repeated field, so a nil SDK slice must still marshal as "[]", never be
+// left nil at the Go level where a naive append-based converter would.
+func TestDeclarationsToProto_NilOrEmpty_StaysNonNilEmpty(t *testing.T) {
+	out := declarationsToProto(nil)
+	require.NotNil(t, out)
+	require.Empty(t, out)
+
+	out = declarationsToProto([]sdk.Declaration{})
+	require.NotNil(t, out)
+	require.Empty(t, out)
+}
+
+func TestDeclarationsToProto_Populated(t *testing.T) {
+	out := declarationsToProto([]sdk.Declaration{
+		{Verb: sdk.VerbAttack, Slot: sdk.SlotNone, Affordable: true},
+	})
+	require.Len(t, out, 1)
+	require.Equal(t, sessionpb.Slot_SLOT_NONE, out[0].GetSlot())
+	require.True(t, out[0].GetAffordable())
+}
+
 func TestDissolveCauseFromProto_ByDecision(t *testing.T) {
 	cause, err := dissolveCauseFromProto(sessionpb.DissolveKind_DISSOLVE_KIND_BY_DECISION)
 	require.NoError(t, err)

--- a/internal/handlers/dnd5e/session/v1alpha1/handler.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/handler.go
@@ -28,6 +28,7 @@ type Manager interface {
 	Exit(ctx context.Context, in *sdk.ExitInput) (*sdk.ExitOutput, error)
 	Move(ctx context.Context, in *sdk.MoveInput) (*sdk.MoveOutput, error)
 	Attack(ctx context.Context, in *sdk.AttackInput) (*sdk.AttackOutput, error)
+	Afford(ctx context.Context, in *sdk.AffordInput) (*sdk.AffordOutput, error)
 	Turn(ctx context.Context, in *sdk.TurnInput) (*sdk.TurnOutput, error)
 	EndTurn(ctx context.Context, in *sdk.EndTurnInput) (*sdk.EndTurnOutput, error)
 	Dissolve(ctx context.Context, in *sdk.DissolveInput) (*sdk.DissolveOutput, error)

--- a/internal/handlers/dnd5e/session/v1alpha1/mock/mock_manager.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/mock/mock_manager.go
@@ -41,6 +41,21 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// Afford mocks base method.
+func (m *MockManager) Afford(ctx context.Context, in *session.AffordInput) (*session.AffordOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Afford", ctx, in)
+	ret0, _ := ret[0].(*session.AffordOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Afford indicates an expected call of Afford.
+func (mr *MockManagerMockRecorder) Afford(ctx, in any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Afford", reflect.TypeOf((*MockManager)(nil).Afford), ctx, in)
+}
+
 // Atlas mocks base method.
 func (m *MockManager) Atlas(ctx context.Context, in *session.AtlasInput) (*session.Atlas, error) {
 	m.ctrl.T.Helper()

--- a/internal/handlers/dnd5e/session/v1alpha1/ownership_test.go
+++ b/internal/handlers/dnd5e/session/v1alpha1/ownership_test.go
@@ -56,6 +56,10 @@ func TestEveryMemberTakingVerbRefusesAForeignMember(t *testing.T) {
 			})
 			return err
 		},
+		"Afford": func(ctx context.Context, h *Handler) error {
+			_, err := h.Afford(ctx, &sessionpb.AffordRequest{Session: "sess-1", Member: foreign})
+			return err
+		},
 		"Turn": func(ctx context.Context, h *Handler) error {
 			_, err := h.Turn(ctx, &sessionpb.TurnRequest{Session: "sess-1", Member: foreign})
 			return err
@@ -120,6 +124,10 @@ func TestEveryMemberTakingVerbRefusesAnEmptyMember(t *testing.T) {
 		},
 		"Attack": func(ctx context.Context, h *Handler) error {
 			_, err := h.Attack(ctx, &sessionpb.AttackRequest{Session: "sess-1", Target: "char-1"})
+			return err
+		},
+		"Afford": func(ctx context.Context, h *Handler) error {
+			_, err := h.Afford(ctx, &sessionpb.AffordRequest{Session: "sess-1"})
 			return err
 		},
 		"GetWhere": func(ctx context.Context, h *Handler) error {


### PR DESCRIPTION
## What

Adds the `Afford` handler to `dnd5e.api.session.v1alpha1.SessionService`: a pure proto <-> SDK translation of `session.Manager.Afford` (toolkit#1138, ADR-0042). Reports what one member can still declare this turn — can-or-cannot per verb, with the same currency-naming text a refused `Attack` would carry — following the exact `Turn`/`Attack` pattern: `callerActingAs(ctx, req.GetMember())`, one `h.manager.Afford` call, `statusError(err)`, project.

## Why

Before this, nothing on the seam said what a member could afford *before* a refusal. A turn UI built against that had two options: fire the button and let the server say no, or re-derive 5e's action economy client-side — the Boundary Rule violation the whole seam exists to prevent. `Afford` closes that gap with a read-only declaration, never a second price: it reads off the exact `SpendProfile` a real `Attack` would pay through, so `Attack` and `Afford` can never disagree by construction.

## The SLOT_NONE law

`session.SlotNone` (`""`) maps to the **explicit** `SLOT_NONE`, never left to fall through to `SLOT_UNSPECIFIED`. A declaration that lights no economy shape (e.g. Extra Attack's second swing, spending a banked attack rather than an action/bonus/reaction) is a *fact about the price*, not a producer defect — collapsing it into `UNSPECIFIED` would tell a client this layer forgot to set a slot when the SDK answered on purpose. Only an unrecognized slot/verb string reaches `UNSPECIFIED`.

`declarationsToProto` returns a non-nil, zero-length slice for nil/empty input — proto has no null-vs-empty distinction on a repeated field, and the SDK's own "empty IS the answer" law for the world clock (`AffordOutput.Declarations` never marshals as null) carries straight through.

## Changes

- `go.mod`/`go.sum`: `rpg-api-protos/gen/go` → v0.1.130's generated commit; `rpg-toolkit/rulebooks/dnd5e/session` → v0.21.3.
- `internal/handlers/dnd5e/session/v1alpha1/handler.go`: `Afford` added to the `Manager` interface.
- `internal/handlers/dnd5e/session/v1alpha1/afford.go`: the handler.
- `internal/handlers/dnd5e/session/v1alpha1/convert.go`: `verbToProto`, `slotToProto`, `declarationToProto`/`declarationsToProto`.
- `internal/handlers/dnd5e/session/v1alpha1/mock/mock_manager.go`: regenerated to carry `Afford`.
- Tests: `afford_test.go` (happy path incl. `Affordable=false` + `Shortfall` verbatim, world-clock empty declarations, error-table translation for `ErrNoMember`/`ErrNoMemberID`), `convert_test.go` cases for the two enum mappers plus `declarationsToProto`'s nil/empty law, and `Afford` added to `ownership_test.go`'s foreign-member/empty-member tables so the caller-binding guard covers it too.

## Evidence

Package tests, verbose:

```
=== RUN   TestAfford_Unauthenticated_Errors
--- PASS: TestAfford_Unauthenticated_Errors (0.00s)
=== RUN   TestAfford_HappyPath_ProjectsDeclarations
--- PASS: TestAfford_HappyPath_ProjectsDeclarations (0.00s)
=== RUN   TestAfford_WorldClock_DeclarationsEmpty
--- PASS: TestAfford_WorldClock_DeclarationsEmpty (0.00s)
=== RUN   TestAfford_ManagerError_TranslatesViaErrorTable
=== RUN   TestAfford_ManagerError_TranslatesViaErrorTable/ErrNoMember
=== RUN   TestAfford_ManagerError_TranslatesViaErrorTable/ErrNoMemberID
--- PASS: TestAfford_ManagerError_TranslatesViaErrorTable (0.00s)
...
=== RUN   TestEveryMemberTakingVerbRefusesAForeignMember/Afford
--- PASS: TestEveryMemberTakingVerbRefusesAForeignMember/Afford (0.00s)
=== RUN   TestEveryMemberTakingVerbRefusesAnEmptyMember/Afford
--- PASS: TestEveryMemberTakingVerbRefusesAnEmptyMember/Afford (0.00s)
PASS
ok  	github.com/KirkDiggler/rpg-api/internal/handlers/dnd5e/session/v1alpha1	0.130s
```

Full repo `go test ./...` passes. `golangci-lint run ./internal/handlers/dnd5e/session/v1alpha1/...` reports 0 issues; the repo-wide `scripts/ci-checks.sh` lint step flags 3 pre-existing findings in `internal/integration/harness/harness.go` and `internal/handlers/dnd5e/v1alpha1/character/handler.go`, untouched by this diff (confirmed against origin/dev) — GitHub Actions CI does not run golangci-lint at all (only release-pin verification, codegen, and `go test`), so this isn't a gate for this PR.

**Live smoke** (isolated throwaway Redis + server instance on a spare port, no shared state touched): drove `CharacterService` draft→finalize, `LobbyService.CreateLobby`→`SetReady`→`StartEncounter` against the reference tomb, then called `Afford` for the seated member before any fight starts:

```json
{
  "clock": "CLOCK_KIND_WORLD",
  "declarations": []
}
```

Confirms the world-clock law live: `Declarations` marshals as an empty array, never null.

— asset-pipeline agent, on behalf of KirkDiggler
