### PR TITLE
fix(character): equipment_slots projects as an empty object, never null (#746)

### DIFF
--- a/internal/handlers/dnd5e/v1alpha1/character/converters.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters.go
@@ -1342,12 +1342,18 @@ func convertEquipmentSlotToToolkit(slot dnd5ev1alpha1.EquipmentSlot) (toolkitcha
 	}
 }
 
-// convertEquipmentSlotsToProto converts toolkit EquipmentSlots to proto EquipmentSlots
+// convertEquipmentSlotsToProto converts toolkit EquipmentSlots to proto
+// EquipmentSlots.
+//
+// ALWAYS returns a non-nil message, even when nothing is equipped
+// (rpg-api#746): a nil *EquipmentSlots marshals on the wire as
+// "equipment_slots": null, which is a producer defect indistinguishable
+// from "this layer forgot to set it" -- the same false-vs-absent law the
+// per-slot fields already keep by leaving an empty slot's InventoryItem nil
+// rather than a zero-valued one. Every real (non-devseed) character
+// finalized with nothing equipped until rpg-api#746's FinalizeDraft fix, so
+// this was reachable on every one of them.
 func convertEquipmentSlotsToProto(slots toolkitchar.EquipmentSlots) *dnd5ev1alpha1.EquipmentSlots {
-	if len(slots) == 0 {
-		return nil
-	}
-
 	// Helper to create InventoryItem from item ID
 	makeItem := func(itemID string) *dnd5ev1alpha1.InventoryItem {
 		if itemID == "" {

--- a/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
+++ b/internal/handlers/dnd5e/v1alpha1/character/converters_test.go
@@ -1092,3 +1092,43 @@ func (s *ConvertersTestSuite) TestConvertRaceTraitsToProto_Discriminates() {
 	assert.False(s.T(), result[0].GetIsChoice())
 	assert.Empty(s.T(), result[0].GetOptions())
 }
+
+// TestConvertEquipmentSlotsToProto_Nil_ReturnsNonNilEmptyStruct pins
+// rpg-api#746's other half: a character with nothing equipped must still
+// marshal "equipment_slots" as an empty object, never null. A nil pointer
+// here IS the producer defect the issue reported -- "equipment_slots: null
+// (not even an empty object)" -- on every real character before finalize
+// learned to auto-equip.
+func (s *ConvertersTestSuite) TestConvertEquipmentSlotsToProto_Nil_ReturnsNonNilEmptyStruct() {
+	result := convertEquipmentSlotsToProto(nil)
+	require.NotNil(s.T(), result, "must return a non-nil EquipmentSlots even when nothing is equipped")
+	assert.Nil(s.T(), result.GetMainHand())
+	assert.Nil(s.T(), result.GetOffHand())
+	assert.Nil(s.T(), result.GetArmor())
+}
+
+// TestConvertEquipmentSlotsToProto_Empty_ReturnsNonNilEmptyStruct is the
+// same pin against an explicitly empty (non-nil) map, the shape
+// EquipItem/UnequipItem produce once anything has ever been touched.
+func (s *ConvertersTestSuite) TestConvertEquipmentSlotsToProto_Empty_ReturnsNonNilEmptyStruct() {
+	result := convertEquipmentSlotsToProto(toolkitchar.EquipmentSlots{})
+	require.NotNil(s.T(), result)
+	assert.Nil(s.T(), result.GetMainHand())
+}
+
+// TestConvertEquipmentSlotsToProto_Populated_StillMapsFields is the existing
+// happy path, pinned alongside the two empty cases above so a future edit
+// cannot fix null-vs-empty by returning a populated struct unconditionally
+// and dropping real slot data.
+func (s *ConvertersTestSuite) TestConvertEquipmentSlotsToProto_Populated_StillMapsFields() {
+	result := convertEquipmentSlotsToProto(toolkitchar.EquipmentSlots{
+		toolkitchar.SlotMainHand: "longsword",
+		toolkitchar.SlotArmor:    "chain-mail",
+	})
+	require.NotNil(s.T(), result)
+	require.NotNil(s.T(), result.GetMainHand())
+	assert.Equal(s.T(), "longsword", result.GetMainHand().GetItemId())
+	require.NotNil(s.T(), result.GetArmor())
+	assert.Equal(s.T(), "chain-mail", result.GetArmor().GetItemId())
+	assert.Nil(s.T(), result.GetOffHand())
+}


### PR DESCRIPTION
## What / why

Salvaged from #811 (closed unmerged): that PR's FinalizeDraft auto-equip was the wrong shape — Kirk: *"i have 2 weapons, which are you auto equipping? we will have an equip panel like before."* The player equips through the existing `EquipItem` RPC from a web panel, not a server-side guess made at character creation.

The converter half of that PR is an independent bug fix worth keeping regardless: `convertEquipmentSlotsToProto` returned `nil` whenever nothing was equipped (`len(slots) == 0`), so `GetCharacter`'s `equipment_slots` field marshaled as `"equipment_slots": null` rather than an empty object — a producer defect, the same false-vs-absent law every per-slot field already keeps (an unequipped slot's `InventoryItem` is `nil`, never a zero-valued one). Every character with nothing equipped hits this today, since nothing calls `EquipItem` until the player does from the panel.

## What changed

`internal/handlers/dnd5e/v1alpha1/character/converters.go` — `convertEquipmentSlotsToProto` now always returns a non-nil `*EquipmentSlots` message.

## Tests

`internal/handlers/dnd5e/v1alpha1/character/converters_test.go` — three new cases: nil input, explicitly empty map, and populated (pinning both the null fix and that a future edit can't "fix" it by unconditionally returning an empty struct and dropping real slot data).

Full `go test ./...` passes. `golangci-lint run` on the changed package: 0 new issues (3 pre-existing findings remain in `handler.go`, untouched by this diff).

— asset-pipeline agent, on behalf of KirkDiggler
