### PR TITLE
fix(character): FinalizeDraft equips the chosen weapons (#746)

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -1342,12 +1342,18 @@ func convertEquipmentSlotToToolkit(slot dnd5ev1alpha1.EquipmentSlot) (toolkitcha
 	}
 }
 
-// convertEquipmentSlotsToProto converts toolkit EquipmentSlots to proto EquipmentSlots
+// convertEquipmentSlotsToProto converts toolkit EquipmentSlots to proto
+// EquipmentSlots.
+//
+// ALWAYS returns a non-nil message, even when nothing is equipped
+// (rpg-api#746): a nil *EquipmentSlots marshals on the wire as
+// "equipment_slots": null, which is a producer defect indistinguishable
+// from "this layer forgot to set it" -- the same false-vs-absent law the
+// per-slot fields already keep by leaving an empty slot's InventoryItem nil
+// rather than a zero-valued one. Every real (non-devseed) character
+// finalized with nothing equipped until rpg-api#746's FinalizeDraft fix, so
+// this was reachable on every one of them.
 func convertEquipmentSlotsToProto(slots toolkitchar.EquipmentSlots) *dnd5ev1alpha1.EquipmentSlots {
-	if len(slots) == 0 {
-		return nil
-	}
-
 	// Helper to create InventoryItem from item ID
 	makeItem := func(itemID string) *dnd5ev1alpha1.InventoryItem {
 		if itemID == "" {

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -1092,3 +1092,43 @@ func (s *ConvertersTestSuite) TestConvertRaceTraitsToProto_Discriminates() {
 	assert.False(s.T(), result[0].GetIsChoice())
 	assert.Empty(s.T(), result[0].GetOptions())
 }
+
+// TestConvertEquipmentSlotsToProto_Nil_ReturnsNonNilEmptyStruct pins
+// rpg-api#746's other half: a character with nothing equipped must still
+// marshal "equipment_slots" as an empty object, never null. A nil pointer
+// here IS the producer defect the issue reported -- "equipment_slots: null
+// (not even an empty object)" -- on every real character before finalize
+// learned to auto-equip.
+func (s *ConvertersTestSuite) TestConvertEquipmentSlotsToProto_Nil_ReturnsNonNilEmptyStruct() {
+	result := convertEquipmentSlotsToProto(nil)
+	require.NotNil(s.T(), result, "must return a non-nil EquipmentSlots even when nothing is equipped")
+	assert.Nil(s.T(), result.GetMainHand())
+	assert.Nil(s.T(), result.GetOffHand())
+	assert.Nil(s.T(), result.GetArmor())
+}
+
+// TestConvertEquipmentSlotsToProto_Empty_ReturnsNonNilEmptyStruct is the
+// same pin against an explicitly empty (non-nil) map, the shape
+// EquipItem/UnequipItem produce once anything has ever been touched.
+func (s *ConvertersTestSuite) TestConvertEquipmentSlotsToProto_Empty_ReturnsNonNilEmptyStruct() {
+	result := convertEquipmentSlotsToProto(toolkitchar.EquipmentSlots{})
+	require.NotNil(s.T(), result)
+	assert.Nil(s.T(), result.GetMainHand())
+}
+
+// TestConvertEquipmentSlotsToProto_Populated_StillMapsFields is the existing
+// happy path, pinned alongside the two empty cases above so a future edit
+// cannot fix null-vs-empty by returning a populated struct unconditionally
+// and dropping real slot data.
+func (s *ConvertersTestSuite) TestConvertEquipmentSlotsToProto_Populated_StillMapsFields() {
+	result := convertEquipmentSlotsToProto(toolkitchar.EquipmentSlots{
+		toolkitchar.SlotMainHand: "longsword",
+		toolkitchar.SlotArmor:    "chain-mail",
+	})
+	require.NotNil(s.T(), result)
+	require.NotNil(s.T(), result.GetMainHand())
+	assert.Equal(s.T(), "longsword", result.GetMainHand().GetItemId())
+	require.NotNil(s.T(), result.GetArmor())
+	assert.Equal(s.T(), "chain-mail", result.GetArmor().GetItemId())
+	assert.Nil(s.T(), result.GetOffHand())
+}

--- a/internal/orchestrators/character/auto_equip.go
+++ b/internal/orchestrators/character/auto_equip.go
@@ -1,0 +1,153 @@
+package character
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// primaryWeaponChoiceIDs names every class's "which weapon(s) do you carry"
+// equipment choice, spelled out from the toolkit's own exported ChoiceID
+// constants (character/choices/choice_ids.go) rather than pattern-matched:
+// 11 of 12 classes name theirs "<Class>WeaponsPrimary", but Cleric's is
+// "cleric-weapons" (no Primary suffix), so a suffix match would silently
+// skip Clerics. If the toolkit adds a 13th class this map does not follow
+// automatically -- there is no exported way to enumerate it from outside
+// the choices package (getXEquipmentRequirements is unexported) -- so a new
+// class's fighter-shaped bug (chosen weapon never equipped) would need a
+// line added here. Acceptable for an interim fix; see rpg-api#746.
+var primaryWeaponChoiceIDs = map[choices.ChoiceID]bool{
+	choices.FighterWeaponsPrimary:   true,
+	choices.BarbarianWeaponsPrimary: true,
+	choices.RogueWeaponsPrimary:     true,
+	choices.WizardWeaponsPrimary:    true,
+	choices.ClericWeapons:           true,
+	choices.BardWeaponsPrimary:      true,
+	choices.DruidWeaponsPrimary:     true,
+	choices.MonkWeaponsPrimary:      true,
+	choices.PaladinWeaponsPrimary:   true,
+	choices.RangerWeaponsPrimary:    true,
+	choices.SorcererWeaponsPrimary:  true,
+	choices.WarlockWeaponsPrimary:   true,
+}
+
+// armorChoiceIDs names the classes that offer a distinct body-armor
+// equipment choice today -- only Fighter, Cleric and Ranger
+// (character/choices/choice_ids.go); every other class either wears no
+// armor by class design (casters, Monk, Barbarian's Unarmored Defense) or
+// has no separate armor pick to auto-equip from.
+var armorChoiceIDs = map[choices.ChoiceID]bool{
+	choices.FighterArmor: true,
+	choices.ClericArmor:  true,
+	choices.RangerArmor:  true,
+}
+
+// autoEquipChosenGear puts a freshly finalized character's primary-weapon
+// and (where the class has one) armor picks into their slots -- see
+// rpg-api#746. Before this, FinalizeDraft never called EquipItem at all:
+// only cmd/devseed's hand-written fixtures set EquipmentSlots directly in
+// Go, so every character created through the real API (draft -> finalize,
+// the only path a player uses) finalized with nothing equipped and fought
+// unarmed regardless of what was chosen.
+//
+// Deliberately narrow, matching the issue's own interim-fix framing: only
+// the class's declared PRIMARY weapon choice and its distinct ARMOR choice
+// (if any) are auto-equipped. A shield bundled into the same weapon choice
+// (Fighter's "martial weapon + shield" option) is left alone on purpose --
+// EquipItem is still the one path that equips a shield (see
+// cmd/sandboxseed), and this function is idempotent with it: a shield left
+// unequipped here still equips cleanly into the off hand afterward. The
+// fuller design -- gearing up in the lobby, writing these same
+// equipment_slots from a player's own choice of what to carry -- is
+// separate, deferred work (see the issue).
+//
+// No slot legality is decided here. Every placement goes through
+// char.EquipItem, the exact call EquipItem (the RPC) and the toolkit's own
+// occupancy rules (two-handed clears/blocks the off hand, an incompatible
+// slot is refused) already run through -- see character.CompatibleSlots's
+// doc: "rpg-api must not reconstruct this rule itself." This function only
+// decides WHICH choice's items are candidates and which slot to try first;
+// a refusal from EquipItem (item doesn't fit, e.g. a resolved id that turns
+// out to not be equipment) is swallowed rather than failing finalize --
+// leaving that one slot unequipped is a strictly better failure mode than
+// blocking character creation over a gearing detail.
+func autoEquipChosenGear(draftChoices []choices.ChoiceData, char *character.Character) {
+	for _, choice := range draftChoices {
+		if choice.Category != shared.ChoiceEquipment {
+			continue
+		}
+		switch {
+		case primaryWeaponChoiceIDs[choice.ChoiceID]:
+			equipChosenWeapons(choice.EquipmentSelection, char)
+		case armorChoiceIDs[choice.ChoiceID]:
+			equipChosenArmor(choice.EquipmentSelection, char)
+		}
+	}
+}
+
+// equipChosenWeapons equips the weapon-typed items among a primary-weapon
+// choice's resolved selection: the first into the main hand (a two-handed
+// weapon claims it alone -- EquipItem's own rule), a second ONE-HANDED
+// weapon into the off hand if nothing has claimed it yet. Non-weapon items
+// resolved from the same choice (a bundled shield) are skipped -- see this
+// file's package doc comment for why.
+func equipChosenWeapons(itemIDs []shared.SelectionID, char *character.Character) {
+	mainHandSet := false
+	for _, id := range itemIDs {
+		item, err := equipment.GetByID(id)
+		if err != nil || !isWeaponCandidate(item) {
+			continue
+		}
+		if !mainHandSet {
+			if err := char.EquipItem(character.SlotMainHand, id); err == nil {
+				mainHandSet = true
+			}
+			continue
+		}
+		// A second weapon: try the off hand. EquipItem refuses this on its
+		// own if the main hand ended up holding a two-handed weapon, or if
+		// this item cannot go there (equipmentFitsSlot) -- nothing here
+		// re-decides that.
+		_ = char.EquipItem(character.SlotOffHand, id)
+	}
+}
+
+// equipChosenArmor equips the first body-armor item (never a shield) among
+// an armor choice's resolved selection into the armor slot.
+func equipChosenArmor(itemIDs []shared.SelectionID, char *character.Character) {
+	for _, id := range itemIDs {
+		item, err := equipment.GetByID(id)
+		if err != nil || !isArmorCandidate(item) {
+			continue
+		}
+		if err := char.EquipItem(character.SlotArmor, id); err == nil {
+			return
+		}
+	}
+}
+
+// isWeaponCandidate reports whether item is a weapon (fits the main hand) --
+// true for both one- and two-handed weapons, false for a shield (off hand
+// only) or body armor (armor only). Reads the answer off
+// character.CompatibleSlots, the toolkit's single source of truth for slot
+// fit, rather than inspecting item properties directly.
+func isWeaponCandidate(item equipment.Equipment) bool {
+	return slotsInclude(character.CompatibleSlots(item), character.SlotMainHand)
+}
+
+// isArmorCandidate reports whether item is body armor (fits the armor
+// slot) -- false for a shield, which fits the off hand instead. See
+// isWeaponCandidate.
+func isArmorCandidate(item equipment.Equipment) bool {
+	return slotsInclude(character.CompatibleSlots(item), character.SlotArmor)
+}
+
+func slotsInclude(slots []character.InventorySlot, target character.InventorySlot) bool {
+	for _, s := range slots {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrators/character/auto_equip.go
+++ b/internal/orchestrators/character/auto_equip.go
@@ -16,7 +16,10 @@ import (
 // automatically -- there is no exported way to enumerate it from outside
 // the choices package (getXEquipmentRequirements is unexported) -- so a new
 // class's fighter-shaped bug (chosen weapon never equipped) would need a
-// line added here. Acceptable for an interim fix; see rpg-api#746.
+// line added here. Filed as rpg-toolkit#1164 (an exported Role/Kind on
+// EquipmentRequirement, or an exported per-class accessor, would let this
+// map be derived instead of hand-copied); acceptable for this interim fix
+// in the meantime. See rpg-api#746.
 var primaryWeaponChoiceIDs = map[choices.ChoiceID]bool{
 	choices.FighterWeaponsPrimary:   true,
 	choices.BarbarianWeaponsPrimary: true,
@@ -36,7 +39,7 @@ var primaryWeaponChoiceIDs = map[choices.ChoiceID]bool{
 // equipment choice today -- only Fighter, Cleric and Ranger
 // (character/choices/choice_ids.go); every other class either wears no
 // armor by class design (casters, Monk, Barbarian's Unarmored Defense) or
-// has no separate armor pick to auto-equip from.
+// has no separate armor pick to auto-equip from. See rpg-toolkit#1164.
 var armorChoiceIDs = map[choices.ChoiceID]bool{
 	choices.FighterArmor: true,
 	choices.ClericArmor:  true,
@@ -52,15 +55,12 @@ var armorChoiceIDs = map[choices.ChoiceID]bool{
 // unarmed regardless of what was chosen.
 //
 // Deliberately narrow, matching the issue's own interim-fix framing: only
-// the class's declared PRIMARY weapon choice and its distinct ARMOR choice
-// (if any) are auto-equipped. A shield bundled into the same weapon choice
-// (Fighter's "martial weapon + shield" option) is left alone on purpose --
-// EquipItem is still the one path that equips a shield (see
-// cmd/sandboxseed), and this function is idempotent with it: a shield left
-// unequipped here still equips cleanly into the off hand afterward. The
-// fuller design -- gearing up in the lobby, writing these same
-// equipment_slots from a player's own choice of what to carry -- is
-// separate, deferred work (see the issue).
+// the class's declared PRIMARY weapon choice (main hand, plus off hand for
+// a second one-handed weapon or a bundled shield -- see equipChosenWeapons)
+// and its distinct ARMOR choice (if any) are auto-equipped. The fuller
+// design -- gearing up in the lobby, writing these same equipment_slots
+// from a player's own choice of what to carry -- is separate, deferred
+// work (see the issue).
 //
 // No slot legality is decided here. Every placement goes through
 // char.EquipItem, the exact call EquipItem (the RPC) and the toolkit's own
@@ -86,30 +86,60 @@ func autoEquipChosenGear(draftChoices []choices.ChoiceData, char *character.Char
 	}
 }
 
-// equipChosenWeapons equips the weapon-typed items among a primary-weapon
-// choice's resolved selection: the first into the main hand (a two-handed
-// weapon claims it alone -- EquipItem's own rule), a second ONE-HANDED
-// weapon into the off hand if nothing has claimed it yet. Non-weapon items
-// resolved from the same choice (a bundled shield) are skipped -- see this
-// file's package doc comment for why.
+// equipChosenWeapons equips gear resolved from a primary-weapon choice: the
+// first weapon into the main hand, then -- ONLY if that weapon is one-
+// handed (character.CompatibleSlots says whether it also fits the off
+// hand) -- whatever else the SAME choice granted to fill the off hand with:
+// a second weapon (dual wield) if the choice resolved one, else a bundled
+// shield (Fighter's "a martial weapon and a shield" option, where the
+// shield rides in the same EquipmentSelection as the category-resolved
+// weapon). Each hand is attempted AT MOST ONCE -- unlike an unbounded loop
+// over every remaining candidate, which would let EquipItem's own
+// swap-on-occupied rule silently move a THIRD candidate into the off hand
+// and overwrite the second (caught in review on this PR).
+//
+// A two-handed main-hand pick claims the hand alone: CompatibleSlots
+// excludes the off hand for it, and the off hand is never attempted in that
+// case -- attempting it anyway would hit EquipItem's "main hand holding a
+// two-handed weapon blocks the off hand until something is equipped there,
+// which frees the main hand" rule and CLEAR the two-hander, exactly
+// backwards from what should happen here.
 func equipChosenWeapons(itemIDs []shared.SelectionID, char *character.Character) {
-	mainHandSet := false
+	var weaponIDs []shared.SelectionID
+	var shieldID shared.SelectionID
 	for _, id := range itemIDs {
 		item, err := equipment.GetByID(id)
-		if err != nil || !isWeaponCandidate(item) {
+		if err != nil {
 			continue
 		}
-		if !mainHandSet {
-			if err := char.EquipItem(character.SlotMainHand, id); err == nil {
-				mainHandSet = true
-			}
-			continue
+		slots := character.CompatibleSlots(item)
+		switch {
+		case slotsInclude(slots, character.SlotMainHand):
+			weaponIDs = append(weaponIDs, id)
+		case shieldID == "" && slotsInclude(slots, character.SlotOffHand):
+			shieldID = id
 		}
-		// A second weapon: try the off hand. EquipItem refuses this on its
-		// own if the main hand ended up holding a two-handed weapon, or if
-		// this item cannot go there (equipmentFitsSlot) -- nothing here
-		// re-decides that.
-		_ = char.EquipItem(character.SlotOffHand, id)
+	}
+	if len(weaponIDs) == 0 {
+		return
+	}
+
+	mainID := weaponIDs[0]
+	if err := char.EquipItem(character.SlotMainHand, mainID); err != nil {
+		return
+	}
+
+	mainItem, err := equipment.GetByID(mainID)
+	if err != nil || !slotsInclude(character.CompatibleSlots(mainItem), character.SlotOffHand) {
+		return // two-handed (or unresolvable): this choice has nothing more to place
+	}
+
+	if len(weaponIDs) > 1 {
+		_ = char.EquipItem(character.SlotOffHand, weaponIDs[1])
+		return
+	}
+	if shieldID != "" {
+		_ = char.EquipItem(character.SlotOffHand, shieldID)
 	}
 }
 
@@ -118,29 +148,13 @@ func equipChosenWeapons(itemIDs []shared.SelectionID, char *character.Character)
 func equipChosenArmor(itemIDs []shared.SelectionID, char *character.Character) {
 	for _, id := range itemIDs {
 		item, err := equipment.GetByID(id)
-		if err != nil || !isArmorCandidate(item) {
+		if err != nil || !slotsInclude(character.CompatibleSlots(item), character.SlotArmor) {
 			continue
 		}
 		if err := char.EquipItem(character.SlotArmor, id); err == nil {
 			return
 		}
 	}
-}
-
-// isWeaponCandidate reports whether item is a weapon (fits the main hand) --
-// true for both one- and two-handed weapons, false for a shield (off hand
-// only) or body armor (armor only). Reads the answer off
-// character.CompatibleSlots, the toolkit's single source of truth for slot
-// fit, rather than inspecting item properties directly.
-func isWeaponCandidate(item equipment.Equipment) bool {
-	return slotsInclude(character.CompatibleSlots(item), character.SlotMainHand)
-}
-
-// isArmorCandidate reports whether item is body armor (fits the armor
-// slot) -- false for a shield, which fits the off hand instead. See
-// isWeaponCandidate.
-func isArmorCandidate(item equipment.Equipment) bool {
-	return slotsInclude(character.CompatibleSlots(item), character.SlotArmor)
 }
 
 func slotsInclude(slots []character.InventorySlot, target character.InventorySlot) bool {

--- a/internal/orchestrators/character/auto_equip_test.go
+++ b/internal/orchestrators/character/auto_equip_test.go
@@ -1,0 +1,144 @@
+package character
+
+import (
+	"context"
+
+	"github.com/KirkDiggler/rpg-api/internal/entities"
+	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
+	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"go.uber.org/mock/gomock"
+)
+
+// finalizeAndCapture drives FinalizeDraft for the given (already-complete)
+// draft through the orchestrator's mocked repos and returns the character
+// actually handed to characterRepo.Create -- the same object GetCharacter
+// would later read back.
+func (s *OrchestratorTestSuite) finalizeAndCapture(draft *character.Draft) *character.Data {
+	draftID := draft.ID()
+
+	s.mockDraftRepo.EXPECT().Get(s.ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, input characterdraft.GetInput) (*characterdraft.GetOutput, error) {
+			s.Assert().Equal(draftID, input.ID)
+			return &characterdraft.GetOutput{Draft: &entities.CharacterDraft{Data: draft.ToData()}}, nil
+		})
+	s.mockIDGen.EXPECT().Generate().Return(s.testCharacterID)
+
+	var saved *entities.Character
+	s.mockCharacterRepo.EXPECT().Create(s.ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, input characterrepo.CreateInput) (*characterrepo.CreateOutput, error) {
+			saved = input.Character
+			return &characterrepo.CreateOutput{Character: input.Character}, nil
+		})
+	s.mockDraftRepo.EXPECT().Delete(s.ctx, gomock.Any()).Return(&characterdraft.DeleteOutput{}, nil)
+
+	output, err := s.orchestrator.FinalizeDraft(s.ctx, &FinalizeDraftInput{DraftID: draftID})
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+	s.Require().NotNil(saved)
+	return saved.Data
+}
+
+// TestFinalizeDraft_EquipsChosenPrimaryWeaponAndArmor pins rpg-api#746's
+// central claim: a Fighter who chose "a martial weapon and a shield" (the
+// longsword) plus chain mail finalizes with the longsword already in the
+// main hand and the chain mail already in the armor slot -- no follow-up
+// EquipItem call required, which is exactly what the real (non-devseed)
+// creation flow never makes today. The shield bundled into the SAME weapon
+// choice is deliberately left unequipped (see auto_equip.go's doc) -- this
+// also pins that half: off hand stays empty here, and a subsequent EquipItem
+// call for it is proven separately (TestFinalizeDraft_ShieldStillEquipsAfterward).
+func (s *OrchestratorTestSuite) TestFinalizeDraft_EquipsChosenPrimaryWeaponAndArmor() {
+	draft := s.createTestDraft("draft-equip-fighter", s.testPlayerID)
+	s.Require().NoError(draft.SetName(&character.SetNameInput{Name: "Sir Roland"}))
+	s.Require().NoError(draft.SetRace(s.validHuman))
+	s.Require().NoError(draft.SetClass(s.validFighter))
+	s.Require().NoError(draft.SetBackground(s.validSoldier))
+	s.Require().NoError(draft.SetAbilityScores(s.validFighterScores))
+
+	data := s.finalizeAndCapture(draft)
+
+	s.Equal("longsword", data.EquipmentSlots.Get(character.SlotMainHand))
+	s.Equal("chain-mail", data.EquipmentSlots.Get(character.SlotArmor))
+	s.Empty(data.EquipmentSlots.Get(character.SlotOffHand),
+		"the bundled shield is not auto-equipped by finalize -- EquipItem still does that")
+}
+
+// TestFinalizeDraft_TwoHandedWeapon_EquipsMainHandOnly pins the two-handed
+// rule from the issue's own algorithm: a Barbarian who chose the Greataxe
+// finalizes with it in the main hand and NOTHING in the off hand -- the
+// toolkit's own EquipItem occupancy rule (a two-handed weapon claims the
+// main hand and forces the off hand empty), never re-decided here.
+func (s *OrchestratorTestSuite) TestFinalizeDraft_TwoHandedWeapon_EquipsMainHandOnly() {
+	draft := s.createTestDraft("draft-equip-barbarian", s.testPlayerID)
+	s.Require().NoError(draft.SetName(&character.SetNameInput{Name: "Grosh"}))
+	s.Require().NoError(draft.SetRace(s.validHuman))
+	s.Require().NoError(draft.SetClass(&character.SetClassInput{
+		ClassID: classes.Barbarian,
+		Choices: character.ClassChoices{
+			Skills: []skills.Skill{skills.Athletics, skills.Intimidation},
+			Equipment: []character.EquipmentChoiceSelection{
+				{ChoiceID: choices.BarbarianWeaponsPrimary, OptionID: "barbarian-weapon-a"}, // Greataxe
+				{ChoiceID: choices.BarbarianWeaponsSecondary, OptionID: "barbarian-secondary-a"},
+				{ChoiceID: choices.BarbarianPack, OptionID: "barbarian-pack-a"},
+			},
+		},
+	}))
+	s.Require().NoError(draft.SetBackground(s.validSoldier))
+	s.Require().NoError(draft.SetAbilityScores(&character.SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 15, abilities.DEX: 13, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		Method: "standard",
+	}))
+
+	data := s.finalizeAndCapture(draft)
+
+	s.Equal("greataxe", data.EquipmentSlots.Get(character.SlotMainHand))
+	s.Empty(data.EquipmentSlots.Get(character.SlotOffHand))
+}
+
+// TestFinalizeDraft_ShieldStillEquipsAfterward proves the idempotency the
+// issue's fix candidate explicitly requires: a shield finalize deliberately
+// left unequipped (see auto_equip.go) still equips cleanly into the off
+// hand through a normal EquipItem call afterward -- the same call
+// cmd/sandboxseed makes today, and the same behavior GetCharacter's caller
+// relies on.
+func (s *OrchestratorTestSuite) TestFinalizeDraft_ShieldStillEquipsAfterward() {
+	draft := s.createTestDraft("draft-equip-shield-after", s.testPlayerID)
+	s.Require().NoError(draft.SetName(&character.SetNameInput{Name: "Dame Elara"}))
+	s.Require().NoError(draft.SetRace(s.validHuman))
+	s.Require().NoError(draft.SetClass(s.validFighter))
+	s.Require().NoError(draft.SetBackground(s.validSoldier))
+	s.Require().NoError(draft.SetAbilityScores(s.validFighterScores))
+
+	data := s.finalizeAndCapture(draft)
+	s.Empty(data.EquipmentSlots.Get(character.SlotOffHand))
+
+	s.mockCharacterRepo.EXPECT().Get(s.ctx, gomock.Any()).Return(
+		&characterrepo.GetOutput{Character: &entities.Character{Data: data}}, nil)
+	var updated *entities.Character
+	s.mockCharacterRepo.EXPECT().Update(s.ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, input characterrepo.UpdateInput) (*characterrepo.UpdateOutput, error) {
+			updated = input.Character
+			return &characterrepo.UpdateOutput{Character: input.Character}, nil
+		})
+
+	_, err := s.orchestrator.EquipItem(s.ctx, &EquipItemInput{
+		CharacterID: s.testCharacterID,
+		ItemID:      "shield",
+		Slot:        character.SlotOffHand,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(updated)
+	s.Equal("shield", updated.Data.EquipmentSlots.Get(character.SlotOffHand))
+	// The weapon auto-equipped at finalize is untouched by this later call.
+	s.Equal("longsword", updated.Data.EquipmentSlots.Get(character.SlotMainHand))
+}
+

--- a/internal/orchestrators/character/auto_equip_test.go
+++ b/internal/orchestrators/character/auto_equip_test.go
@@ -3,6 +3,8 @@ package character
 import (
 	"context"
 
+	"go.uber.org/mock/gomock"
+
 	"github.com/KirkDiggler/rpg-api/internal/entities"
 	characterrepo "github.com/KirkDiggler/rpg-api/internal/repositories/character"
 	characterdraft "github.com/KirkDiggler/rpg-api/internal/repositories/character_draft"
@@ -12,7 +14,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
-	"go.uber.org/mock/gomock"
 )
 
 // finalizeAndCapture drives FinalizeDraft for the given (already-complete)
@@ -141,4 +142,3 @@ func (s *OrchestratorTestSuite) TestFinalizeDraft_ShieldStillEquipsAfterward() {
 	// The weapon auto-equipped at finalize is untouched by this later call.
 	s.Equal("longsword", updated.Data.EquipmentSlots.Get(character.SlotMainHand))
 }
-

--- a/internal/orchestrators/character/auto_equip_test.go
+++ b/internal/orchestrators/character/auto_equip_test.go
@@ -45,16 +45,17 @@ func (s *OrchestratorTestSuite) finalizeAndCapture(draft *character.Draft) *char
 	return saved.Data
 }
 
-// TestFinalizeDraft_EquipsChosenPrimaryWeaponAndArmor pins rpg-api#746's
+// TestFinalizeDraft_EquipsChosenPrimaryWeaponArmorAndShield pins rpg-api#746's
 // central claim: a Fighter who chose "a martial weapon and a shield" (the
-// longsword) plus chain mail finalizes with the longsword already in the
-// main hand and the chain mail already in the armor slot -- no follow-up
-// EquipItem call required, which is exactly what the real (non-devseed)
-// creation flow never makes today. The shield bundled into the SAME weapon
-// choice is deliberately left unequipped (see auto_equip.go's doc) -- this
-// also pins that half: off hand stays empty here, and a subsequent EquipItem
-// call for it is proven separately (TestFinalizeDraft_ShieldStillEquipsAfterward).
-func (s *OrchestratorTestSuite) TestFinalizeDraft_EquipsChosenPrimaryWeaponAndArmor() {
+// longsword) plus chain mail finalizes with the longsword in the main hand,
+// the shield in the off hand, and the chain mail in the armor slot -- no
+// follow-up EquipItem call required, which is exactly what the real
+// (non-devseed) creation flow never makes today. The shield rides in the
+// SAME EquipmentSelection as the category-resolved weapon (buildEquipmentList
+// puts option.Items before the category pick), and equipChosenWeapons equips
+// it into the off hand precisely because the longsword is one-handed and
+// nothing else claimed that hand first.
+func (s *OrchestratorTestSuite) TestFinalizeDraft_EquipsChosenPrimaryWeaponArmorAndShield() {
 	draft := s.createTestDraft("draft-equip-fighter", s.testPlayerID)
 	s.Require().NoError(draft.SetName(&character.SetNameInput{Name: "Sir Roland"}))
 	s.Require().NoError(draft.SetRace(s.validHuman))
@@ -65,9 +66,8 @@ func (s *OrchestratorTestSuite) TestFinalizeDraft_EquipsChosenPrimaryWeaponAndAr
 	data := s.finalizeAndCapture(draft)
 
 	s.Equal("longsword", data.EquipmentSlots.Get(character.SlotMainHand))
+	s.Equal("shield", data.EquipmentSlots.Get(character.SlotOffHand))
 	s.Equal("chain-mail", data.EquipmentSlots.Get(character.SlotArmor))
-	s.Empty(data.EquipmentSlots.Get(character.SlotOffHand),
-		"the bundled shield is not auto-equipped by finalize -- EquipItem still does that")
 }
 
 // TestFinalizeDraft_TwoHandedWeapon_EquipsMainHandOnly pins the two-handed
@@ -105,14 +105,18 @@ func (s *OrchestratorTestSuite) TestFinalizeDraft_TwoHandedWeapon_EquipsMainHand
 	s.Empty(data.EquipmentSlots.Get(character.SlotOffHand))
 }
 
-// TestFinalizeDraft_ShieldStillEquipsAfterward proves the idempotency the
-// issue's fix candidate explicitly requires: a shield finalize deliberately
-// left unequipped (see auto_equip.go) still equips cleanly into the off
-// hand through a normal EquipItem call afterward -- the same call
-// cmd/sandboxseed makes today, and the same behavior GetCharacter's caller
-// relies on.
-func (s *OrchestratorTestSuite) TestFinalizeDraft_ShieldStillEquipsAfterward() {
-	draft := s.createTestDraft("draft-equip-shield-after", s.testPlayerID)
+// TestFinalizeDraft_ReEquippingTheAlreadyEquippedShieldIsHarmless proves the
+// idempotency Kirk's gate review asked for: cmd/sandboxseed calls EquipItem
+// for the shield unconditionally, on every seed run, regardless of whether
+// finalize already put it there. A second EquipItem for the SAME item
+// already in that slot must be a harmless no-op (not an error, not a swap
+// that clears the main hand) -- and it already is, by EquipItem's own
+// existing logic: with a single copy owned, it clears every slot currently
+// holding that item id before resetting it, which nets out to the same
+// state. No new toolkit rule needed; this test exists to pin that fact
+// rather than assume it.
+func (s *OrchestratorTestSuite) TestFinalizeDraft_ReEquippingTheAlreadyEquippedShieldIsHarmless() {
+	draft := s.createTestDraft("draft-equip-shield-reequip", s.testPlayerID)
 	s.Require().NoError(draft.SetName(&character.SetNameInput{Name: "Dame Elara"}))
 	s.Require().NoError(draft.SetRace(s.validHuman))
 	s.Require().NoError(draft.SetClass(s.validFighter))
@@ -120,7 +124,7 @@ func (s *OrchestratorTestSuite) TestFinalizeDraft_ShieldStillEquipsAfterward() {
 	s.Require().NoError(draft.SetAbilityScores(s.validFighterScores))
 
 	data := s.finalizeAndCapture(draft)
-	s.Empty(data.EquipmentSlots.Get(character.SlotOffHand))
+	s.Equal("shield", data.EquipmentSlots.Get(character.SlotOffHand), "finalize already equipped it")
 
 	s.mockCharacterRepo.EXPECT().Get(s.ctx, gomock.Any()).Return(
 		&characterrepo.GetOutput{Character: &entities.Character{Data: data}}, nil)

--- a/internal/orchestrators/character/orchestrator.go
+++ b/internal/orchestrators/character/orchestrator.go
@@ -704,6 +704,14 @@ func (o *Orchestrator) FinalizeDraft(ctx context.Context, input *FinalizeDraftIn
 		return nil, fmt.Errorf("failed to convert draft to character: %w", err)
 	}
 
+	// Auto-equip the chosen primary weapon (and armor, where the class has
+	// a distinct choice for it) -- see rpg-api#746 and auto_equip.go's doc.
+	// Runs on this freshly built character, before it is ever persisted, so
+	// EquipmentSlots is correct in the FIRST save rather than needing a
+	// follow-up EquipItem call the real (non-devseed) creation flow never
+	// makes.
+	autoEquipChosenGear(draft.Choices(), char)
+
 	// Convert character to data for storage
 	// ToData is now a method on Character
 	charData := char.ToData()


### PR DESCRIPTION
## What / why

Kirk was walking the 3D combat panel live: `Attack` came back `FAILED_PRECONDITION "nothing equipped in main_hand"` for `toolkit-sandbox-fighter`. The session SDK prices and resolves the swing off the equipped main hand correctly — the character was wrong, not the swing.

Root cause, confirmed via redis + live combat (#746): `FinalizeDraft` never called `EquipItem`. Only `cmd/devseed`'s hand-written fixtures set `EquipmentSlots` directly in Go, so every character created through the real (non-devseed) API — the only path a player uses — finalized with nothing equipped and fought unarmed regardless of what was chosen. A second, related bug: `GetCharacter`'s `equipment_slots` marshaled as `null` (not even an empty object) whenever nothing was equipped, which was true of every real character.

## What changed

**`internal/orchestrators/character/auto_equip.go`** (new): `autoEquipChosenGear` runs right after `draft.ToCharacter`, before the first save. It:
- Equips the class's declared **primary weapon** choice into the main hand. If that weapon is one-handed (`character.CompatibleSlots` says so — never re-derived here), it also fills the off hand with whatever else the SAME choice granted: a second one-handed weapon (dual wield) if resolved, else a **bundled shield** (Fighter's "martial weapon + shield" option). A two-handed pick claims the main hand alone and the off hand is never attempted for it — attempting it would hit `EquipItem`'s own "main hand holding a two-hander blocks the off hand until something frees it" rule and clear the two-hander, exactly backwards.
- Equips the class's distinct **armor** choice (Fighter, Cleric, Ranger — the only three with one) into the armor slot.
- Never reimplements slot legality: every placement goes through `char.EquipItem`, using `character.CompatibleSlots` (the toolkit's own exported classifier) only to pick which slot to *try* — the same rules `EquipItem` (the RPC) already gates behind. Each hand is attempted **at most once** (an earlier revision looped over every remaining candidate, which Copilot correctly flagged: a 3+-candidate choice could let `EquipItem`'s swap-on-occupied rule silently move the *last* one into the off hand).
- `primaryWeaponChoiceIDs`/`armorChoiceIDs` are explicit maps over the toolkit's own exported `choices.ChoiceID` constants (never re-derived strings) — 11 of 12 classes name theirs `<Class>WeaponsPrimary`, but Cleric's is `cleric-weapons` (no suffix), so a pattern match would silently skip it. **Filed rpg-toolkit#1164** for the underlying gap: there's no exported way to enumerate a class's equipment-choice roles from outside `character/choices`, so this list has to be hand-copied and re-synced against future toolkit changes.

**`internal/handlers/dnd5e/v1alpha1/character/converters.go`**: `convertEquipmentSlotsToProto` returned `nil` whenever `len(slots) == 0`, so an unequipped character's `equipment_slots` marshaled as `null` — a producer defect, the same false-vs-absent law every per-slot field already keeps (an equipped slot is nil, never a zero-valued `InventoryItem`). Now always returns a non-nil message.

Neither the session/toolkit refusal nor `EquipItem`'s occupancy rules are touched — this only makes `FinalizeDraft` call the same equip path that already exists. `cmd/sandboxseed`'s later `EquipItem(shield, OFF_HAND)` call needed no change: re-equipping an item already in that slot is already a harmless no-op by `EquipItem`'s own existing logic (a single-copy item is cleared from every slot holding it before being reset, netting out to the same state) — pinned by a test rather than assumed.

## Tests

- `internal/orchestrators/character/auto_equip_test.go` (new): `TestFinalizeDraft_EquipsChosenPrimaryWeaponArmorAndShield` (Fighter, longsword + shield + chain mail → `main_hand=longsword`, `off_hand=shield`, `armor=chain-mail`, all from finalize alone), `TestFinalizeDraft_TwoHandedWeapon_EquipsMainHandOnly` (Barbarian, Greataxe → `main_hand=greataxe` only), `TestFinalizeDraft_ReEquippingTheAlreadyEquippedShieldIsHarmless` (a second `EquipItem` for the same shield, matching what `cmd/sandboxseed` actually does on every run, is a no-op — the main-hand weapon stays untouched).
- `internal/handlers/dnd5e/v1alpha1/character/converters_test.go`: three new cases for `convertEquipmentSlotsToProto` — nil input, empty map, and populated — pinning the null fix without breaking the real mapping.
- Full `go test ./...` passes, including the existing integration suite (`TestCharacterCreationSuite`, `TestSandboxSeedSuite`) — the fighter shows `off_hand=shield` both before and after the seed's own explicit `EquipItem` call now, and the barbarian's `off_hand` stays empty, exactly as it did before this PR.

## Live evidence

Built the branch, ran it on an isolated port against a throwaway Redis (never touched the running `rpg-api` dev container on :50051), then ran `cmd/sandboxseed` against it and called `GetCharacter`:

```json
{
  "id": "char_85d47ed4-934d-4550-9346-aac0e1366288",
  "name": "Toolkit Sandbox Fighter",
  "equipmentSlots": {
    "mainHand": { "itemId": "longsword", "quantity": 1 },
    "offHand":  { "itemId": "shield",    "quantity": 1 },
    "armor":    { "itemId": "chain-mail","quantity": 1 }
  }
}
```

Barbarian (Greataxe, two-handed):

```json
{
  "id": "char_2cabe937-f2cb-48f3-a53c-364f1d434838",
  "equipmentSlots": { "mainHand": { "itemId": "greataxe", "quantity": 1 } }
}
```

(Evidence above is from the version before the shield fix landed — `off_hand` was still empty for the fighter at that point. The unit tests now pin `off_hand=shield`, and the integration suite's `TestSandboxSeedSuite` — which calls `GetCharacter` through the real API — confirms it live on every `go test ./...` run: `off_hand=shield` for the fighter, unchanged from before this PR.)

## Judgment calls

- **Shields ARE auto-equipped now** (reversed from an earlier revision after gate review): the fighter's "martial weapon and a shield" bundle finalizes with both pieces on, matching #746's own description of the bug. `cmd/sandboxseed`'s redundant explicit `EquipItem(shield)` call stays as-is — it's a proven no-op now, not dead code that needs removing, since the RPC contract already supports "equip what's already there" without a new rule.
- **Primary-weapon/armor choice IDs are hardcoded** from the toolkit's exported constants, not derived dynamically — tracked as rpg-toolkit#1164.
- **"No weapon chosen → slots empty-but-not-null"** is covered as the general "nothing equipped" case at the converter level (nil and empty-map inputs both tested) rather than as a specific finalize scenario — every class's weapon choice is validation-required, so a real "no weapon" finalize isn't reachable through the normal flow.

— asset-pipeline agent, on behalf of KirkDiggler
